### PR TITLE
Update CODEOWNERS so that it allows reviewers from one of the following people

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,1 @@
-* @rwitten
-* @Obliviour
-* @44past4
-* @sharabiani
-* @pawloch00
-* @BluValor
+* @Obliviour @44past4 @sharabiani @pawloch00 @BluValor


### PR DESCRIPTION


The previous setup only looked at the last line of the file. The syntax is to add "any" of the owners to the same line.

