### PR TITLE
Add GCS Fuse Storage to workload creation

### DIFF
--- a/.github/workflows/build_tests.yaml
+++ b/.github/workflows/build_tests.yaml
@@ -44,6 +44,10 @@ jobs:
       with:
         version: '>= 363.0.0'
         install_components: 'beta,gke-gcloud-auth-plugin'
+    - name: Generate random seed
+      run: |
+        RANDOM_SEED=$((RANDOM % 10000))  # Generate a random number between 0 and 9999
+        echo "RANDOM_SEED=$RANDOM_SEED" >> $GITHUB_ENV
     - name: Verify gcp setup
       run: gcloud info
     - name: Set Google Cloud CLI properties to a unused zone to verify --zone arg is passed properly in commands.
@@ -72,7 +76,8 @@ jobs:
       run: |
         echo -e \
         '#!/bin/bash \n
-        echo "Hello world from a test script!"' \
+        echo "Hello world from a test script!"
+        cd ~/../test-mount-point && echo "Hello world from a Github Action CI/CD test script!" > '$RANDOM_SEED'.txt' \
         > test.sh
     - name: Run a base-docker-image workload
       run: |
@@ -87,6 +92,10 @@ jobs:
         python3 xpk.py workload create-pathways --cluster $TPU_CLUSTER_NAME --workload $PATHWAYS_WORKLOAD_NAME \
         --docker-image='marketplace.gcr.io/google/ubuntu2004' --tpu-type=v4-8 --num-slices=2 --zone=us-central2-b \
         --command "echo \"Hello world from a test script! \""
+    - name: Verify if the file was created in the GCS bucket
+      run: gsutil cp gs://xpk-ci-cd-tests/$RANDOM_SEED.txt .
+    - name: Check if the file contains desired content
+      run: grep 'Hello world from a Github Action CI/CD test script!' $RANDOM_SEED.txt
     - name: Wait for Pathways workload completion and confirm it succeeded
       run: python3 xpk.py workload list --cluster $TPU_CLUSTER_NAME --zone=us-central2-b --wait-for-job-completion $PATHWAYS_WORKLOAD_NAME --timeout 300
     - name: List out the workloads on the cluster
@@ -95,6 +104,8 @@ jobs:
       run: python3 xpk.py workload delete --workload $WORKLOAD_NAME --cluster $TPU_CLUSTER_NAME --zone=us-central2-b
     - name: Delete the Pathways workload on the cluster
       run: python3 xpk.py workload delete --workload $PATHWAYS_WORKLOAD_NAME --cluster $TPU_CLUSTER_NAME --zone=us-central2-b
+    - name: Delete created GCS file
+      run: gsutil rm gs://xpk-ci-cd-tests/$RANDOM_SEED.txt
     - name: Delete existing Storage
       run: python3 xpk.py storage delete $STORAGE_NAME  --cluster $TPU_CLUSTER_NAME --zone=us-central2-b
     - name: Delete the cluster created

--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ and the following GPU types:
 and the following CPU types:
 * n2-standard-32
 
+xpk also supports Google Cloud Storage solutions:
+* [Cloud Storage FUSE](https://cloud.google.com/storage/docs/gcs-fuse)
+
 # Permissions needed on Cloud Console:
 
 Artifact Registry Writer
@@ -117,6 +120,8 @@ cleanup with a `Cluster Delete`.
 
 If you have failures with workloads not running, use `xpk inspector` to investigate
 more.
+
+If you need your Workloads to have persistent storage, use `xpk storage` to find more.
 
 ## Cluster Create
 
@@ -311,6 +316,30 @@ will fail the cluster creation process because Vertex AI Tensorboard is not supp
     python3 xpk.py cluster cacheimage \
     --cluster xpk-test --docker-image gcr.io/your_docker_image \
     --tpu-type=v5litepod-16
+    ```
+
+## Storage Create
+Currently xpk supports Cloud Storage FUSE. A FUSE adapter that lets you mount and access Cloud Storage buckets as local file systems, so applications can read and write objects in your bucket using standard file system semantics.
+
+To use the GCS FUSE with XPK user needs to create a a [Storage Bucket](https://pantheon.corp.google.com/storage/)
+and a manifest with PersistentVolume and PersistentVolumeClaim that mounts to the Bucket. To learn how to properly
+set up PersistentVolume and PersistentVolumeClaim visit [GKE Cloud Storage documentation](https://cloud.google.com/kubernetes-engine/docs/how-to/persistent-volumes/cloud-storage-fuse-csi-driver#provision-static)
+
+Once it's ready user can define
+
+`--type` - defines a type of a storage, currently xpk supports `gcsfuse` only.
+`--auto-mount` - if set to true means that all workloads should have a given storage mounted by default.
+`--mount-point` - defines the path on which a given storage should be mounted for a workload.
+`--manifest` -- 
+
+
+* Create simple Storage
+
+    ```shell
+    python3 xpk.py storage create test-storage --project=$PROJECT
+    --cluster=xpk-test --type=test-type --auto-mount=false \
+    --mount-point='/test-mount-point' --readonly=false \
+    --manifest='pv-pvc-auto-mount.yaml'
     ```
 
 ## Workload Create

--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ will fail the cluster creation process because Vertex AI Tensorboard is not supp
     --tpu-type=v5litepod-16
     ```
 
-## Storage Create
+## Storage
 Currently xpk supports Cloud Storage FUSE. A FUSE adapter that lets you mount and access Cloud Storage buckets as local file systems, so applications can read and write objects in your bucket using standard file system semantics.
 
 To use the GCS FUSE with XPK user needs to create a a [Storage Bucket](https://pantheon.corp.google.com/storage/)
@@ -330,16 +330,35 @@ Once it's ready user can define
 `--type` - defines a type of a storage, currently xpk supports `gcsfuse` only.
 `--auto-mount` - if set to true means that all workloads should have a given storage mounted by default.
 `--mount-point` - defines the path on which a given storage should be mounted for a workload.
-`--manifest` -- 
+`--manifest` - defines the path to manifest which contains PersistentVolue and PersistentVolumeClaim definitions
 
 
-* Create simple Storage
+* Create a simple Storage
 
     ```shell
     python3 xpk.py storage create test-storage --project=$PROJECT
-    --cluster=xpk-test --type=test-type --auto-mount=false \
+    --cluster=xpk-test --type=gcsfuse --auto-mount=false \
     --mount-point='/test-mount-point' --readonly=false \
     --manifest='pv-pvc-auto-mount.yaml'
+    ```
+
+* Create a simple Workload with Storage attached
+    ```shell
+    python3 xpk.py workload create \
+    --workload xpk-test-workload --command "echo goodbye" \
+    --cluster xpk-test \
+    --tpu-type=v5litepod-16 \
+    --storage test-storage
+    ```
+
+* List Storage
+    ```shell
+    python3 xpk.py storage list --cluster xpk-test --zone=us-central2-b
+    ```
+
+* Delete Storage
+    ```shell
+    python3 xpk.py storage delete test-storage  --cluster xpk-test --zone=us-central2-b
     ```
 
 ## Workload Create

--- a/src/xpk/commands/workload.py
+++ b/src/xpk/commands/workload.py
@@ -88,7 +88,6 @@ metadata:
     xpk.google.com/workload: {args.workload}
   annotations:
     alpha.jobset.sigs.k8s.io/exclusive-topology: cloud.google.com/gke-nodepool # 1:1 job replica to node pool assignment
-    {gcs_fuse_annotation}
 spec:
   failurePolicy:
     maxRestarts: {args.max_restarts}

--- a/src/xpk/core/core.py
+++ b/src/xpk/core/core.py
@@ -55,7 +55,7 @@ from .commands import (
     run_command_with_updates_retry,
     run_commands,
 )
-from .storage import Storage, get_storages
+from .storage import Storage, get_storages_to_mount, GCS_FUSE_TYPE
 from .system_characteristics import (
     AcceleratorType,
     AcceleratorTypeToAcceleratorCharacteristics,
@@ -2589,9 +2589,12 @@ def get_volumes(args, system: SystemCharacteristics) -> str:
               - name: shared-data
               """
 
-  storages: list[Storage] = get_storages(setup_k8s_env(args), args.storage)
+  storages: list[Storage] = get_storages_to_mount(
+      setup_k8s_env(args), args.storage
+  )
   for storage in storages:
-    volumes += f"""- name: {storage.pv}
+    if storage.type == GCS_FUSE_TYPE:
+      volumes += f"""- name: {storage.pv}
                 persistentVolumeClaim:
                   claimName: {storage.pvc}
                   readOnly: {storage.readonly}
@@ -2647,9 +2650,12 @@ def get_volume_mounts(args, system: SystemCharacteristics) -> str:
                   mountPath: /usr/share/workload
                   """
 
-  storages: list[Storage] = get_storages(setup_k8s_env(args), args.storage)
+  storages: list[Storage] = get_storages_to_mount(
+      setup_k8s_env(args), args.storage
+  )
   for storage in storages:
-    volume_mount_yaml += f"""- name: {storage.pv}
+    if storage.type == GCS_FUSE_TYPE:
+      volume_mount_yaml += f"""- name: {storage.pv}
                   mountPath: {storage.mount_point}
                   readOnly: {storage.readonly}
                 """

--- a/src/xpk/core/core.py
+++ b/src/xpk/core/core.py
@@ -46,6 +46,7 @@ from google.api_core.exceptions import PermissionDenied
 from google.cloud import resourcemanager_v3
 from kubernetes import client as k8s_client
 from kubernetes import config
+from kubernetes.client.exceptions import ApiException
 
 from ..utils import get_user_input, write_tmp_file, xpk_exit, xpk_print
 from .commands import (
@@ -54,6 +55,7 @@ from .commands import (
     run_command_with_updates_retry,
     run_commands,
 )
+from .storage import Storage, get_storages
 from .system_characteristics import (
     AcceleratorType,
     AcceleratorTypeToAcceleratorCharacteristics,
@@ -343,6 +345,20 @@ def setup_k8s_env(args: Namespace) -> k8s_client.ApiClient:
 
   config.load_kube_config()
   return k8s_client.ApiClient()
+
+
+def create_k8s_service_account(name: str, namespace: str) -> None:
+  k8s_core_client = k8s_client.CoreV1Api()
+  sa = k8s_client.V1ServiceAccount(metadata=k8s_client.V1ObjectMeta(name=name))
+
+  xpk_print(f'Creating a new service account: {name}')
+  try:
+    k8s_core_client.create_namespaced_service_account(
+        namespace, sa, pretty=True
+    )
+    xpk_print(f'Created a new service account: {sa} successfully')
+  except ApiException:
+    xpk_print(f'Service account: {name} already exists. Skipping its creation')
 
 
 def get_total_chips_requested_from_args(
@@ -2561,7 +2577,8 @@ def get_volumes(args, system: SystemCharacteristics) -> str:
   """
   volumes = """- emptyDir:
                   medium: Memory
-                name: dshm-2"""
+                name: dshm-2
+              """
 
   if (
       system.accelerator_type == AcceleratorType['TPU']
@@ -2569,8 +2586,16 @@ def get_volumes(args, system: SystemCharacteristics) -> str:
   ):
     volumes += """
               - name: tpu-stack-trace
-              - name: shared-data"""
+              - name: shared-data
+              """
 
+  storages: list[Storage] = get_storages(setup_k8s_env(args), args.storage)
+  for storage in storages:
+    volumes += f"""- name: {storage.pv}
+                persistentVolumeClaim:
+                  claimName: {storage.pvc}
+                  readOnly: {storage.readonly}
+              """
   return volumes
 
 
@@ -2584,20 +2609,22 @@ def get_volume_mounts(args, system: SystemCharacteristics) -> str:
       YAML for the volumes mounted within a Pathways container or GPU container as a YAML string.
   """
   volume_mount_yaml = """- mountPath: /dev/shm
-                  name: dshm-2"""
+                  name: dshm-2
+                """
 
   if args.use_pathways:
     volume_mount_yaml = """- mountPath: /tmp
-                  name: shared-tmp"""
+                  name: shared-tmp
+                """
   elif (
       system.accelerator_type == AcceleratorType['TPU']
       and args.deploy_stacktrace_sidecar
   ):
-    volume_mount_yaml += """
-                - name: tpu-stack-trace
+    volume_mount_yaml += """- name: tpu-stack-trace
                   mountPath: /tmp/debugging
                 - name: shared-data
-                  mountPath: /shared-volume"""
+                  mountPath: /shared-volume
+                """
   elif system.accelerator_type == AcceleratorType['GPU']:
     if system.device_type == h100_device_type:
       volume_mount_yaml = """- name: nvidia-install-dir-host
@@ -2609,15 +2636,23 @@ def get_volume_mounts(args, system: SystemCharacteristics) -> str:
                 - name: shared-memory
                   mountPath: /dev/shm
                 - name: workload-terminated-volume
-                  mountPath: /usr/share/workload"""
+                  mountPath: /usr/share/workload
+                """
     elif system.device_type == h100_mega_device_type:
       volume_mount_yaml = """- name: nvidia-install-dir-host
                   mountPath: /usr/local/nvidia/lib64
                 - name: shared-memory
                   mountPath: /dev/shm
                 - name: workload-terminated-volume
-                  mountPath: /usr/share/workload"""
+                  mountPath: /usr/share/workload
+                  """
 
+  storages: list[Storage] = get_storages(setup_k8s_env(args), args.storage)
+  for storage in storages:
+    volume_mount_yaml += f"""- name: {storage.pv}
+                  mountPath: {storage.mount_point}
+                  readOnly: {storage.readonly}
+                """
   return volume_mount_yaml
 
 

--- a/src/xpk/core/storage.py
+++ b/src/xpk/core/storage.py
@@ -19,6 +19,7 @@ from argparse import Namespace
 from dataclasses import dataclass
 
 import yaml
+from google.cloud import storage as gcp_storage
 from kubernetes import client as k8s_client
 from kubernetes import utils
 from kubernetes.client import ApiClient
@@ -281,7 +282,132 @@ def install_storage_crd(k8s_api_client: ApiClient) -> None:
       xpk_exit(1)
 
 
-def print_storages_for_cluster(storages: list[Storage]) -> None:
+def get_storage_volume_mounts_yaml(storages: list[Storage]) -> str:
+  """
+  Generates the YAML representation of the volumeMounts section for the given Storages.
+
+  This function creates the YAML snippet that defines how the storage volumes
+  should be mounted within a Pod's containers.
+
+  Args:
+      storages: A list of Storage objects.
+
+  Returns:
+      A string containing the YAML representation of the volumeMounts section.
+  """
+  yaml_str = ""
+  for storage in storages:
+    yaml_str += f"""- name: {storage.pv}
+                mountPath: {storage.mount_point}
+                readOnly: {storage.readonly}
+            """
+  return yaml_str
+
+
+def get_storage_volumes_yaml(storages: list[Storage]) -> str:
+  """
+  Generates the YAML representation of the volumes section for the given Storages.
+
+  This function creates the YAML snippet that defines the volumes to be
+  mounted in a Pod, including the PersistentVolumeClaim associated with
+  each Storage.
+
+  Args:
+      storages: A list of Storage objects.
+
+  Returns:
+      A string containing the YAML representation of the volumes section.
+  """
+  yaml_str = ""
+  for storage in storages:
+    yaml_str += f"""- name: {storage.pv}
+              persistentVolumeClaim:
+                claimName: {storage.pvc}
+                readOnly: {storage.readonly}
+            """
+  return yaml_str
+
+
+def get_storage_volume_mounts_yaml_for_gpu(storages: list[Storage]) -> str:
+  """
+  Generates the YAML representation of the volumeMounts section for the given Storages.
+
+  This function creates the YAML snippet that defines how the storage volumes
+  should be mounted within a Pod's containers.
+
+  Args:
+      storages: A list of Storage objects.
+
+  Returns:
+      A string containing the YAML representation of the volumeMounts section.
+  """
+  yaml_str = ""
+  for storage in storages:
+    yaml_str += f"""- name: {storage.pv}
+                  mountPath: {storage.mount_point}
+                  readOnly: {storage.readonly}
+            """
+  return yaml_str
+
+
+def get_storage_volumes_yaml_for_gpu(storages: list[Storage]) -> str:
+  """
+  Generates the YAML representation of the volumes section for the given Storages.
+
+  This function creates the YAML snippet that defines the volumes to be
+  mounted in a Pod, including the PersistentVolumeClaim associated with
+  each Storage.
+
+  Args:
+      storages: A list of Storage objects.
+
+  Returns:
+      A string containing the YAML representation of the volumes section.
+  """
+  yaml_str = ""
+  for storage in storages:
+    yaml_str += f"""- name: {storage.pv}
+                persistentVolumeClaim:
+                  claimName: {storage.pvc}
+                  readOnly: {storage.readonly}
+            """
+  return yaml_str
+
+
+def add_bucket_iam_members(args: Namespace, storages: list[Storage]) -> None:
+  """
+  Adds IAM members to the GCS buckets associated with the given Storages.
+
+  This function grants the necessary permissions to the XPK service account
+  to access the GCS buckets. The specific role (viewer or user) is determined
+  based on the `readonly` attribute of each Storage object.
+
+  Args:
+      args: An argparse Namespace object containing command-line arguments.
+      storages: A list of Storage objects.
+  """
+  storage_client = gcp_storage.Client()
+
+  for storage in storages:
+    bucket = storage_client.bucket(storage.bucket)
+    policy = bucket.get_iam_policy(requested_policy_version=3)
+    if storage.readonly:
+      role = "roles/storage.objectViewer"
+    else:
+      role = "roles/storage.objectUser"
+
+    member = (
+        f"principal://iam.googleapis.com/projects/{args.project_number}/"
+        f"locations/global/workloadIdentityPools/{args.project}.svc.id.goog/"
+        f"subject/ns/default/sa/{XPK_SA}"
+    )
+
+    policy.bindings.append({"role": role, "members": {member}})
+    bucket.set_iam_policy(policy)
+    print(f"Added {member} with role {role} to {storage.bucket}.")
+
+
+def print_storages_for_cluster(storages: list[Storage], cluster: str):
   """
   Prints in human readable manner a table of Storage resources that belong to the specified cluster.
 

--- a/src/xpk/core/storage.py
+++ b/src/xpk/core/storage.py
@@ -404,10 +404,10 @@ def add_bucket_iam_members(args: Namespace, storages: list[Storage]) -> None:
 
     policy.bindings.append({"role": role, "members": {member}})
     bucket.set_iam_policy(policy)
-    print(f"Added {member} with role {role} to {storage.bucket}.")
+    xpk_print(f"Added {member} with role {role} to {storage.bucket}.")
 
 
-def print_storages_for_cluster(storages: list[Storage], cluster: str):
+def print_storages_for_cluster(storages: list[Storage]) -> None:
   """
   Prints in human readable manner a table of Storage resources that belong to the specified cluster.
 

--- a/src/xpk/parser/workload.py
+++ b/src/xpk/parser/workload.py
@@ -115,6 +115,12 @@ def set_workload_parsers(workload_parser):
   )
 
   workload_create_parser_optional_arguments.add_argument(
+      '--storage',
+      action='append',
+      default=[],
+      help='Names of storages the workload uses',
+  )
+  workload_create_parser_optional_arguments.add_argument(
       '--num-nodes',
       type=int,
       default=1,
@@ -242,6 +248,12 @@ def set_workload_parsers(workload_parser):
           ' python3 train.py\'".'
       ),
       required=False,
+  )
+  workload_create_pathways_parser_optional_arguments.add_argument(
+      '--storage',
+      action='append',
+      default=[],
+      help='Names of storages the workload uses',
   )
 
   add_shared_workload_create_required_arguments([

--- a/src/xpk/templates/storage.yaml
+++ b/src/xpk/templates/storage.yaml
@@ -1,13 +1,13 @@
 apiVersion: xpk.x-k8s.io/v1
 kind: Storage
 metadata:
-  name:
+  name: $NAME
 spec:
   auto_mount:
   cluster:
   manifest:
   mount_point:
   readonly:
-  type:
+  type: $NAME
   pvc:
   pv:


### PR DESCRIPTION
## Fixes / Features
- Add PersistentVolume and PersistentVolumeClaims to the Pods definitions so workload can use GCS Fuse Storage

## Testing / Documentation
Testing details.

- [ y ] Tests pass
- [ y ] Appropriate changes to documentation are included in the PR
