### PR TITLE
Fix duplicate definition of JOBSET_NAME

### DIFF
--- a/src/xpk/core/core.py
+++ b/src/xpk/core/core.py
@@ -209,7 +209,7 @@ def parse_env_config(args, tensorboard_config, system: SystemCharacteristics):
     tensorboard_config: configuration of Vertex Tensorboard.
     system: system characteristics.
   """
-  env = {'JOBSET_NAME': args.workload}
+  env = {}
 
   env_pat = re.compile(r'(^[a-zA-Z_][a-zA-Z0-9_]*?)(?:=(.*))?$', re.M)
   if args.env_file:


### PR DESCRIPTION
The duplicate definition causes issues with newer versions of kueue failing in something like this:

The JobSet "xyz" is invalid: spec.replicatedJobs[0].template.spec.template.spec.containers[1].env[10]: Duplicate value: map[string]interface {}{"name":"JOBSET_NAME"}

## Fixes / Features
-
-

## Testing / Documentation
Testing details.

- [ y/n ] Tests pass
- [ y/n ] Appropriate changes to documentation are included in the PR
