### PR TITLE
Fix GKE node version selection

### DIFF
--- a/src/xpk/core/core.py
+++ b/src/xpk/core/core.py
@@ -1737,7 +1737,17 @@ def get_gke_node_pool_version(
   if args.gke_version is not None:
     node_pool_gke_version = args.gke_version
   else:
-    node_pool_gke_version = current_gke_master_version.strip()
+    master_gke_version = current_gke_master_version.strip()
+    node_pool_gke_version = ''
+    # Select minimum version which is >= master_gke_version and has the same minor version.
+    # If this does not exist select maximum version which is < master_gke_version.
+    for version in gke_server_config.valid_versions:
+      if (((
+               node_pool_gke_version == '' or node_pool_gke_version < version) and version < master_gke_version) or
+          ((node_pool_gke_version == '' or node_pool_gke_version > version) and
+           master_gke_version <= version and master_gke_version.split('.')[
+                                             :2] == version.split('.')[:2])):
+        node_pool_gke_version = version
 
   is_supported_node_pool_version = (
       node_pool_gke_version in gke_server_config.valid_versions

--- a/src/xpk/core/core.py
+++ b/src/xpk/core/core.py
@@ -1739,11 +1739,14 @@ def get_gke_node_pool_version(
     # Select minimum version which is >= master_gke_version and has the same minor version.
     # If this does not exist select maximum version which is < master_gke_version.
     for version in gke_server_config.valid_versions:
-      if (((
-               node_pool_gke_version == '' or node_pool_gke_version < version) and version < master_gke_version) or
-          ((node_pool_gke_version == '' or node_pool_gke_version > version) and
-           master_gke_version <= version and master_gke_version.split('.')[
-                                             :2] == version.split('.')[:2])):
+      if (
+          (node_pool_gke_version == '' or node_pool_gke_version < version)
+          and version < master_gke_version
+      ) or (
+          (node_pool_gke_version == '' or node_pool_gke_version > version)
+          and master_gke_version <= version
+          and master_gke_version.split('.')[:2] == version.split('.')[:2]
+      ):
         node_pool_gke_version = version
 
   is_supported_node_pool_version = (


### PR DESCRIPTION
## Fixes / Features
- Fixes problem with GKE nodes version selection if the current GKE cluster version is no longer a valid GKE rapid version.

## Testing / Documentation
Tested manually

- [ y/n ] Tests pass
- [ y/n ] Appropriate changes to documentation are included in the PR
