### PR TITLE
Update the CloudDNS check.

### DIFF
--- a/src/xpk/core/core.py
+++ b/src/xpk/core/core.py
@@ -1029,17 +1029,14 @@ def is_cluster_using_clouddns(args) -> bool:
   command = (
       f'gcloud container clusters describe {args.cluster}'
       f' --project={args.project} --region={zone_to_region(args.zone)}'
-      ' | grep "clusterDns: CLOUD_DNS" | wc -l'
+      ' | grep "clusterDns: CLOUD_DNS"'
   )
-  return_code, cloud_dns_matches = run_command_for_value(
+  return_code, _ = run_command_for_value(
       command,
       'Check if Cloud DNS is enabled in cluster describe.',
       args,
   )
-  if return_code != 0:
-    xpk_exit(return_code)
-  cloud_dns_matches = int(cloud_dns_matches)
-  if cloud_dns_matches > 0:
+  if return_code == 0:
     xpk_print('Cloud DNS is enabled on the cluster, no update needed.')
     return True
   return False


### PR DESCRIPTION
If there is an upgrad available for the cluster, additional text is printed to stderr

```
* - There is an upgrade available for your cluster(s).

To upgrade nodes to the latest available version, run
  $ gcloud container clusters upgrade <cluster>
```

That text is captured by run_command_for_value and a ValueError is returned when trying to convert it to an integer.

The fix is to inspect the return_code of grep instead of the text output of wc -l.

## Fixes / Features
-
-

## Testing / Documentation
Testing details.

- [ y/n ] Tests pass
- [ y/n ] Appropriate changes to documentation are included in the PR
