### PR TITLE
Support --time flag on batch command.

### DIFF
--- a/.github/workflows/build_tests.yaml
+++ b/.github/workflows/build_tests.yaml
@@ -109,15 +109,16 @@ jobs:
     - name: Create test script to execute in batch
       run: echo -e '#!/bin/bash \n#SBATCH --unknown-flag=value\n echo "Hello world from a test script!"' > batch.sh
     - name: Run a batch job on the cluster
-      run: python3 xpk.py batch --cluster $TPU_CLUSTER_NAME --zone=us-central2-b batch.sh --ignore-unknown-flags --array 1-5 --nodes 2 --ntasks 3
+      run: python3 xpk.py batch --cluster $TPU_CLUSTER_NAME --zone=us-central2-b batch.sh --ignore-unknown-flags --array 1-5 --nodes 2 --ntasks 3 --time 60
     - name: List out the jobs on the cluster
       run: python3 xpk.py job ls --cluster $TPU_CLUSTER_NAME --zone=us-central2-b | grep 'xpk-def-app-profile-slurm-'
     - name: Get created job name
       run: |
         JOB_NAME=$(python3 xpk.py job ls --cluster $TPU_CLUSTER_NAME --zone=us-central2-b | grep 'xpk-def-app-profile-slurm-' | head -1 | awk '{print $1}')
         echo "JOB_NAME=${JOB_NAME}" >> $GITHUB_ENV
-    - name: Check job spec
+    - name: Check created job
       run: |
+        kubectl get job ${JOB_NAME} -o jsonpath='{.metadata.labels}' | grep '"kueue.x-k8s.io/max-exec-time-seconds":"3600"'
         job_spec=$(kubectl get job ${JOB_NAME} -o jsonpath='{.spec}')
         echo "$job_spec" | grep '"completions":2'
         echo "$job_spec" | grep '"parallelism":2'

--- a/src/xpk/commands/batch.py
+++ b/src/xpk/commands/batch.py
@@ -99,10 +99,8 @@ def submit_job(args: Namespace) -> None:
   if args.chdir is not None:
     cmd += f' --chdir {args.chdir}'
 
-  # --time supported on Kueue >=0.9.x.
-  # TODO: Uncomment it after upgrade Kueue to 0.9.x or newer.
-  # if args.time is not None:
-  #   cmd += f' --time {args.time}'
+  if args.time is not None:
+    cmd += f' --time {args.time}'
 
   return_code, _ = run_command_for_value(cmd, 'submit job', args)
 

--- a/src/xpk/parser/batch.py
+++ b/src/xpk/parser/batch.py
@@ -169,18 +169,16 @@ def set_batch_parser(batch_parser):
       default=None,
       help='Change directory before executing the script.',
   )
-  # --time supported on Kueue >=0.9.x.
-  # TODO: Uncomment it after upgrade Kueue to 0.9.x or newer.
-  # batch_optional_arguments.add_argument(
-  #     '-t',
-  #     '--time',
-  #     type=str,
-  #     default=None,
-  #     help=(
-  #         'Set a limit on the total run time of the job. '
-  #         'A time limit of zero requests that no time limit be imposed. '
-  #         'Acceptable time formats include "minutes", "minutes:seconds", '
-  #         '"hours:minutes:seconds", "days-hours", "days-hours:minutes" '
-  #         'and "days-hours:minutes:seconds".'
-  #     ),
-  # )
+  batch_optional_arguments.add_argument(
+      '-t',
+      '--time',
+      type=str,
+      default=None,
+      help=(
+          'Set a limit on the total run time of the job. '
+          'A time limit of zero requests that no time limit be imposed. '
+          'Acceptable time formats include "minutes", "minutes:seconds", '
+          '"hours:minutes:seconds", "days-hours", "days-hours:minutes" '
+          'and "days-hours:minutes:seconds".'
+      ),
+  )


### PR DESCRIPTION
## Fixes / Features
- Support --time flag on batch command.

| Option              | Description |
|---------------------|-------------|
| -t, --time          | Set a limit on the total run time of the job. A time limit of zero requests that no time limit be imposed. Acceptable time formats include "minutes", "minutes:seconds", "hours:minutes:seconds", "days-hours", "days-hours:minutes" and "days-hours:minutes:seconds". |

## Testing / Documentation
Testing details.

- [ y/n ] Tests pass
- [ y/n ] Appropriate changes to documentation are included in the PR
