### PR TITLE
Update kjob installation guide link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ xpk uses many tool to provide all neccessary functionalities. User must install 
 - gcloud (install from [here](https://cloud.google.com/sdk/gcloud#download_and_install_the))
 - kubectl (install from [here](https://kubernetes.io/docs/tasks/tools/))
 - kueuectl (install from [here](https://kueue.sigs.k8s.io/docs/reference/kubectl-kueue/installation/))
-- kjob (installation instructions [here](https://github.com/kubernetes-sigs/kueue/blob/main/cmd/experimental/kjobctl/docs/installation.md))
+- kjob (installation instructions [here](https://github.com/kubernetes-sigs/kjob/blob/main/docs/installation.md))
 
 # Installation
 To install xpk, run the following command and install additional tools, mentioned in [prerequisites](#prerequisites). [Makefile](https://github.com/AI-Hypercomputer/xpk/blob/main/Makefile) provides a way to install all neccessary tools:

--- a/src/xpk/core/kjob.py
+++ b/src/xpk/core/kjob.py
@@ -105,7 +105,7 @@ def verify_kjob_installed(args: Namespace) -> int:
   if verify_kjob_installed_code != 0:
     xpk_print(
         " kjob not found. Please follow"
-        " https://github.com/kubernetes-sigs/kueue/blob/main/cmd/experimental/kjobctl/docs/installation.md"
+        " https://github.com/kubernetes-sigs/kjob/blob/main/docs/installation.md"
         " to install kjob."
     )
     return verify_kjob_installed_code


### PR DESCRIPTION
## Fixes / Features
- Update kjob installation guide link.

Kjobctl moved to https://github.com/kubernetes-sigs/kjob.

## Testing / Documentation
Testing details.

- [ y/n ] Tests pass
- [ y/n ] Appropriate changes to documentation are included in the PR
