### PR TITLE
Add the option to use RAMDisk in workloads

### DIFF
--- a/src/xpk/core/core.py
+++ b/src/xpk/core/core.py
@@ -2090,6 +2090,12 @@ def get_volumes(args, system: SystemCharacteristics) -> str:
                   medium: Memory
                 name: dshm-2"""
 
+  if args.ramdisk_directory != '':
+    volumes += """
+              - name: cache
+                csi:
+                  driver: phase1-checkpoint.csi.storage.gke.io"""
+        
   if (
       system.accelerator_type == AcceleratorType['TPU']
       and args.deploy_stacktrace_sidecar
@@ -2112,6 +2118,11 @@ def get_volume_mounts(args, system: SystemCharacteristics) -> str:
   """
   volume_mount_yaml = """- mountPath: /dev/shm
                   name: dshm-2"""
+  
+  if args.ramdisk_directory != '':
+    volume_mount_yaml += f"""
+                - mountPath: /{args.ramdisk_directory}
+                  name: cache"""
 
   if args.use_pathways:
     volume_mount_yaml = """- mountPath: /tmp

--- a/src/xpk/core/core.py
+++ b/src/xpk/core/core.py
@@ -2095,7 +2095,7 @@ def get_volumes(args, system: SystemCharacteristics) -> str:
               - name: cache
                 csi:
                   driver: phase1-checkpoint.csi.storage.gke.io"""
-        
+
   if (
       system.accelerator_type == AcceleratorType['TPU']
       and args.deploy_stacktrace_sidecar
@@ -2118,7 +2118,7 @@ def get_volume_mounts(args, system: SystemCharacteristics) -> str:
   """
   volume_mount_yaml = """- mountPath: /dev/shm
                   name: dshm-2"""
-  
+
   if args.ramdisk_directory != '':
     volume_mount_yaml += f"""
                 - mountPath: /{args.ramdisk_directory}

--- a/src/xpk/parser/workload.py
+++ b/src/xpk/parser/workload.py
@@ -558,6 +558,15 @@ def add_shared_workload_create_optional_arguments(args_parsers):
             ' deprecated soon).'
         ),
     )
+    custom_parser.add_argument(
+        '--ramdisk-directory',
+        type=str,
+        default='',
+        help=(
+            'The directory of the locally mounted RAM disk. This is only to'
+            ' be used with the CSI driver provided by GKE.'
+        ),
+    )
 
 
 def add_shared_workload_create_env_arguments(args_parsers):


### PR DESCRIPTION
## Fixes / Features
- Add the option to use RAMDisk in workloads

## Testing / Documentation
Testing details.

- Manually verified that the pods can indeed access the specified RAMDisk directory.
