### PR TITLE
Set cluster to apply job command on

### DIFF
--- a/.github/workflows/build_tests.yaml
+++ b/.github/workflows/build_tests.yaml
@@ -107,11 +107,11 @@ jobs:
     - name: Run a batch job on the cluster
       run: python3 xpk.py batch --cluster $TPU_CLUSTER_NAME --zone=us-central2-b test.sh
     - name: List out the jobs on the cluster
-      run: python3 xpk.py job ls | grep 'xpk-def-app-profile-slurm-'
+      run: python3 xpk.py job ls --cluster $TPU_CLUSTER_NAME --zone=us-central2-b | grep 'xpk-def-app-profile-slurm-'
     - name: Cancel the batch job on the cluster
       run: |
-        job_name=$(python3 xpk.py job ls | grep 'xpk-def-app-profile-slurm-' | head -1 | awk '{print $1}')
-        python3 xpk.py job cancel ${job_name} | grep "job.batch/${job_name} deleted"
+        job_name=$(python3 xpk.py job ls --cluster $TPU_CLUSTER_NAME --zone=us-central2-b | grep 'xpk-def-app-profile-slurm-' | head -1 | awk '{print $1}')
+        python3 xpk.py job cancel ${job_name} --cluster $TPU_CLUSTER_NAME --zone=us-central2-b | grep "job.batch/${job_name} deleted"
     - name: Delete the cluster created
       if: always()
       run: python xpk.py cluster delete --cluster $TPU_CLUSTER_NAME --zone=us-central2-b

--- a/README.md
+++ b/README.md
@@ -609,7 +609,7 @@ when creating the workload otherwise the workload will always finish with `Compl
 *   Job List (see jobs submitted via batch command):
 
     ```shell
-    python3 xpk.py job ls 
+    python3 xpk.py job ls --cluster xpk-test
     ```
 
 * Example Job List Output:
@@ -627,7 +627,7 @@ when creating the workload otherwise the workload will always finish with `Compl
 *   Job Cancel (delete job submitted via batch command):
 
     ```shell
-    python3 xpk.py job cancel xpk-def-app-profile-slurm-74kbv
+    python3 xpk.py job cancel xpk-def-app-profile-slurm-74kbv --cluster xpk-test
     ```
 
 ## Inspector

--- a/src/xpk/commands/job.py
+++ b/src/xpk/commands/job.py
@@ -20,6 +20,7 @@ from ..core.app_profile import APP_PROFILE_TEMPLATE_DEFAULT_NAME
 from ..core.commands import (
     run_command_with_updates,
 )
+from .cluster import set_cluster_command
 
 
 def job_list(args) -> None:
@@ -32,6 +33,10 @@ def job_list(args) -> None:
     None
   """
   add_zone_and_project(args)
+  set_cluster_command_code = set_cluster_command(args)
+  if set_cluster_command_code != 0:
+    xpk_exit(set_cluster_command_code)
+
   xpk_print(
       f'Listing jobs for project {args.project} and zone {args.zone}:',
       flush=True,
@@ -63,6 +68,9 @@ def job_cancel(args) -> None:
   """
   xpk_print(f'Starting job cancel for job: {args.name}', flush=True)
   add_zone_and_project(args)
+  set_cluster_command_code = set_cluster_command(args)
+  if set_cluster_command_code != 0:
+    xpk_exit(set_cluster_command_code)
 
   return_code = run_slurm_job_delete_command(args)
   xpk_exit(return_code)

--- a/src/xpk/parser/job.py
+++ b/src/xpk/parser/job.py
@@ -31,7 +31,24 @@ def set_job_parser(job_parser):
   ### "job ls" command parser ###
   job_list_parser = job_subcommands.add_parser('ls', help='List jobs.')
 
-  add_shared_arguments(job_list_parser)
+  job_list_required_arguments = job_list_parser.add_argument_group(
+      'Required Arguments',
+      'Arguments required for job list.',
+  )
+  job_list_optional_arguments = job_list_parser.add_argument_group(
+      'Optional Arguments', 'Arguments optional for job list.'
+  )
+
+  ### Required arguments
+  job_list_required_arguments.add_argument(
+      '--cluster',
+      type=str,
+      default=None,
+      help='The name of the cluster to list jobs on.',
+      required=True,
+  )
+
+  add_shared_arguments(job_list_optional_arguments)
   job_list_parser.set_defaults(func=job_list)
 
   ### "job cancel" command parser ###
@@ -54,6 +71,14 @@ def set_job_parser(job_parser):
       default=None,
       help='The name of the job to be cancelled.',
       nargs='+',
+  )
+
+  job_cancel_required_arguments.add_argument(
+      '--cluster',
+      type=str,
+      default=None,
+      help='The name of the cluster to delete the job on.',
+      required=True,
   )
 
   add_shared_arguments(job_cancel_optional_arguments)


### PR DESCRIPTION
## Fixes / Features
- Allow to set a cluster to run `job` commands.
-

## Testing / Documentation
Testing details.

- [ y/n ] Tests pass
- [ y/n ] Appropriate changes to documentation are included in the PR
