### PR TITLE
Ensure proxy and server images are only provided with --use-pathways.

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,15 +125,6 @@ all zones.
     --num-slices=4 --spot
     ```
 
-* Cluster Create for Pathways:
-    Pathways compatible cluster can be created using `--enable-pathways`
-    ```shell
-    python3 xpk.py cluster create \
-    --cluster xpk-pw-test \
-    --num-slices=4 --on-demand \
-    --tpu-type=v5litepod-16 \
-    --enable-pathways
-    ```
  
 *   Cluster Create can be called again with the same `--cluster name` to modify
     the number of slices or retry failed steps.
@@ -209,36 +200,6 @@ all zones.
     --workload xpk-test-workload --command "echo goodbye" \
     --cluster xpk-test \
     --tpu-type=v5litepod-16
-    ```
-
-*   Workload Create for Pathways:
-    Pathways workload can be submitted using `--use-pathways` on a Pathways enabled cluster (created with `--enable-pathways`)
-    
-    Pathways workload example:
-    ```shell
-    python3 xpk.py workload create \
-    --workload xpk-pw-test \
-    --num-slices=1 \
-    --tpu-type=v5litepod-16 \
-    --use-pathways \
-    --cluster xpk-pw-test \
-    --docker-name='user-workload' \
-    --docker-image=<maxtext docker image> \
-    --command='bash /usr/pathways/ifrt/maxtext_entrypoint.sh base_output_directory=<output directory> dataset_path=<dataset path> per_device_batch_size=1 enable_checkpointing=false enable_profiler=false remat_policy=full global_parameter_scale=4 steps=300 max_target_length=2048 use_iota_embed=true reuse_example_batch=1 dataset_type=synthetic attention=flash gcs_metrics=True run_name=$(USER)-pw-xpk-test-1'
-    ```
-
-    Regular workload can also be submitted on a Pathways enabled cluster (created with `--enable-pathways`)
-    
-    Pathways workload example:
-    ```shell
-    python3 xpk.py workload create \
-    --workload xpk-regular-test \
-    --num-slices=1 \
-    --tpu-type=v5litepod-16 \
-    --cluster xpk-pw-test \
-    --docker-name='user-workload' \
-    --docker-image=<maxtext docker image> \
-    --command='python3 MaxText/train.py MaxText/configs/base.yml base_output_directory=<output directory> dataset_path=<dataset path> per_device_batch_size=1 enable_checkpointing=false enable_profiler=false remat_policy=full global_parameter_scale=4 steps=300 max_target_length=2048 use_iota_embed=true reuse_example_batch=1 dataset_type=synthetic attention=flash gcs_metrics=True run_name=$(USER)-pw-xpk-test-1'
     ```
 
 ### Set `max-restarts` for production jobs
@@ -353,6 +314,49 @@ checkpointing so the job restarts near where it was interrupted.
     ```shell
     python3 xpk.py workload list \
     --cluster xpk-test --filter-by-job=$USER
+    ```
+## Pathways on XPK
+
+* Cluster Create for Pathways:
+    Pathways compatible cluster can be created using `--enable-pathways`
+    ```shell
+    python3 xpk.py cluster create \
+    --cluster xpk-pw-test \
+    --num-slices=4 --on-demand \
+    --tpu-type=v5litepod-16 \
+    --enable-pathways
+    ```
+
+*   Workload Create for Pathways:
+    Pathways workload can be submitted using `--use-pathways` on a Pathways enabled cluster (created with `--enable-pathways`)
+    
+    Pathways workload example:
+    ```shell
+    python3 xpk.py workload create \
+    --workload xpk-pw-test \
+    --num-slices=1 \
+    --tpu-type=v5litepod-16 \
+    --cluster xpk-pw-test \
+    --use-pathways \
+    --server-image=<Pathways server image> \
+    --proxy-server-image=<Pathways proxy server image> \
+    --docker-name='user-workload' \
+    --docker-image=<maxtext docker image> \
+    --command='bash /usr/pathways/ifrt/maxtext_entrypoint.sh base_output_directory=<output directory> dataset_path=<dataset path> per_device_batch_size=1 enable_checkpointing=false enable_profiler=false remat_policy=full global_parameter_scale=4 steps=300 max_target_length=2048 use_iota_embed=true reuse_example_batch=1 dataset_type=synthetic attention=flash gcs_metrics=True run_name=$(USER)-pw-xpk-test-1'
+    ```
+
+    Regular workload can also be submitted (by omitting `--use-pathways`) on a Pathways enabled cluster (i.e a cluster created with `--enable-pathways`)
+    
+    Pathways workload example:
+    ```shell
+    python3 xpk.py workload create \
+    --workload xpk-regular-test \
+    --num-slices=1 \
+    --tpu-type=v5litepod-16 \
+    --cluster xpk-pw-test \
+    --docker-name='user-workload' \
+    --docker-image=<maxtext docker image> \
+    --command='python3 MaxText/train.py MaxText/configs/base.yml base_output_directory=<output directory> dataset_path=<dataset path> per_device_batch_size=1 enable_checkpointing=false enable_profiler=false remat_policy=full global_parameter_scale=4 steps=300 max_target_length=2048 use_iota_embed=true reuse_example_batch=1 dataset_type=synthetic attention=flash gcs_metrics=True run_name=$(USER)-pw-xpk-test-1'
     ```
 
 ## Inspector

--- a/xpk.py
+++ b/xpk.py
@@ -3208,8 +3208,7 @@ def check_use_pathways(args) -> bool:
     args: user provided arguments for running the command.
 
   Returns:
-    bool:
-      yaml for main and sidecar container
+    bool: Whether the expected images are provided with --use-pathways.
   """
   return args.use_pathways == (args.proxy_server_image is not None and args.server_image is not None)
 
@@ -3217,15 +3216,14 @@ def validate_pathways_docker_images(args) -> bool:
   """Validates the existence of Pathways server and proxy docker images in the project.
 
   Args:
-      args (_type_): _description_
+      args: user provided arguments for running the command.
 
   Returns:
-      bool: _description_
+      bool: whether the Pathways proxy and server images are valid.
   """
-  # pylint: disable=line-too-long
   proxy_server_return_code = validate_docker_image(args.proxy_server_image, args)
   server_return_code = validate_docker_image(args.server_image, args)
-  if proxy_server_return_code>0 or server_return_code>0:
+  if proxy_server_return_code > 0 or server_return_code > 0:
     return False
   else:
     return True
@@ -3410,7 +3408,6 @@ def get_pathways_proxy_args(args) -> str:
               - --pathways_ifrt_proxy_server_resource_manager={args.workload}-rm-0-0.{args.workload}:38677
               - --pathways_ifrt_proxy_server_port=38676
               - --pathways_tmp_dir_pattern={args.pathways_gcs_location}
-              - --pathways_xprof_trace_enable_bulk_upload=true
               - --pathways_plaque_network=gcp"""
   if args.use_pathways:
     return yaml.format(args=args)


### PR DESCRIPTION
## Fixes / Features
- Remove default values for proxy-server and server images.
- Ensure user provides both proxy-server-image and server-image when --use-pathways is set and vice-versa.
- Validate that the proxy-server-image and server-image exist on GCR.
- Remove a Pathways flag.

## Testing / Documentation
Testing details.
Additionally, I did some manual tests to see that the user gets the right error message for - 
```
[XPK] --proxy-server-image and --server-image need to be provided with --use-pathways.
``` 
Also manually tested that invalid docker images are detected and user is guided with an error message.
```
[XPK] Failed to validate your docker image, check the docker image. You should be able to navigate to the URL gcr.io/hello_world in cloud-tpu-multipod-dev
[XPK] Please check the proxy-server-image or server-image as advised!
```
- [ y ] Tests pass
- [ y ] Appropriate changes to documentation are included in the PR
