### PR TITLE
Add url to the workload logs link directly

### DIFF
--- a/src/xpk/commands/workload.py
+++ b/src/xpk/commands/workload.py
@@ -576,6 +576,14 @@ def workload_create(args) -> None:
         # pylint: disable=line-too-long
         f' https://console.cloud.google.com/kubernetes/service/{zone_to_region(args.zone)}/{args.cluster}/default/{args.workload}/details?project={args.project}'
     )
+    duration_of_logs='P1D'  # Past 1 Day
+    xpk_print(
+        'Follow your worker 0, slice 0 logs here:'
+        ' Adjust the pod name ([prefix]-slice-job-[slice_number]-[worker_number])'
+        ' after clicking the url if you want other worker logs.'
+        # pylint: disable=line-too-long
+        f' https://console.cloud.google.com/logs/query;query=resource.type%3D%22k8s_container%22%0Aresource.labels.project_id%3D%22{args.project}%22%0Aresource.labels.location%3D%22{zone_to_region(args.zone)}%22%0Aresource.labels.cluster_name%3D%22{args.cluster}%22%0Aresource.labels.namespace_name%3D%22default%22%0Aresource.labels.pod_name:%22{args.workload}-slice-job-0-0-%22%20severity%3E%3DDEFAULT;storageScope=project;duration={duration_of_logs}?e=13802955&mods=allow_workbench_image_override&project={args.project}'
+    )
 
   xpk_exit(0)
 


### PR DESCRIPTION
## Fixes / Features
- Adds a new url that returns the url link to the workload logs directly for the first worker of the first slice
- This allows users to easily click for the logs and especially useful since this link will work after the workload is deleted. So if a user has access to xpk logs after deleting the workload, they can still follow this link.

## Testing / Documentation
Created an xpk workload on trillium and clicked the url generated to get to the workload link. This should work on TPUs and GPUs.

- [ y ] Tests pass
- [ y ] Appropriate changes to documentation are included in the PR
