### PR TITLE
Add required flag --ray-version to README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ all zones.
     ```shell
     python3 xpk.py cluster create-ray \
     --cluster xpk-rc-test \
+    --ray-version=2.39.0 \
     --num-slices=4 --on-demand \
     --tpu-type=v5litepod-8
     ```


### PR DESCRIPTION
## Fixes / Features
- Adding required --ray-version flag to example cluster create-ray usage in README

## Testing / Documentation
N/A

- [ y ] Tests pass
- [ y ] Appropriate changes to documentation are included in the PR
