### PR TITLE
Storage delete fs pv pvc

### DIFF
--- a/examples/storage/gcsfuse-manifest.yaml
+++ b/examples/storage/gcsfuse-manifest.yaml
@@ -15,9 +15,6 @@ spec:
     volumeHandle: BUCKET_NAME
     volumeAttributes:
       gcsfuseLoggingSeverity: warning
-  claimRef:
-    name: gcs-fuse-csi-static-pvc
-    namespace: default
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -31,3 +28,4 @@ spec:
     requests:
       storage: 5Gi
   storageClassName: xpk-gcsfuse-storage
+  volumeName: xpk-gcs-fuse-csi-pv

--- a/src/xpk/commands/storage.py
+++ b/src/xpk/commands/storage.py
@@ -97,7 +97,7 @@ def storage_delete(args: Namespace) -> None:
   api_instance = k8s_client.CustomObjectsApi(k8s_api_client)
   core_api = k8s_client.CoreV1Api()
   storage = get_storage(k8s_api_client, args.name)
-  if storage.type == GCS_FUSE_TYPE:
+  if storage.type == GCS_FUSE_TYPE or storage.type == GCP_FILESTORE_TYPE:
     delete_resource(
         lambda name: core_api.delete_namespaced_persistent_volume_claim(
             name, "default"


### PR DESCRIPTION
## Fixes / Features
- Delete pv and pvc when invoking `storage delete` for fs storage
- Fix gcs fuse example manifest

## Testing / Documentation
Testing details.

- [ y/n ] Tests pass
- [ y/n ] Appropriate changes to documentation are included in the PR
