### PR TITLE
pathways port remap

### DIFF
--- a/src/xpk/commands/workload.py
+++ b/src/xpk/commands/workload.py
@@ -202,7 +202,7 @@ spec:
               imagePullPolicy: Always
               name: pathways-worker
               ports:
-              - containerPort: 38677
+              - containerPort: 29001
               - containerPort: 8471
               - containerPort: 8080
               resources:
@@ -257,7 +257,7 @@ spec:
               imagePullPolicy: Always
               name: pathways-rm
               ports:
-              - containerPort: 38677
+              - containerPort: 29001
               securityContext:
                 privileged: true
               volumeMounts:
@@ -291,7 +291,7 @@ spec:
               imagePullPolicy: Always
               name: pathways-proxy
               ports:
-              - containerPort: 38676
+              - containerPort: 29000
             hostNetwork: true
             dnsPolicy: ClusterFirstWithHostNet
             nodeSelector:

--- a/src/xpk/core/pathways.py
+++ b/src/xpk/core/pathways.py
@@ -41,7 +41,7 @@ def get_pathways_worker_args(args) -> str:
   Returns:
     str: yaml containing arguments for the Pathways workers.
   """
-  yaml = """- --server_port=38677
+  yaml = """- --server_port=29001
               - --resource_manager_address={rm_address}
               - --gcs_scratch_location={args.pathways_gcs_location}"""
   if args.use_pathways:
@@ -58,7 +58,7 @@ def get_pathways_proxy_args(args) -> str:
   Returns:
     str: yaml containing arguments for the Pathways proxy.
   """
-  yaml = """- --server_port=38676
+  yaml = """- --server_port=29000
               - --resource_manager_address={rm_address}
               - --gcs_scratch_location={args.pathways_gcs_location}"""
 
@@ -198,7 +198,7 @@ def get_pathways_rm_args(args, system: SystemCharacteristics) -> str:
   Returns:
     str: yaml containing arguments for the Pathways resource manager.
   """
-  yaml = """- --server_port=38677
+  yaml = """- --server_port=29001
               - --gcs_scratch_location={args.pathways_gcs_location}
               - --node_type=resource_manager
               - --instance_count={instance_count}
@@ -267,7 +267,7 @@ def get_rm_address(args) -> str:
   suffix = ''
   if is_cluster_using_clouddns(args):
     suffix = f'.default.svc.{args.cluster}-domain.'
-  rm_address = f'{args.workload}-rm-0-0.{args.workload}{suffix}:38677'
+  rm_address = f'{args.workload}-rm-0-0.{args.workload}{suffix}:29001'
   return rm_address
 
 
@@ -283,7 +283,7 @@ def get_proxy_address(args) -> str:
   if is_cluster_using_clouddns(args):
     suffix = f'.default.svc.{args.cluster}-domain.'
   proxy_address = (
-      f'grpc://{args.workload}-proxy-0-0.{args.workload}{suffix}:38676'
+      f'grpc://{args.workload}-proxy-0-0.{args.workload}{suffix}:29000'
   )
   return proxy_address
 


### PR DESCRIPTION
## Fixes / Features
- remap pathways port usage to:
```
38676 -> 29000
38677 -> 29001
38678 -> 29002
```
The previous ports would conflict with k8s ports at large scale. Details in b/374130169.

- pyink run for workload.py and pathways.py
- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR