### PR TITLE
Add create-ray-cluster subcommand

### DIFF
--- a/.github/workflows/nightly_tests.yaml
+++ b/.github/workflows/nightly_tests.yaml
@@ -185,6 +185,12 @@ jobs:
       run: |
         gcloud config set compute/zone us-east4-a
         gcloud config get compute/zone
+    - name: Install xpk dependencies
+      run: |
+        make install 
+        echo $PWD/bin >> "$GITHUB_PATH"
+    - name: Check xpk installation
+      run: xpk --help
     - name: Create a RayCluster-enabled XPK Cluster with 2 x v4-8 nodepools
       run: python xpk.py cluster create-ray --cluster $RAYCLUSTER_TPU_CLUSTER_NAME --tpu-type=v4-8  --num-slices=2 --zone=us-central2-b --default-pool-cpu-machine-type=n1-standard-16 --default-pool-cpu-num-nodes=16 --reservation='${{ secrets.GCP_TPU_V4_RESERVATION }}' --custom-cluster-arguments='${{ secrets.CLUSTER_ARGUMENTS}}'
     - name: Delete the RayCluster-enabled XPK cluster

--- a/.github/workflows/nightly_tests.yaml
+++ b/.github/workflows/nightly_tests.yaml
@@ -165,7 +165,7 @@ jobs:
       run: python xpk.py cluster delete --cluster $PATHWAYS_TPU_CLUSTER_NAME --zone=us-central2-b
 
   rc-cluster:
-    runs-on: [ubuntu-20.04]
+    runs-on: [ubuntu-22.04]
     concurrency: # We support one build test to run at a time currently.
       group: nightly-rc-test-cluster-group
       cancel-in-progress: false

--- a/.github/workflows/nightly_tests.yaml
+++ b/.github/workflows/nightly_tests.yaml
@@ -186,7 +186,7 @@ jobs:
         gcloud config set compute/zone us-east4-a
         gcloud config get compute/zone
     - name: Create a RayCluster-enabled XPK Cluster with 2 x v4-8 nodepools
-      run: python xpk.py cluster create-ray --cluster $RAYCLUSTER_TPU_CLUSTER_NAME --tpu-type=v4-8  --num-slices=2 --zone=us-central2-b --default-pool-cpu-machine-type=n1-standard-16 --default-pool-cpu-num-nodes=16 --reservation='${{ secrets.GCP_TPU_V4_RESERVATION }}'
+      run: python xpk.py cluster create-ray --cluster $RAYCLUSTER_TPU_CLUSTER_NAME --tpu-type=v4-8  --num-slices=2 --zone=us-central2-b --default-pool-cpu-machine-type=n1-standard-16 --default-pool-cpu-num-nodes=16 --reservation='${{ secrets.GCP_TPU_V4_RESERVATION }}' --custom-cluster-arguments="${CLUSTER_ARGUMENTS}"
     - name: Delete the RayCluster-enabled XPK cluster
       if: always()
       run: python xpk.py cluster delete --cluster $RAYCLUSTER_TPU_CLUSTER_NAME --zone=us-central2-b

--- a/.github/workflows/nightly_tests.yaml
+++ b/.github/workflows/nightly_tests.yaml
@@ -192,7 +192,7 @@ jobs:
     - name: Check xpk installation
       run: xpk --help
     - name: Create a RayCluster-enabled XPK Cluster with 2 x v4-8 nodepools
-      run: python xpk.py cluster create-ray --cluster $RAYCLUSTER_TPU_CLUSTER_NAME --tpu-type=v4-8  --num-slices=2 --zone=us-central2-b --default-pool-cpu-machine-type=n1-standard-16 --default-pool-cpu-num-nodes=16 --reservation='${{ secrets.GCP_TPU_V4_RESERVATION }}' --custom-cluster-arguments='${{ secrets.CLUSTER_ARGUMENTS}}'
+      run: python xpk.py cluster create-ray --cluster $RAYCLUSTER_TPU_CLUSTER_NAME --tpu-type=v4-8  --num-slices=2 --zone=us-central2-b --ray-version=2.39.0 --default-pool-cpu-machine-type=n1-standard-16 --default-pool-cpu-num-nodes=16 --reservation='${{ secrets.GCP_TPU_V4_RESERVATION }}' --custom-cluster-arguments='${{ secrets.CLUSTER_ARGUMENTS}}'
     - name: Delete the RayCluster-enabled XPK cluster
       if: always()
       run: python xpk.py cluster delete --cluster $RAYCLUSTER_TPU_CLUSTER_NAME --zone=us-central2-b

--- a/.github/workflows/nightly_tests.yaml
+++ b/.github/workflows/nightly_tests.yaml
@@ -186,7 +186,7 @@ jobs:
         gcloud config set compute/zone us-east4-a
         gcloud config get compute/zone
     - name: Create a RayCluster-enabled XPK Cluster with 2 x v4-8 nodepools
-      run: python xpk.py cluster create-ray --cluster $RAYCLUSTER_TPU_CLUSTER_NAME --tpu-type=v4-8  --num-slices=2 --zone=us-central2-b --default-pool-cpu-machine-type=n1-standard-16 --default-pool-cpu-num-nodes=16 --reservation='${{ secrets.GCP_TPU_V4_RESERVATION }}' --custom-cluster-arguments="${CLUSTER_ARGUMENTS}"
+      run: python xpk.py cluster create-ray --cluster $RAYCLUSTER_TPU_CLUSTER_NAME --tpu-type=v4-8  --num-slices=2 --zone=us-central2-b --default-pool-cpu-machine-type=n1-standard-16 --default-pool-cpu-num-nodes=16 --reservation='${{ secrets.GCP_TPU_V4_RESERVATION }}' --custom-cluster-arguments='${{ secrets.CLUSTER_ARGUMENTS}}'
     - name: Delete the RayCluster-enabled XPK cluster
       if: always()
       run: python xpk.py cluster delete --cluster $RAYCLUSTER_TPU_CLUSTER_NAME --zone=us-central2-b

--- a/.github/workflows/nightly_tests.yaml
+++ b/.github/workflows/nightly_tests.yaml
@@ -186,7 +186,7 @@ jobs:
         gcloud config set compute/zone us-east4-a
         gcloud config get compute/zone
     - name: Create a RayCluster-enabled XPK Cluster with 2 x v4-8 nodepools
-      run: python xpk.py cluster create-ray-cluster --cluster $RAYCLUSTER_TPU_CLUSTER_NAME --tpu-type=v4-8  --num-slices=2 --zone=us-central2-b --default-pool-cpu-machine-type=n1-standard-16 --default-pool-cpu-num-nodes=16 --reservation='${{ secrets.GCP_TPU_V4_RESERVATION }}'
+      run: python xpk.py cluster create-ray --cluster $RAYCLUSTER_TPU_CLUSTER_NAME --tpu-type=v4-8  --num-slices=2 --zone=us-central2-b --default-pool-cpu-machine-type=n1-standard-16 --default-pool-cpu-num-nodes=16 --reservation='${{ secrets.GCP_TPU_V4_RESERVATION }}'
     - name: Delete the RayCluster-enabled XPK cluster
       if: always()
       run: python xpk.py cluster delete --cluster $RAYCLUSTER_TPU_CLUSTER_NAME --zone=us-central2-b

--- a/.github/workflows/nightly_tests.yaml
+++ b/.github/workflows/nightly_tests.yaml
@@ -29,6 +29,8 @@ env:
   PATHWAYS_WORKLOAD_NAME: xpkpw-nightly-${{ github.run_attempt }}
   PW_CLUSTER_ARGUMENTS: "--network=${{secrets.NETWORK_NAME}}"
   CLUSTER_NETWORK_ARGUMENTS: "--network=${{secrets.NETWORK_NAME}} --subnetwork=${{secrets.SUBNETWORK_NAME}}"
+  RAYCLUSTER_TPU_CLUSTER_NAME: rc-nightly-test-2-v4-8-nodepools
+
 jobs:
   cluster-create-and-delete:
     runs-on: [ubuntu-22.04]
@@ -161,6 +163,33 @@ jobs:
     - name: Delete the Pathways cluster created
       if: always()
       run: python xpk.py cluster delete --cluster $PATHWAYS_TPU_CLUSTER_NAME --zone=us-central2-b
+
+  rc-cluster:
+    runs-on: [ubuntu-20.04]
+    concurrency: # We support one build test to run at a time currently.
+      group: nightly-rc-test-cluster-group
+      cancel-in-progress: false
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.10'
+    - uses: 'google-github-actions/auth@v2'
+      with:
+        credentials_json: '${{ secrets.GCP_SA_KEY }}'
+    - uses: google-github-actions/setup-gcloud@v2
+      with:
+        version: '>= 363.0.0'
+        install_components: 'beta,gke-gcloud-auth-plugin'
+    - name: Set Google Cloud CLI properties to a unused zone to verify --zone arg is passed properly in commands.
+      run: |
+        gcloud config set compute/zone us-east4-a
+        gcloud config get compute/zone
+    - name: Create a RayCluster-enabled XPK Cluster with 2 x v4-8 nodepools
+      run: python xpk.py cluster create-ray-cluster --cluster $RAYCLUSTER_TPU_CLUSTER_NAME --tpu-type=v4-8  --num-slices=2 --zone=us-central2-b --default-pool-cpu-machine-type=n1-standard-16 --default-pool-cpu-num-nodes=16 --reservation='${{ secrets.GCP_TPU_V4_RESERVATION }}'
+    - name: Delete the RayCluster-enabled XPK cluster
+      if: always()
+      run: python xpk.py cluster delete --cluster $RAYCLUSTER_TPU_CLUSTER_NAME --zone=us-central2-b
 
 
 

--- a/README.md
+++ b/README.md
@@ -186,6 +186,15 @@ all zones.
     --tpu-type=v5litepod-16
     ```
 
+*   Cluster Create for Ray:
+    A cluster with KubeRay enabled and a RayCluster can be created using `cluster create-ray`.
+    ```shell
+    python3 xpk.py cluster create-ray \
+    --cluster xpk-rc-test \
+    --num-slices=4 --on-demand \
+    --tpu-type=v5litepod-8
+    ```
+
 *   Cluster Create can be called again with the same `--cluster name` to modify
     the number of slices or retry failed steps.
 

--- a/src/xpk/commands/cluster.py
+++ b/src/xpk/commands/cluster.py
@@ -50,6 +50,7 @@ from ..core.kueue import (
     wait_for_kueue_available,
 )
 from ..core.nap import enable_autoprovisioning_on_cluster
+from ..core.ray import install_ray_cluster
 from ..core.system_characteristics import (
     AcceleratorType,
     AcceleratorTypeToAcceleratorCharacteristics,
@@ -202,6 +203,13 @@ def cluster_create(args) -> None:
   )
   if create_cluster_configmaps_code != 0:
     xpk_exit(create_cluster_configmaps_code)
+
+  if args.enable_ray_cluster:
+    return_code = install_ray_cluster(args, system)
+  if return_code != 0:
+    xpk_exit(return_code)
+    # Inject values into RayCluster spec
+    # kubectl apply RayCluster
 
   xpk_print('GKE commands done! Resources are created.')
   xpk_print(
@@ -363,7 +371,23 @@ def cluster_create_pathways(args) -> None:
     0 if successful and 1 otherwise.
   """
   args.enable_pathways = True
+  args.enable_ray_cluster = False
   cluster_create(args)
+
+
+def cluster_create_ray_cluster(args) -> None:
+    """Function around cluster creation for RayCluster.
+
+    Args:
+      args: user provided arguments for running the command.
+
+    Returns:
+      None
+    """
+    args.enable_ray_cluster = True
+    #args.enable_pathways = False
+    args.enable_autoprovisioning = False
+    cluster_create(args)
 
 
 def create_cluster_if_necessary(
@@ -509,6 +533,11 @@ def run_gke_cluster_create_command(
 
   if enable_ip_alias:
     command += ' --enable-ip-alias'
+
+  if args.enable_ray_cluster:
+    command += (
+        ' --addons RayOperator'
+    )
 
   return_code = run_command_with_updates(command, 'GKE Cluster Create', args)
   if return_code != 0:

--- a/src/xpk/commands/cluster.py
+++ b/src/xpk/commands/cluster.py
@@ -208,8 +208,6 @@ def cluster_create(args) -> None:
     return_code = install_ray_cluster(args, system)
   if return_code != 0:
     xpk_exit(return_code)
-    # Inject values into RayCluster spec
-    # kubectl apply RayCluster
 
   xpk_print('GKE commands done! Resources are created.')
   xpk_print(
@@ -376,18 +374,17 @@ def cluster_create_pathways(args) -> None:
 
 
 def cluster_create_ray_cluster(args) -> None:
-    """Function around cluster creation for RayCluster.
+  """Function around cluster creation for RayCluster.
 
-    Args:
-      args: user provided arguments for running the command.
+  Args:
+    args: user provided arguments for running the command.
 
-    Returns:
-      None
-    """
-    args.enable_ray_cluster = True
-    #args.enable_pathways = False
-    args.enable_autoprovisioning = False
-    cluster_create(args)
+  Returns:
+    None
+  """
+  args.enable_ray_cluster = True
+  args.enable_autoprovisioning = False
+  cluster_create(args)
 
 
 def create_cluster_if_necessary(
@@ -535,9 +532,7 @@ def run_gke_cluster_create_command(
     command += ' --enable-ip-alias'
 
   if args.enable_ray_cluster:
-    command += (
-        ' --addons RayOperator'
-    )
+    command += ' --addons RayOperator'
 
   return_code = run_command_with_updates(command, 'GKE Cluster Create', args)
   if return_code != 0:

--- a/src/xpk/commands/cluster.py
+++ b/src/xpk/commands/cluster.py
@@ -206,8 +206,8 @@ def cluster_create(args) -> None:
 
   if args.enable_ray_cluster:
     return_code = install_ray_cluster(args, system)
-  if return_code != 0:
-    xpk_exit(return_code)
+    if return_code != 0:
+      xpk_exit(return_code)
 
   xpk_print('GKE commands done! Resources are created.')
   xpk_print(

--- a/src/xpk/commands/cluster.py
+++ b/src/xpk/commands/cluster.py
@@ -207,7 +207,7 @@ def cluster_create(args) -> None:
   if args.enable_ray_cluster:
     return_code = install_ray_cluster(args, system)
     if return_code != 0:
-      xpk_print("Installation of RayCluster failed.")
+      xpk_print('Installation of RayCluster failed.')
       xpk_exit(return_code)
 
   xpk_print('GKE commands done! Resources are created.')

--- a/src/xpk/commands/cluster.py
+++ b/src/xpk/commands/cluster.py
@@ -207,6 +207,7 @@ def cluster_create(args) -> None:
   if args.enable_ray_cluster:
     return_code = install_ray_cluster(args, system)
     if return_code != 0:
+      xpk_print("Installation of RayCluster failed.")
       xpk_exit(return_code)
 
   xpk_print('GKE commands done! Resources are created.')

--- a/src/xpk/core/ray.py
+++ b/src/xpk/core/ray.py
@@ -97,10 +97,14 @@ def install_ray_cluster(args, system) -> int:
   delete_ray_cluster(args)
 
   label = 'cloud.google.com/gke-nodepool=default-pool'
-  available_head_cpu, available_head_mem = generate_available_resources(label, args, 0.5)
+  available_head_cpu, available_head_mem = generate_available_resources(
+      label, args, 0.5
+  )
 
   label = f'cloud.google.com/gke-tpu-accelerator={system.gke_accelerator}'
-  available_worker_cpu, available_worker_mem = generate_available_resources(label, args, 0.9)
+  available_worker_cpu, available_worker_mem = generate_available_resources(
+      label, args, 0.9
+  )
 
   yml_string = ray_cluster_crd_yaml.format(
       accelerator=system.gke_accelerator,
@@ -151,6 +155,7 @@ def delete_ray_cluster(args) -> None:
 
   return
 
+
 def generate_available_resources(label, args, percent) -> tuple:
   """Generate the available resources for the nodes that match the given label
 
@@ -163,11 +168,15 @@ def generate_available_resources(label, args, percent) -> tuple:
     A tuple with the available cpu and memory
   """
 
-  command = f'kubectl get nodes -l {label} -o jsonpath=\'{{.items[0].metadata.name}}\''
+  command = (
+      f"kubectl get nodes -l {label} -o jsonpath='{{.items[0].metadata.name}}'"
+  )
   task = f'Getting nodes with label {label}'
   _, node_name = run_command_for_value(command, task, args)
 
-  command = f'kubectl get node {node_name} -o jsonpath=\'{{.status.allocatable.cpu}}\''
+  command = (
+      f"kubectl get node {node_name} -o jsonpath='{{.status.allocatable.cpu}}'"
+  )
   task = 'Fetching available CPU on node'
   _, available_cpu = run_command_for_value(command, task, args)
   match = re.match(r'(\d+)([a-zA-Z]+)', available_cpu)
@@ -175,7 +184,10 @@ def generate_available_resources(label, args, percent) -> tuple:
   cpu_value = int(int(value) * percent)
   adjusted_available_cpu = str(cpu_value) + units
 
-  command = f'kubectl get node {node_name} -o jsonpath=\'{{.status.allocatable.memory}}\''
+  command = (
+      f'kubectl get node {node_name} -o'
+      " jsonpath='{.status.allocatable.memory}'"
+  )
   task = 'Fetching available memory on node'
   _, available_memory = run_command_for_value(command, task, args)
   match = re.match(r'(\d+)([a-zA-Z]+)', available_memory)

--- a/src/xpk/core/ray.py
+++ b/src/xpk/core/ray.py
@@ -193,7 +193,10 @@ def generate_available_resources(label, args, percent) -> tuple:
   _, available_cpu = run_command_for_value(command, task, args)
   match = re.match(r'(\d+)([a-zA-Z]+)', available_cpu)
   if not match:
-    xpk_print(f'Could not find a regex match for allocatable cpu on TPU node {node_name}')
+    xpk_print(
+        'Could not find a regex match for allocatable cpu on TPU node'
+        f' {node_name}'
+    )
     xpk_exit(1)
   value, units = match.group(1), match.group(2)
   cpu_value = int(int(value) * percent)
@@ -207,7 +210,10 @@ def generate_available_resources(label, args, percent) -> tuple:
   _, available_memory = run_command_for_value(command, task, args)
   match = re.match(r'(\d+)([a-zA-Z]+)', available_memory)
   if not match:
-    xpk_print(f'Could not find a regex match for allocatable memory on TPU node {node_name}')
+    xpk_print(
+        'Could not find a regex match for allocatable memory on TPU node'
+        f' {node_name}'
+    )
     xpk_exit(1)
   value, units = match.group(1), match.group(2)
   memory_value = int(int(value) * percent)

--- a/src/xpk/core/ray.py
+++ b/src/xpk/core/ray.py
@@ -15,8 +15,9 @@ limitations under the License.
 """
 
 import re
-from ..utils import write_tmp_file, xpk_print, xpk_exit
-from .commands import run_command_with_updates_retry, run_command_for_value
+from ..utils.console import xpk_exit, xpk_print
+from ..utils.file import write_tmp_file
+from .commands import run_command_for_value, run_command_with_updates_retry
 
 
 ray_cluster_crd_yaml = """apiVersion: v1

--- a/src/xpk/core/ray.py
+++ b/src/xpk/core/ray.py
@@ -75,40 +75,38 @@ spec:
 
 
 def install_ray_cluster(args, system) -> int:
-    """Install a RayCluster on the cluster
+  """Install a RayCluster on the cluster
 
-    Args:
+  Args:
     args: user provided arguments for running the command.
     system: system characteristics.
 
-    Returns:
+  Returns:
     0 if successful and 1 otherwise.
-    """
+  """
 
-    command = 'kubectl delete rayclusters --all'
-    task = 'Deleting old RayCluster'
-    retry_attempts = 1
-    return_code = run_command_with_updates_retry(
-        command, task, args, num_retry_attempts=retry_attempts
-    )
+  command = 'kubectl delete rayclusters --all'
+  task = 'Deleting old RayCluster'
+  retry_attempts = 1
+  return_code = run_command_with_updates_retry(
+      command, task, args, num_retry_attempts=retry_attempts
+  )
 
-    yml_string = ray_cluster_crd_yaml.format(
-        accelerator=system.gke_accelerator,
-        topology=system.topology,
-        chips_per_vm=system.chips_per_vm,
-        num_hosts=system.vms_per_slice,
-        replicas=args.num_slices
-    )
+  yml_string = ray_cluster_crd_yaml.format(
+      accelerator=system.gke_accelerator,
+      topology=system.topology,
+      chips_per_vm=system.chips_per_vm,
+      num_hosts=system.vms_per_slice,
+      replicas=args.num_slices,
+  )
 
-    tmp = write_tmp_file(yml_string)
-    command = f'kubectl apply -f {str(tmp.file.name)}'
-    task = 'Applying RayCluster'
-    retry_attempts = 1
-    return_code = run_command_with_updates_retry(
-        command, task, args, num_retry_attempts=retry_attempts
-    )
-    if return_code != 0:
-        xpk_print(
-            f'{task} not successful.'
-        )
-    return return_code
+  tmp = write_tmp_file(yml_string)
+  command = f'kubectl apply -f {str(tmp.file.name)}'
+  task = 'Applying RayCluster'
+  retry_attempts = 1
+  return_code = run_command_with_updates_retry(
+      command, task, args, num_retry_attempts=retry_attempts
+  )
+  if return_code != 0:
+    xpk_print(f'{task} not successful.')
+  return return_code

--- a/src/xpk/core/ray.py
+++ b/src/xpk/core/ray.py
@@ -87,12 +87,7 @@ def install_ray_cluster(args, system) -> int:
     0 if successful and 1 otherwise.
   """
 
-  command = 'kubectl delete rayclusters --all'
-  task = 'Deleting old RayCluster'
-  retry_attempts = 1
-  return_code = run_command_with_updates_retry(
-      command, task, args, num_retry_attempts=retry_attempts
-  )
+  delete_ray_cluster(args)
 
   yml_string = ray_cluster_crd_yaml.format(
       accelerator=system.gke_accelerator,
@@ -112,4 +107,26 @@ def install_ray_cluster(args, system) -> int:
   )
   if return_code != 0:
     xpk_print(f'{task} not successful.')
+  return return_code
+
+def delete_ray_cluster(args) -> None:
+  """Delete all RayClusters on the cluster
+
+  Args:
+    args: user provided arguments for running the command.
+
+  Returns:
+    0 if successful and 1 otherwise.
+  """
+
+  command = 'kubectl delete rayclusters --all'
+  task = 'Deleting old RayCluster'
+  retry_attempts = 1
+  return_code = run_command_with_updates_retry(
+      command, task, args, num_retry_attempts=retry_attempts
+  )
+
+  if return_code != 0:
+      xpk_print(f'{task} not successful.')
+
   return return_code

--- a/src/xpk/core/ray.py
+++ b/src/xpk/core/ray.py
@@ -106,7 +106,7 @@ def install_ray_cluster(args, system) -> int:
 
   label = 'cloud.google.com/gke-nodepool=default-pool'
   available_head_cpu, available_head_mem = generate_available_resources(
-      label, args, HEAD_CPU 
+      label, args, HEAD_CPU
   )
 
   label = f'cloud.google.com/gke-tpu-accelerator={system.gke_accelerator}'

--- a/src/xpk/core/ray.py
+++ b/src/xpk/core/ray.py
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from ..utils import write_tmp_file, xpk_print
+from ..utils import write_tmp_file, xpk_print, xpk_exit
 from .commands import run_command_with_updates_retry
 
 
@@ -107,6 +107,7 @@ def install_ray_cluster(args, system) -> int:
   )
   if return_code != 0:
     xpk_print(f'{task} not successful.')
+    xpk_exit(return_code)
   return return_code
 
 

--- a/src/xpk/core/ray.py
+++ b/src/xpk/core/ray.py
@@ -1,0 +1,114 @@
+"""
+Copyright 2024 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from ..utils import write_tmp_file, xpk_print
+from .commands import run_command_with_updates_retry
+
+
+ray_cluster_crd_yaml = """apiVersion: ray.io/v1
+kind: RayCluster
+metadata:
+  name: raycluster
+spec:
+  rayVersion: '2.34.0'
+  headGroupSpec:
+    rayStartParams: {{}}
+    #pod template
+    template:
+      spec:
+        containers:
+        - name: ray-head
+          image: rayproject/ray:2.34.0
+          resources:
+            limits:
+              cpu: 1
+              memory: 2Gi
+            requests:
+              cpu: 500m
+              memory: 2Gi
+          ports:
+          - containerPort: 6379
+            name: gcs-server
+          - containerPort: 8265 # Ray dashboard
+            name: dashboard
+          - containerPort: 10001
+            name: client
+  workerGroupSpecs:
+    - replicas: {replicas}
+      numOfHosts: {num_hosts}
+      minReplicas: {replicas}
+      maxReplicas: {replicas}
+      groupName: workergroup0
+      rayStartParams:
+        block: 'true'
+      template:
+        spec:
+          containers:
+            - name: ray-worker
+              image: rayproject/ray:2.34.0
+              resources:
+                limits:
+                  cpu: 1
+                  google.com/tpu: {chips_per_vm}
+                  memory: 40G
+                requests:
+                  cpu: 1
+                  google.com/tpu: {chips_per_vm}
+                  memory: 40G
+          nodeSelector:
+            cloud.google.com/gke-tpu-accelerator: {accelerator}
+            cloud.google.com/gke-tpu-topology: {topology}
+"""
+
+
+def install_ray_cluster(args, system) -> int:
+    """Install a RayCluster on the cluster
+
+    Args:
+    args: user provided arguments for running the command.
+    system: system characteristics.
+
+    Returns:
+    0 if successful and 1 otherwise.
+    """
+
+    command = 'kubectl delete rayclusters --all'
+    task = 'Deleting old RayCluster'
+    retry_attempts = 1
+    return_code = run_command_with_updates_retry(
+        command, task, args, num_retry_attempts=retry_attempts
+    )
+
+    yml_string = ray_cluster_crd_yaml.format(
+        accelerator=system.gke_accelerator,
+        topology=system.topology,
+        chips_per_vm=system.chips_per_vm,
+        num_hosts=system.vms_per_slice,
+        replicas=args.num_slices
+    )
+
+    tmp = write_tmp_file(yml_string)
+    command = f'kubectl apply -f {str(tmp.file.name)}'
+    task = 'Applying RayCluster'
+    retry_attempts = 1
+    return_code = run_command_with_updates_retry(
+        command, task, args, num_retry_attempts=retry_attempts
+    )
+    if return_code != 0:
+        xpk_print(
+            f'{task} not successful.'
+        )
+    return return_code

--- a/src/xpk/core/ray.py
+++ b/src/xpk/core/ray.py
@@ -193,7 +193,7 @@ def generate_available_resources(label, args, percent) -> tuple:
   _, available_cpu = run_command_for_value(command, task, args)
   match = re.match(r'(\d+)([a-zA-Z]+)', available_cpu)
   if not match:
-    xpk_print(f"Could not find a regex match for allocatable cpu on TPU node {node_name}")
+    xpk_print(f'Could not find a regex match for allocatable cpu on TPU node {node_name}')
     xpk_exit(1)
   value, units = match.group(1), match.group(2)
   cpu_value = int(int(value) * percent)
@@ -207,7 +207,7 @@ def generate_available_resources(label, args, percent) -> tuple:
   _, available_memory = run_command_for_value(command, task, args)
   match = re.match(r'(\d+)([a-zA-Z]+)', available_memory)
   if not match:
-    xpk_print(f"Could not find a regex match for allocatable memory on TPU node {node_name}")
+    xpk_print(f'Could not find a regex match for allocatable memory on TPU node {node_name}')
     xpk_exit(1)
   value, units = match.group(1), match.group(2)
   memory_value = int(int(value) * percent)

--- a/src/xpk/core/ray.py
+++ b/src/xpk/core/ray.py
@@ -109,6 +109,7 @@ def install_ray_cluster(args, system) -> int:
     xpk_print(f'{task} not successful.')
   return return_code
 
+
 def delete_ray_cluster(args) -> int:
   """Delete all RayClusters on the cluster
 

--- a/src/xpk/core/ray.py
+++ b/src/xpk/core/ray.py
@@ -181,6 +181,8 @@ def generate_available_resources(label, args, percent) -> tuple:
   task = 'Fetching available CPU on node'
   _, available_cpu = run_command_for_value(command, task, args)
   match = re.match(r'(\d+)([a-zA-Z]+)', available_cpu)
+  if not match:
+    xpk_exit(1)
   value, units = match.group(1), match.group(2)
   cpu_value = int(int(value) * percent)
   adjusted_available_cpu = str(cpu_value) + units
@@ -192,6 +194,8 @@ def generate_available_resources(label, args, percent) -> tuple:
   task = 'Fetching available memory on node'
   _, available_memory = run_command_for_value(command, task, args)
   match = re.match(r'(\d+)([a-zA-Z]+)', available_memory)
+  if not match:
+    xpk_exit(1)
   value, units = match.group(1), match.group(2)
   memory_value = int(int(value) * percent)
   adjusted_available_memory = str(memory_value) + units

--- a/src/xpk/core/ray.py
+++ b/src/xpk/core/ray.py
@@ -109,7 +109,7 @@ def install_ray_cluster(args, system) -> int:
     xpk_print(f'{task} not successful.')
   return return_code
 
-def delete_ray_cluster(args) -> None:
+def delete_ray_cluster(args) -> int:
   """Delete all RayClusters on the cluster
 
   Args:
@@ -127,6 +127,6 @@ def delete_ray_cluster(args) -> None:
   )
 
   if return_code != 0:
-      xpk_print(f'{task} not successful.')
+    xpk_print(f'{task} not successful.')
 
   return return_code

--- a/src/xpk/core/ray.py
+++ b/src/xpk/core/ray.py
@@ -96,10 +96,10 @@ def install_ray_cluster(args, system) -> int:
 
   delete_ray_cluster(args)
 
-  label = "cloud.google.com/gke-nodepool=default-pool"
+  label = 'cloud.google.com/gke-nodepool=default-pool'
   available_head_cpu, available_head_mem = generate_available_resources(label, args, 0.5)
 
-  label = f"cloud.google.com/gke-tpu-accelerator={system.gke_accelerator}"
+  label = f'cloud.google.com/gke-tpu-accelerator={system.gke_accelerator}'
   available_worker_cpu, available_worker_mem = generate_available_resources(label, args, 0.9)
 
   yml_string = ray_cluster_crd_yaml.format(
@@ -170,18 +170,16 @@ def generate_available_resources(label, args, percent) -> tuple:
   command = f'kubectl get node {node_name} -o jsonpath=\'{{.status.allocatable.cpu}}\''
   task = 'Fetching available CPU on node'
   _, available_cpu = run_command_for_value(command, task, args)
-  match = re.match(r"(\d+)([a-zA-Z]+)", available_cpu)
+  match = re.match(r'(\d+)([a-zA-Z]+)', available_cpu)
   value, units = match.group(1), match.group(2)
-  xpk_print("VALUE, UNITS", value, units)
   cpu_value = int(int(value) * percent)
   adjusted_available_cpu = str(cpu_value) + units
 
   command = f'kubectl get node {node_name} -o jsonpath=\'{{.status.allocatable.memory}}\''
   task = 'Fetching available memory on node'
   _, available_memory = run_command_for_value(command, task, args)
-  match = re.match(r"(\d+)([a-zA-Z]+)", available_memory)
+  match = re.match(r'(\d+)([a-zA-Z]+)', available_memory)
   value, units = match.group(1), match.group(2)
-  xpk_print("VALUE, UNITS", value, units)
   memory_value = int(int(value) * percent)
   adjusted_available_memory = str(memory_value) + units
 

--- a/src/xpk/core/ray.py
+++ b/src/xpk/core/ray.py
@@ -18,12 +18,14 @@ from ..utils import write_tmp_file, xpk_print
 from .commands import run_command_with_updates_retry
 
 
+RAY_VERSION = '2.34.0'
+
 ray_cluster_crd_yaml = """apiVersion: ray.io/v1
 kind: RayCluster
 metadata:
   name: raycluster
 spec:
-  rayVersion: '2.34.0'
+  rayVersion: '{version}'
   headGroupSpec:
     rayStartParams: {{}}
     #pod template
@@ -31,7 +33,7 @@ spec:
       spec:
         containers:
         - name: ray-head
-          image: rayproject/ray:2.34.0
+          image: rayproject/ray:{version}
           resources:
             limits:
               cpu: 1
@@ -47,7 +49,7 @@ spec:
           - containerPort: 10001
             name: client
   workerGroupSpecs:
-    - replicas: {replicas}
+    - replicas: {replicas} # TODO: Set min and max replicas
       numOfHosts: {num_hosts}
       minReplicas: {replicas}
       maxReplicas: {replicas}
@@ -58,7 +60,7 @@ spec:
         spec:
           containers:
             - name: ray-worker
-              image: rayproject/ray:2.34.0
+              image: rayproject/ray:{version}
               resources:
                 limits:
                   cpu: 1
@@ -98,6 +100,7 @@ def install_ray_cluster(args, system) -> int:
       chips_per_vm=system.chips_per_vm,
       num_hosts=system.vms_per_slice,
       replicas=args.num_slices,
+      version=RAY_VERSION,
   )
 
   tmp = write_tmp_file(yml_string)

--- a/src/xpk/main.py
+++ b/src/xpk/main.py
@@ -61,6 +61,7 @@ set_parser(parser=parser)
 
 xpk_print('Starting xpk', flush=True)
 main_args = parser.parse_args()
+main_args.enable_ray_cluster = False
 main_args.func(main_args)
 
 

--- a/src/xpk/parser/cluster.py
+++ b/src/xpk/parser/cluster.py
@@ -18,6 +18,7 @@ from ..commands.cluster import (
     cluster_cacheimage,
     cluster_create,
     cluster_create_pathways,
+    cluster_create_ray_cluster,
     cluster_delete,
     cluster_describe,
     cluster_list,
@@ -169,25 +170,85 @@ def set_cluster_parser(cluster_parser):
       help='The tpu type to use, v5litepod-16, etc.',
   )
 
+  ### "cluster create-ray-cluster" command parser
+
+  cluster_create_ray_cluster_parser = cluster_subcommands.add_parser(
+      'create-ray-cluster',
+      help='Create RayCluster',
+  )
+  cluster_create_ray_cluster_required_arguments = (
+      cluster_create_ray_cluster_parser.add_argument_group(
+          'Required Arguments',
+          'Arguments required for cluster create-ray-cluster.',
+      )
+  )
+  cluster_create_ray_cluster_optional_arguments = (
+      cluster_create_ray_cluster_parser.add_argument_group(
+          'Optional Arguments',
+          'Arguments optional for cluster create-ray-cluster.',
+      )
+  )
+  cluster_create_ray_cluster_capacity_arguments = (
+      cluster_create_ray_cluster_parser.add_argument_group(
+          'Capacity Arguments',
+          'Arguments related to capacity for cluster create-ray-cluster.',
+      )
+  )
+  cluster_create_ray_cluster_tensorboard_arguments = (
+      cluster_create_ray_cluster_parser.add_argument_group(
+          'Optional Vertex AI Tensorboard Arguments',
+          'Arguments for creating Vertex AI Tensorboard in cluster create.',
+      )
+  )
+
+  ### RayCluster required arguments specific to "cluster create"
+  cluster_create_ray_cluster_required_arguments.add_argument(
+      '--tpu-type',
+      type=str,
+      default=None,
+      help='The tpu type to use, v5litepod-16, etc.',
+  )
+  ### Optional arguments specific to "cluster create"
+  cluster_create_ray_cluster_optional_arguments.add_argument(
+      '--num-nodes',
+      type=int,
+      default=2,
+      help='The number of nodes for a cluster, defaults to 2.',
+      required=False,
+  )
+  cluster_create_ray_cluster_optional_arguments.add_argument(
+      '--enable-pathways',
+      action='store_true',
+      help=(
+          'DEPRECATING SOON!!! Please use `xpk cluster create-pathways`.'
+          ' Enable cluster to accept Pathways workloads.'
+      ),
+  )
+
   add_shared_cluster_create_required_arguments([
       cluster_create_required_arguments,
       cluster_create_pathways_required_arguments,
+      cluster_create_ray_cluster_required_arguments,
   ])
   add_shared_cluster_create_optional_arguments([
       cluster_create_optional_arguments,
       cluster_create_pathways_optional_arguments,
+      cluster_create_ray_cluster_optional_arguments,
   ])
   add_shared_cluster_create_capacity_arguments([
       cluster_create_capacity_arguments,
       cluster_create_pathways_capacity_arguments,
+      cluster_create_ray_cluster_capacity_arguments,
   ])
   add_shared_cluster_create_tensorboard_arguments([
       cluster_create_tensorboard_arguments,
       cluster_create_pathways_tensorboard_arguments,
+      cluster_create_ray_cluster_tensorboard_arguments,
   ])
 
   cluster_create_parser.set_defaults(func=cluster_create)
   cluster_create_pathways_parser.set_defaults(func=cluster_create_pathways)
+  cluster_create_ray_cluster_parser.set_defaults(func=cluster_create_ray_cluster)
 
   ### "cluster delete" command parser ###
   cluster_delete_parser = cluster_subcommands.add_parser(

--- a/src/xpk/parser/cluster.py
+++ b/src/xpk/parser/cluster.py
@@ -209,20 +209,13 @@ def set_cluster_parser(cluster_parser):
       help='The tpu type to use, v5litepod-16, etc.',
       required=True,
   )
+  # TODO(bzmarke): Add --device-type to support GPU/CPU
   cluster_create_ray_cluster_required_arguments.add_argument(
       '--ray-version',
       type=str,
       default=None,
       help="The Ray version to use, e.g. '2.38.0'",
       required=True,
-  )
-  ### Optional arguments specific to "cluster create"
-  cluster_create_ray_cluster_optional_arguments.add_argument(
-      '--num-nodes',
-      type=int,
-      default=2,
-      help='The number of nodes for a cluster, defaults to 2.',
-      required=False,
   )
   cluster_create_ray_cluster_optional_arguments.add_argument(
       '--enable-pathways',

--- a/src/xpk/parser/cluster.py
+++ b/src/xpk/parser/cluster.py
@@ -213,7 +213,7 @@ def set_cluster_parser(cluster_parser):
       '--ray-version',
       type=str,
       default=None,
-      help='The Ray version to use, e.g. \'2.38.0\'',
+      help="The Ray version to use, e.g. '2.38.0'",
       required=True,
   )
   ### Optional arguments specific to "cluster create"

--- a/src/xpk/parser/cluster.py
+++ b/src/xpk/parser/cluster.py
@@ -179,19 +179,19 @@ def set_cluster_parser(cluster_parser):
   cluster_create_ray_cluster_required_arguments = (
       cluster_create_ray_cluster_parser.add_argument_group(
           'Required Arguments',
-          'Arguments required for cluster create-ray-cluster.',
+          'Arguments required for cluster create-ray.',
       )
   )
   cluster_create_ray_cluster_optional_arguments = (
       cluster_create_ray_cluster_parser.add_argument_group(
           'Optional Arguments',
-          'Arguments optional for cluster create-ray-cluster.',
+          'Arguments optional for cluster create-ray.',
       )
   )
   cluster_create_ray_cluster_capacity_arguments = (
       cluster_create_ray_cluster_parser.add_argument_group(
           'Capacity Arguments',
-          'Arguments related to capacity for cluster create-ray-cluster.',
+          'Arguments related to capacity for cluster create-ray.',
       )
   )
   cluster_create_ray_cluster_tensorboard_arguments = (

--- a/src/xpk/parser/cluster.py
+++ b/src/xpk/parser/cluster.py
@@ -170,10 +170,10 @@ def set_cluster_parser(cluster_parser):
       help='The tpu type to use, v5litepod-16, etc.',
   )
 
-  ### "cluster create-ray-cluster" command parser
+  ### "cluster create-ray" command parser
 
   cluster_create_ray_cluster_parser = cluster_subcommands.add_parser(
-      'create-ray-cluster',
+      'create-ray',
       help='Create RayCluster',
   )
   cluster_create_ray_cluster_required_arguments = (

--- a/src/xpk/parser/cluster.py
+++ b/src/xpk/parser/cluster.py
@@ -207,6 +207,14 @@ def set_cluster_parser(cluster_parser):
       type=str,
       default=None,
       help='The tpu type to use, v5litepod-16, etc.',
+      required=True,
+  )
+  cluster_create_ray_cluster_required_arguments.add_argument(
+      '--ray-version',
+      type=str,
+      default=None,
+      help='The Ray version to use, e.g. \'2.38.0\'',
+      required=True,
   )
   ### Optional arguments specific to "cluster create"
   cluster_create_ray_cluster_optional_arguments.add_argument(

--- a/src/xpk/parser/cluster.py
+++ b/src/xpk/parser/cluster.py
@@ -248,7 +248,9 @@ def set_cluster_parser(cluster_parser):
 
   cluster_create_parser.set_defaults(func=cluster_create)
   cluster_create_pathways_parser.set_defaults(func=cluster_create_pathways)
-  cluster_create_ray_cluster_parser.set_defaults(func=cluster_create_ray_cluster)
+  cluster_create_ray_cluster_parser.set_defaults(
+      func=cluster_create_ray_cluster
+  )
 
   ### "cluster delete" command parser ###
   cluster_delete_parser = cluster_subcommands.add_parser(


### PR DESCRIPTION
## Fixes / Features
-Adds the create-ray subcommand, which creates a RayCluster with a head node and a workergroup that utilizes all TPU resources

## Testing / Documentation
Manually tested `python3 xpk.py cluster create-ray ...` with several different TPU configurations. Also added a nightly test for RayCluster creation.

- [ y ] Tests pass
- [ y ] Appropriate changes to documentation are included in the PR
