### PR TITLE
Add Makefile for installing dependencies

### DIFF
--- a/.github/workflows/build_tests.yaml
+++ b/.github/workflows/build_tests.yaml
@@ -51,7 +51,7 @@ jobs:
         gcloud config set compute/zone us-east4-a
         gcloud config get compute/zone
     - name: Install xpk dependencies
-      run: make install 
+      run: make install && export PATH=$PATH:$PWD/bin
     - name: Create a private Pathways-enabled XPK Cluster with 2x v4-8 nodepools. Larger num-nodes to avoid master resizing.
       run: python xpk.py cluster create-pathways --cluster $TPU_CLUSTER_NAME --private --tpu-type=v4-8  --num-slices=2 --zone=us-central2-b --default-pool-cpu-machine-type=n1-standard-16 --default-pool-cpu-num-nodes=16 --reservation='${{ secrets.GCP_TPU_V4_RESERVATION }}' --custom-cluster-arguments="${CLUSTER_ARGUMENTS}"
     - name: Verify the created cluster is private

--- a/.github/workflows/build_tests.yaml
+++ b/.github/workflows/build_tests.yaml
@@ -50,18 +50,8 @@ jobs:
       run: |
         gcloud config set compute/zone us-east4-a
         gcloud config get compute/zone
-    - name: Install kjob
-      run: |
-        git clone https://github.com/kubernetes-sigs/kueue.git
-        cd kueue/cmd/experimental/kjobctl
-        make kubectl-kjob
-        mv ./bin/kubectl-kjob /usr/local/bin/kubectl-kjob
-    - name: Install kueuectl
-      run: curl -Lo ./kubectl-kueue https://github.com/kubernetes-sigs/kueue/releases/download/v0.8.1/kubectl-kueue-linux-amd64 && chmod +x ./kubectl-kueue && mv ./kubectl-kueue /usr/local/bin/kubectl-kueue
-    - name: Install xpk with pip and verify it executes corretly
-      run: |
-        pip install .
-        xpk --help
+    - name: Install xpk dependencies
+      run: make install 
     - name: Create a private Pathways-enabled XPK Cluster with 2x v4-8 nodepools. Larger num-nodes to avoid master resizing.
       run: python xpk.py cluster create-pathways --cluster $TPU_CLUSTER_NAME --private --tpu-type=v4-8  --num-slices=2 --zone=us-central2-b --default-pool-cpu-machine-type=n1-standard-16 --default-pool-cpu-num-nodes=16 --reservation='${{ secrets.GCP_TPU_V4_RESERVATION }}' --custom-cluster-arguments="${CLUSTER_ARGUMENTS}"
     - name: Verify the created cluster is private

--- a/.github/workflows/build_tests.yaml
+++ b/.github/workflows/build_tests.yaml
@@ -51,7 +51,9 @@ jobs:
         gcloud config set compute/zone us-east4-a
         gcloud config get compute/zone
     - name: Install xpk dependencies
-      run: make install && export PATH=$PATH:$PWD/bin
+      run: |
+        make install && export PATH=$PATH:$PWD/bin
+        echo $PWD
     - name: Create a private Pathways-enabled XPK Cluster with 2x v4-8 nodepools. Larger num-nodes to avoid master resizing.
       run: python xpk.py cluster create-pathways --cluster $TPU_CLUSTER_NAME --private --tpu-type=v4-8  --num-slices=2 --zone=us-central2-b --default-pool-cpu-machine-type=n1-standard-16 --default-pool-cpu-num-nodes=16 --reservation='${{ secrets.GCP_TPU_V4_RESERVATION }}' --custom-cluster-arguments="${CLUSTER_ARGUMENTS}"
     - name: Verify the created cluster is private

--- a/.github/workflows/build_tests.yaml
+++ b/.github/workflows/build_tests.yaml
@@ -54,6 +54,7 @@ jobs:
       run: |
         make install && export PATH=$PATH:$PWD/bin
         echo $PWD
+        echo $PATH
     - name: Create a private Pathways-enabled XPK Cluster with 2x v4-8 nodepools. Larger num-nodes to avoid master resizing.
       run: python xpk.py cluster create-pathways --cluster $TPU_CLUSTER_NAME --private --tpu-type=v4-8  --num-slices=2 --zone=us-central2-b --default-pool-cpu-machine-type=n1-standard-16 --default-pool-cpu-num-nodes=16 --reservation='${{ secrets.GCP_TPU_V4_RESERVATION }}' --custom-cluster-arguments="${CLUSTER_ARGUMENTS}"
     - name: Verify the created cluster is private

--- a/.github/workflows/build_tests.yaml
+++ b/.github/workflows/build_tests.yaml
@@ -54,6 +54,8 @@ jobs:
       run: |
         make install 
         echo $PWD/bin >> "$GITHUB_PATH"
+    - name: Check xpk installation
+      run: xpk --help
     - name: Create a private Pathways-enabled XPK Cluster with 2x v4-8 nodepools. Larger num-nodes to avoid master resizing.
       run: python xpk.py cluster create-pathways --cluster $TPU_CLUSTER_NAME --private --tpu-type=v4-8  --num-slices=2 --zone=us-central2-b --default-pool-cpu-machine-type=n1-standard-16 --default-pool-cpu-num-nodes=16 --reservation='${{ secrets.GCP_TPU_V4_RESERVATION }}' --custom-cluster-arguments="${CLUSTER_ARGUMENTS}"
     - name: Verify the created cluster is private

--- a/.github/workflows/build_tests.yaml
+++ b/.github/workflows/build_tests.yaml
@@ -52,9 +52,8 @@ jobs:
         gcloud config get compute/zone
     - name: Install xpk dependencies
       run: |
-        make install && export PATH=$PATH:$PWD/bin
-        echo $PWD
-        echo $PATH
+        make install 
+        echo $PWD/bin >> "$GITHUB_PATH"
     - name: Create a private Pathways-enabled XPK Cluster with 2x v4-8 nodepools. Larger num-nodes to avoid master resizing.
       run: python xpk.py cluster create-pathways --cluster $TPU_CLUSTER_NAME --private --tpu-type=v4-8  --num-slices=2 --zone=us-central2-b --default-pool-cpu-machine-type=n1-standard-16 --default-pool-cpu-num-nodes=16 --reservation='${{ secrets.GCP_TPU_V4_RESERVATION }}' --custom-cluster-arguments="${CLUSTER_ARGUMENTS}"
     - name: Verify the created cluster is private

--- a/.github/workflows/nightly_tests.yaml
+++ b/.github/workflows/nightly_tests.yaml
@@ -53,18 +53,8 @@ jobs:
       run: |
         gcloud config set compute/zone us-east4-a
         gcloud config get compute/zone
-    - name: Install kjob
-      run: |
-        git clone https://github.com/kubernetes-sigs/kueue.git
-        cd kueue/cmd/experimental/kjobctl
-        make kubectl-kjob
-        mv ./bin/kubectl-kjob /usr/local/bin/kubectl-kjob      
-    - name: Install kueuectl
-      run: curl -Lo ./kubectl-kueue https://github.com/kubernetes-sigs/kueue/releases/download/v0.8.1/kubectl-kueue-linux-amd64 && chmod +x ./kubectl-kueue && mv ./kubectl-kueue /usr/local/bin/kubectl-kueue
-    - name: Install xpk with pip and verify it executes corretly
-      run: |
-        pip install .
-        xpk --help
+    - name: Install xpk dependencies
+      run: make install 
     - name: Create an XPK Cluster with zero node pools
       run: python xpk.py cluster create --cluster $EMPTY_CLUSTER_NAME --tpu-type=v4-8  --num-slices=0 --zone=us-central2-b --default-pool-cpu-machine-type=n1-standard-16 --reservation='${{ secrets.GCP_TPU_V4_RESERVATION }}' --custom-cluster-arguments='${{ secrets.CLUSTER_ARGUMENTS }}'
     - name: Delete the cluster created
@@ -120,18 +110,8 @@ jobs:
       run: |
         gcloud config set compute/zone us-east4-a
         gcloud config get compute/zone
-    - name: Install kjob
-      run: |
-        git clone https://github.com/kubernetes-sigs/kueue.git
-        cd kueue/cmd/experimental/kjobctl
-        make kubectl-kjob
-        mv ./bin/kubectl-kjob /usr/local/bin/kubectl-kjob
-    - name: Install xpk with pip and verify it executes corretly
-      run: |
-        pip install .
-        xpk --help
-    - name: Install kueuectl
-      run: curl -Lo ./kubectl-kueue https://github.com/kubernetes-sigs/kueue/releases/download/v0.8.1/kubectl-kueue-linux-amd64 && chmod +x ./kubectl-kueue && mv ./kubectl-kueue /usr/local/bin/kubectl-kueue
+    - name: Install xpk dependencies
+      run: make install 
     - name: Create an Pathways-enabled XPK Cluster with 2 x v4-8 nodepools
       run: python xpk.py cluster create-pathways --cluster $PATHWAYS_TPU_CLUSTER_NAME --tpu-type=v4-8  --num-slices=2 --zone=us-central2-b --default-pool-cpu-machine-type=n1-standard-16 --default-pool-cpu-num-nodes=16 --reservation='${{ secrets.GCP_TPU_V4_RESERVATION }}' --custom-cluster-arguments="${PW_CLUSTER_ARGUMENTS}"
     - name: Create test script to execute in workloads

--- a/.github/workflows/nightly_tests.yaml
+++ b/.github/workflows/nightly_tests.yaml
@@ -57,6 +57,8 @@ jobs:
       run: |
         make install 
         echo $PWD/bin >> "$GITHUB_PATH"
+    - name: Check xpk installation
+      run: xpk --help
     - name: Create an XPK Cluster with zero node pools
       run: python xpk.py cluster create --cluster $EMPTY_CLUSTER_NAME --tpu-type=v4-8  --num-slices=0 --zone=us-central2-b --default-pool-cpu-machine-type=n1-standard-16 --reservation='${{ secrets.GCP_TPU_V4_RESERVATION }}' --custom-cluster-arguments='${{ secrets.CLUSTER_ARGUMENTS }}'
     - name: Delete the cluster created
@@ -116,6 +118,8 @@ jobs:
       run: |
         make install 
         echo $PWD/bin >> "$GITHUB_PATH"
+    - name: Check xpk installation
+      run: xpk --help
     - name: Create an Pathways-enabled XPK Cluster with 2 x v4-8 nodepools
       run: python xpk.py cluster create-pathways --cluster $PATHWAYS_TPU_CLUSTER_NAME --tpu-type=v4-8  --num-slices=2 --zone=us-central2-b --default-pool-cpu-machine-type=n1-standard-16 --default-pool-cpu-num-nodes=16 --reservation='${{ secrets.GCP_TPU_V4_RESERVATION }}' --custom-cluster-arguments="${PW_CLUSTER_ARGUMENTS}"
     - name: Create test script to execute in workloads

--- a/.github/workflows/nightly_tests.yaml
+++ b/.github/workflows/nightly_tests.yaml
@@ -54,7 +54,9 @@ jobs:
         gcloud config set compute/zone us-east4-a
         gcloud config get compute/zone
     - name: Install xpk dependencies
-      run: make install && export PATH=$PATH:$PWD/bin
+      run: |
+        make install 
+        echo $PWD/bin >> "$GITHUB_PATH"
     - name: Create an XPK Cluster with zero node pools
       run: python xpk.py cluster create --cluster $EMPTY_CLUSTER_NAME --tpu-type=v4-8  --num-slices=0 --zone=us-central2-b --default-pool-cpu-machine-type=n1-standard-16 --reservation='${{ secrets.GCP_TPU_V4_RESERVATION }}' --custom-cluster-arguments='${{ secrets.CLUSTER_ARGUMENTS }}'
     - name: Delete the cluster created
@@ -111,7 +113,9 @@ jobs:
         gcloud config set compute/zone us-east4-a
         gcloud config get compute/zone
     - name: Install xpk dependencies
-      run: make install && export PATH=$PATH:$PWD/bin
+      run: |
+        make install 
+        echo $PWD/bin >> "$GITHUB_PATH"
     - name: Create an Pathways-enabled XPK Cluster with 2 x v4-8 nodepools
       run: python xpk.py cluster create-pathways --cluster $PATHWAYS_TPU_CLUSTER_NAME --tpu-type=v4-8  --num-slices=2 --zone=us-central2-b --default-pool-cpu-machine-type=n1-standard-16 --default-pool-cpu-num-nodes=16 --reservation='${{ secrets.GCP_TPU_V4_RESERVATION }}' --custom-cluster-arguments="${PW_CLUSTER_ARGUMENTS}"
     - name: Create test script to execute in workloads

--- a/.github/workflows/nightly_tests.yaml
+++ b/.github/workflows/nightly_tests.yaml
@@ -54,7 +54,7 @@ jobs:
         gcloud config set compute/zone us-east4-a
         gcloud config get compute/zone
     - name: Install xpk dependencies
-      run: make install 
+      run: make install && export PATH=$PATH:$PWD/bin
     - name: Create an XPK Cluster with zero node pools
       run: python xpk.py cluster create --cluster $EMPTY_CLUSTER_NAME --tpu-type=v4-8  --num-slices=0 --zone=us-central2-b --default-pool-cpu-machine-type=n1-standard-16 --reservation='${{ secrets.GCP_TPU_V4_RESERVATION }}' --custom-cluster-arguments='${{ secrets.CLUSTER_ARGUMENTS }}'
     - name: Delete the cluster created
@@ -111,7 +111,7 @@ jobs:
         gcloud config set compute/zone us-east4-a
         gcloud config get compute/zone
     - name: Install xpk dependencies
-      run: make install 
+      run: make install && export PATH=$PATH:$PWD/bin
     - name: Create an Pathways-enabled XPK Cluster with 2 x v4-8 nodepools
       run: python xpk.py cluster create-pathways --cluster $PATHWAYS_TPU_CLUSTER_NAME --tpu-type=v4-8  --num-slices=2 --zone=us-central2-b --default-pool-cpu-machine-type=n1-standard-16 --default-pool-cpu-num-nodes=16 --reservation='${{ secrets.GCP_TPU_V4_RESERVATION }}' --custom-cluster-arguments="${PW_CLUSTER_ARGUMENTS}"
     - name: Create test script to execute in workloads

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ __pycache__/
 
 # C extensions
 *.so
-
+bin/
 # Distribution / packaging
 .Python
 build/

--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,10 @@ KUEUE_REPO=https://github.com/kubernetes-sigs/kueue.git
 KUEUE_TMP_PATH=/tmp/xpk_tmp/kueue
 
 KUBECTL_VERSION := $(shell curl -L -s https://dl.k8s.io/release/stable.txt)
-OS := $(shell dpkg --print-architecture)
+PLATFORM := $(shell dpkg --print-architecture)
 
-KUBECTL_URL = "https://dl.k8s.io/release/$(KUBECTL_VERSION)/bin/linux/$(OS)/kubectl"
-KUEUECTL_URL = "https://github.com/kubernetes-sigs/kueue/releases/download/v0.9.0/kubectl-kueue-linux-$(OS)"
+KUBECTL_URL = "https://dl.k8s.io/release/$(KUBECTL_VERSION)/bin/linux/$(PLATFORM)/kubectl"
+KUEUECTL_URL = "https://github.com/kubernetes-sigs/kueue/releases/download/v0.9.0/kubectl-kueue-linux-$(PLATFORM)"
 
 PROJECT_DIR := $(realpath $(shell dirname $(firstword $(MAKEFILE_LIST))))
 

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ install-kjob: install-kubectl
 mkdir-bin:
 	mkdir -p $(BIN_PATH)
 
-install-kubectl mkdir-bin:
+install-kubectl: mkdir-bin
 	curl -LO $(KUBECTL_URL)
 	chmod +x kubectl
 	mv ./kubectl $(BIN_PATH)/kubectl

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,32 @@
+KUEUE_REPO=https://github.com/kubernetes-sigs/kueue.git
+KUEUE_TMP_PATH=/tmp/xpk_tmp/kueue
+
+
+.PHONY: install install_kjob install_kueuectl install_gcloud check_python
+
+install: install_kjob
+	pip install .
+
+install_kjob: install_kueuectl
+	git clone $(KUEUE_REPO) $(KUEUE_TMP_PATH)
+	make -C $(KUEUE_TMP_PATH)/cmd/experimental/kjobctl kubectl-kjob
+	sudo mv $(KUEUE_TMP_PATH)/cmd/experimental/kjobctl/bin/kubectl-kjob /usr/local/bin/kubectl-kjob
+	rm -rf $(KUEUE_TMP_PATH)
+
+install_kubectl:check_gcloud
+	curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+	chmod +x kubectl
+	mkdir -p ~/.local/bin
+	mv ./kubectl ~/.local/bin/kubectl
+
+install_kueuectl:install_kubectl
+	git clone $(KUEUE_REPO) $(KUEUE_TMP_PATH)
+	make -C $(KUEUE_TMP_PATH) kueuectl
+	sudo mv $(KUEUE_TMP_PATH)/bin/kubectl-kueue /usr/local/bin/kubectl-kueue
+	rm -rf $(KUEUE_TMP_PATH)
+
+check_gcloud: check_python
+	gcloud version || (echo "gcloud not installed, use this link to install: https://cloud.google.com/sdk/docs/install" && exit 1)
+
+check_python:
+	python3 --version || (echo "python3 not installed. Please install python in version required by xpk" && exit 1)

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,8 @@ install-kjob: install-kubectl
 	rm -rf $(KUEUE_TMP_PATH)
 
 install-kubectl:
+	echo $(PROJECT_DIR)
+	echo $(BIN_PATH)
 	curl -LO $(KUBECTL_URL)
 	chmod +x kubectl
 	mv ./kubectl $(BIN_PATH)/kubectl

--- a/Makefile
+++ b/Makefile
@@ -4,19 +4,8 @@ KUEUE_TMP_PATH=/tmp/xpk_tmp/kueue
 KUBECTL_VERSION := $(shell curl -L -s https://dl.k8s.io/release/stable.txt)
 OS := $(shell dpkg --print-architecture)
 
-ifeq ($(OS),amd64)
-	KUBECTL_URL = "https://dl.k8s.io/release/$(KUBECTL_VERSION)/bin/linux/amd64/kubectl"
-endif
-ifeq ($(OS),arm64)
-	KUBECTL_URL = "https://dl.k8s.io/release/$(KUBECTL_VERSION)/bin/linux/arm64/kubectl"
-endif	
-
-ifeq ($(OS),amd64)
-	KUEUECTL_URL = "https://github.com/kubernetes-sigs/kueue/releases/download/v0.9.0/kubectl-kueue-linux-amd64"
-endif
-ifeq ($(OS),arm64)
-	KUEUECTL_URL = "https://github.com/kubernetes-sigs/kueue/releases/download/v0.9.0/kubectl-kueue-linux-arm64"
-endif	
+KUBECTL_URL = "https://dl.k8s.io/release/$(KUBECTL_VERSION)/bin/linux/$(OS)/kubectl"
+KUEUECTL_URL = "https://github.com/kubernetes-sigs/kueue/releases/download/v0.9.0/kubectl-kueue-linux-$(OS)"
 
 PROJECT_DIR := $(realpath $(shell dirname $(firstword $(MAKEFILE_LIST))))
 

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,15 @@ OS := $(shell dpkg --print-architecture)
 ifeq ($(OS),amd64)
 	KUBECTL_URL = "https://dl.k8s.io/release/$(KUBECTL_VERSION)/bin/linux/amd64/kubectl"
 endif
-ifeq ($(OS),arm)
+ifeq ($(OS),arm64)
 	KUBECTL_URL = "https://dl.k8s.io/release/$(KUBECTL_VERSION)/bin/linux/arm64/kubectl"
+endif	
+
+ifeq ($(OS),amd64)
+	KUEUECTL_URL = "https://github.com/kubernetes-sigs/kueue/releases/download/v0.9.0/kubectl-kueue-linux-amd64"
+endif
+ifeq ($(OS),arm64)
+	KUEUECTL_URL = "https://github.com/kubernetes-sigs/kueue/releases/download/v0.9.0/kubectl-kueue-linux-arm64"
 endif	
 
 PROJECT_DIR := $(realpath $(shell dirname $(firstword $(MAKEFILE_LIST))))
@@ -29,18 +36,17 @@ install-kjob: install-kubectl
 	rm -rf $(KUEUE_TMP_PATH)
 
 mkdir-bin:
-	test -d $(BIN_PATH) || mkdir $(BIN_PATH)
+	mkdir -p $(BIN_PATH)
 
-install-kubectl:
+install-kubectl mkdir-bin:
 	curl -LO $(KUBECTL_URL)
 	chmod +x kubectl
 	mv ./kubectl $(BIN_PATH)/kubectl
 
 install-kueuectl: install-kubectl
-	git clone $(KUEUE_REPO) $(KUEUE_TMP_PATH)
-	make -C $(KUEUE_TMP_PATH) kueuectl
-	mv $(KUEUE_TMP_PATH)/bin/kubectl-kueue $(BIN_PATH)/kubectl-kueue
-	rm -rf $(KUEUE_TMP_PATH)
+	curl -Lo ./kubectl-kueue $(KUEUECTL_URL)
+	chmod +x ./kubectl-kueue
+	mv ./kubectl-kueue $(BIN_PATH)/kubectl-kueue
 
 check-gcloud:
 	gcloud version || (echo "gcloud not installed, use this link to install: https://cloud.google.com/sdk/docs/install" && exit 1)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
 KUEUE_REPO=https://github.com/kubernetes-sigs/kueue.git
 KUEUE_TMP_PATH=/tmp/xpk_tmp/kueue
 
+KUBECTL_AMD64="https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+KUBECTL_ARM="https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/arm64/kubectl"
+
+OS := $(shell dpkg --print-architecture)
 
 .PHONY: install install_kjob install_kueuectl install_gcloud check_python
 
@@ -10,11 +14,16 @@ install: install_kjob
 install_kjob: install_kueuectl
 	git clone $(KUEUE_REPO) $(KUEUE_TMP_PATH)
 	make -C $(KUEUE_TMP_PATH)/cmd/experimental/kjobctl kubectl-kjob
-	sudo mv $(KUEUE_TMP_PATH)/cmd/experimental/kjobctl/bin/kubectl-kjob /usr/local/bin/kubectl-kjob
+	mv $(KUEUE_TMP_PATH)/cmd/experimental/kjobctl/bin/kubectl-kjob /usr/local/bin/kubectl-kjob
 	rm -rf $(KUEUE_TMP_PATH)
 
 install_kubectl: check_gcloud
-	curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+ifeq ($(OS),amd64)
+	curl -LO $(KUBECTL_AMD64)
+endif
+ifeq ($(OS),arm)
+	curl -LO $(KUBECTL_ARM)
+endif	
 	chmod +x kubectl
 	mkdir -p ~/.local/bin
 	mv ./kubectl ~/.local/bin/kubectl
@@ -22,7 +31,7 @@ install_kubectl: check_gcloud
 install_kueuectl: install_kubectl
 	git clone $(KUEUE_REPO) $(KUEUE_TMP_PATH)
 	make -C $(KUEUE_TMP_PATH) kueuectl
-	sudo mv $(KUEUE_TMP_PATH)/bin/kubectl-kueue /usr/local/bin/kubectl-kueue
+	mv $(KUEUE_TMP_PATH)/bin/kubectl-kueue /usr/local/bin/kubectl-kueue
 	rm -rf $(KUEUE_TMP_PATH)
 
 check_gcloud: check_python

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
 KUEUE_REPO=https://github.com/kubernetes-sigs/kueue.git
 KUEUE_TMP_PATH=/tmp/xpk_tmp/kueue
 
-KUBECTL_AMD64="https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
-KUBECTL_ARM="https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/arm64/kubectl"
+KUBECTL_VERSION := $(shell curl -L -s https://dl.k8s.io/release/stable.txt)
+
+KUBECTL_AMD64="https://dl.k8s.io/release/$(KUBECTL_VERSION)/bin/linux/amd64/kubectl"
+KUBECTL_ARM="https://dl.k8s.io/release/$(KUBECTL_VERSION)/bin/linux/arm64/kubectl"
 
 OS := $(shell dpkg --print-architecture)
 
@@ -14,7 +16,7 @@ install: install_kjob
 install_kjob: install_kueuectl
 	git clone $(KUEUE_REPO) $(KUEUE_TMP_PATH)
 	make -C $(KUEUE_TMP_PATH)/cmd/experimental/kjobctl kubectl-kjob
-	mv $(KUEUE_TMP_PATH)/cmd/experimental/kjobctl/bin/kubectl-kjob /usr/local/bin/kubectl-kjob
+	mv $(KUEUE_TMP_PATH)/cmd/experimental/kjobctl/bin/kubectl-kjob ~/.local/bin/kubectl-kjob
 	rm -rf $(KUEUE_TMP_PATH)
 
 install_kubectl: check_gcloud
@@ -31,7 +33,7 @@ endif
 install_kueuectl: install_kubectl
 	git clone $(KUEUE_REPO) $(KUEUE_TMP_PATH)
 	make -C $(KUEUE_TMP_PATH) kueuectl
-	mv $(KUEUE_TMP_PATH)/bin/kubectl-kueue /usr/local/bin/kubectl-kueue
+	mv $(KUEUE_TMP_PATH)/bin/kubectl-kueue ~/.local/bin/kubectl-kueue
 	rm -rf $(KUEUE_TMP_PATH)
 
 check_gcloud: check_python

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ BIN_PATH=$(PROJECT_DIR)/bin
 
 .PHONY: install install_kjob install_kueuectl install_gcloud check_python update-path
 
-install: check-python check-gcloud install-kubectl install-kueuectl install-kjob pip-install
+install: check-python check-gcloud mkdir-bin install-kubectl install-kueuectl install-kjob pip-install
 
 pip-install:
 	pip install .
@@ -28,9 +28,10 @@ install-kjob: install-kubectl
 	mv $(KUEUE_TMP_PATH)/cmd/experimental/kjobctl/bin/kubectl-kjob $(BIN_PATH)/kubectl-kjob
 	rm -rf $(KUEUE_TMP_PATH)
 
+mkdir-bin:
+	test -d $(BIN_PATH) || mkdir $(BIN_PATH)
+
 install-kubectl:
-	echo $(PROJECT_DIR)
-	echo $(BIN_PATH)
 	curl -LO $(KUBECTL_URL)
 	chmod +x kubectl
 	mv ./kubectl $(BIN_PATH)/kubectl

--- a/Makefile
+++ b/Makefile
@@ -13,13 +13,13 @@ install_kjob: install_kueuectl
 	sudo mv $(KUEUE_TMP_PATH)/cmd/experimental/kjobctl/bin/kubectl-kjob /usr/local/bin/kubectl-kjob
 	rm -rf $(KUEUE_TMP_PATH)
 
-install_kubectl:check_gcloud
+install_kubectl: check_gcloud
 	curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
 	chmod +x kubectl
 	mkdir -p ~/.local/bin
 	mv ./kubectl ~/.local/bin/kubectl
 
-install_kueuectl:install_kubectl
+install_kueuectl: install_kubectl
 	git clone $(KUEUE_REPO) $(KUEUE_TMP_PATH)
 	make -C $(KUEUE_TMP_PATH) kueuectl
 	sudo mv $(KUEUE_TMP_PATH)/bin/kubectl-kueue /usr/local/bin/kubectl-kueue

--- a/Makefile
+++ b/Makefile
@@ -2,42 +2,45 @@ KUEUE_REPO=https://github.com/kubernetes-sigs/kueue.git
 KUEUE_TMP_PATH=/tmp/xpk_tmp/kueue
 
 KUBECTL_VERSION := $(shell curl -L -s https://dl.k8s.io/release/stable.txt)
-
-KUBECTL_AMD64="https://dl.k8s.io/release/$(KUBECTL_VERSION)/bin/linux/amd64/kubectl"
-KUBECTL_ARM="https://dl.k8s.io/release/$(KUBECTL_VERSION)/bin/linux/arm64/kubectl"
-
 OS := $(shell dpkg --print-architecture)
 
-.PHONY: install install_kjob install_kueuectl install_gcloud check_python
-
-install: install_kjob
-	pip install .
-
-install_kjob: install_kueuectl
-	git clone $(KUEUE_REPO) $(KUEUE_TMP_PATH)
-	make -C $(KUEUE_TMP_PATH)/cmd/experimental/kjobctl kubectl-kjob
-	mv $(KUEUE_TMP_PATH)/cmd/experimental/kjobctl/bin/kubectl-kjob ~/.local/bin/kubectl-kjob
-	rm -rf $(KUEUE_TMP_PATH)
-
-install_kubectl: check_gcloud
 ifeq ($(OS),amd64)
-	curl -LO $(KUBECTL_AMD64)
+	KUBECTL_URL = "https://dl.k8s.io/release/$(KUBECTL_VERSION)/bin/linux/amd64/kubectl"
 endif
 ifeq ($(OS),arm)
-	curl -LO $(KUBECTL_ARM)
+	KUBECTL_URL = "https://dl.k8s.io/release/$(KUBECTL_VERSION)/bin/linux/arm64/kubectl"
 endif	
-	chmod +x kubectl
-	mkdir -p ~/.local/bin
-	mv ./kubectl ~/.local/bin/kubectl
 
-install_kueuectl: install_kubectl
+PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
+
+BIN_PATH=$(PROJECT_DIR)/bin
+
+.PHONY: install install_kjob install_kueuectl install_gcloud check_python update-path
+
+install: check-python check-gcloud install-kubectl install-kueuectl install-kjob pip-install
+
+pip-install:
+	pip install .
+
+install-kjob: install-kubectl
 	git clone $(KUEUE_REPO) $(KUEUE_TMP_PATH)
-	make -C $(KUEUE_TMP_PATH) kueuectl
-	mv $(KUEUE_TMP_PATH)/bin/kubectl-kueue ~/.local/bin/kubectl-kueue
+	make -C $(KUEUE_TMP_PATH)/cmd/experimental/kjobctl kubectl-kjob
+	mv $(KUEUE_TMP_PATH)/cmd/experimental/kjobctl/bin/kubectl-kjob $(BIN_PATH)/kubectl-kjob
 	rm -rf $(KUEUE_TMP_PATH)
 
-check_gcloud: check_python
+install-kubectl:
+	curl -LO $(KUBECTL_URL)
+	chmod +x kubectl
+	mv ./kubectl $(BIN_PATH)/kubectl
+
+install-kueuectl: install-kubectl
+	git clone $(KUEUE_REPO) $(KUEUE_TMP_PATH)
+	make -C $(KUEUE_TMP_PATH) kueuectl
+	mv $(KUEUE_TMP_PATH)/bin/kubectl-kueue $(BIN_PATH)/kubectl-kueue
+	rm -rf $(KUEUE_TMP_PATH)
+
+check-gcloud:
 	gcloud version || (echo "gcloud not installed, use this link to install: https://cloud.google.com/sdk/docs/install" && exit 1)
 
-check_python:
+check-python:
 	python3 --version || (echo "python3 not installed. Please install python in version required by xpk" && exit 1)

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ ifeq ($(OS),arm)
 	KUBECTL_URL = "https://dl.k8s.io/release/$(KUBECTL_VERSION)/bin/linux/arm64/kubectl"
 endif	
 
-PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
+PROJECT_DIR := $(realpath $(shell dirname $(firstword $(MAKEFILE_LIST))))
 
 BIN_PATH=$(PROJECT_DIR)/bin
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ following commands to begin using XPK commands:
 git clone https://github.com/google/xpk.git
 cd xpk
 # Install required dependencies with make
-make install
+make install && export PATH=$PATH:$PWD/bin
 ```
 
 If you see an error saying: `This environment is externally managed`, please use a virtual environment.
@@ -104,7 +104,7 @@ Example:
   git clone https://github.com/google/xpk.git
   cd xpk
   # Install required dependencies with make
-  make install 
+  make install && export PATH=$PATH:$PWD/bin
 ```
 
 # XPK for Large Scale (>1k VMs)

--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ following commands to begin using XPK commands:
 ```shell
 git clone https://github.com/google/xpk.git
 cd xpk
-# Install dependencies such as cloud-accelerator-diagnostics
-pip install .
+# Install required dependencies with make
+make install
 ```
 
 If you see an error saying: `This environment is externally managed`, please use a virtual environment.
@@ -103,8 +103,8 @@ Example:
   ## Clone the repository and installing dependencies.
   git clone https://github.com/google/xpk.git
   cd xpk
-  # Install dependencies such as cloud-accelerator-diagnostics
-  pip install .
+  # Install required dependencies with make
+  make install 
 ```
 
 # XPK for Large Scale (>1k VMs)

--- a/README.md
+++ b/README.md
@@ -74,11 +74,12 @@ xpk uses many tool to provide all neccessary functionalities. User must install 
 - kjob (installation instructions [here](https://github.com/kubernetes-sigs/kueue/blob/main/cmd/experimental/kjobctl/docs/installation.md))
 
 # Installation
-To install xpk, run the following command:
+To install xpk, run the following command and install additional tools, mentioned in [prerequisites](#prerequisites). [Makefile](https://github.com/AI-Hypercomputer/xpk/blob/main/Makefile) provides a way to install all neccessary tools:
 
 ```shell
 pip install xpk
 ```
+
 
 If you are running XPK by cloning GitHub repository, first run the
 following commands to begin using XPK commands:
@@ -89,6 +90,9 @@ cd xpk
 # Install required dependencies with make
 make install && export PATH=$PATH:$PWD/bin
 ```
+
+If you want to have installed dependecies persist in your PATH please run:
+`echo $PWD/bin` and add its value to `PATH` in .bashrc  or .zshrc
 
 If you see an error saying: `This environment is externally managed`, please use a virtual environment.
 


### PR DESCRIPTION
## Fixes / Features
- Add Makefile for installing depenedencides
- Working with xpk from github will have following steps:
 1. git clone xpk
 2. make install

We are not installing python and gcloud in this makefile. Installing gcloud would require setting project etc. which is out of scope for makefile
## Testing / Documentation
Testing details.

- [ y/n ] Tests pass
- [ y/n ] Appropriate changes to documentation are included in the PR
