### PR TITLE
Add support for automatic cleanup of jobsets

### DIFF
--- a/src/xpk/commands/workload.py
+++ b/src/xpk/commands/workload.py
@@ -77,6 +77,7 @@ metadata:
   annotations:
     alpha.jobset.sigs.k8s.io/exclusive-topology: cloud.google.com/gke-nodepool # 1:1 job replica to node pool assignment
 spec:
+  ttlSecondsAfterFinished: {args.ttl_seconds_after_finished}
   failurePolicy:
     maxRestarts: {args.max_restarts}
   replicatedJobs:
@@ -118,6 +119,7 @@ metadata:
     kueue.x-k8s.io/queue-name: multislice-queue  # Name of the LocalQueue
     xpk.google.com/workload: {args.workload}
 spec:
+  ttlSecondsAfterFinished: {args.ttl_seconds_after_finished}
   failurePolicy:
     maxRestarts: {args.max_restarts}
   replicatedJobs:
@@ -175,6 +177,7 @@ metadata:
     kueue.x-k8s.io/queue-name: multislice-queue  # Name of the LocalQueue
     xpk.google.com/workload: {args.workload}
 spec:
+  ttlSecondsAfterFinished: {args.ttl_seconds_after_finished}
   failurePolicy:
     maxRestarts: {args.max_restarts}
   replicatedJobs:

--- a/src/xpk/parser/workload.py
+++ b/src/xpk/parser/workload.py
@@ -115,6 +115,15 @@ def set_workload_parsers(workload_parser):
   )
 
   workload_create_parser_optional_arguments.add_argument(
+      '--ttl-seconds-after-finished',
+      type=int,
+      default=12 * 60 * 60,
+      help=(
+          'Set the number of seconds to clean up finished Jobsets (either'
+          ' Complete or Failed). This is by default set to 12 hours.'
+      ),
+  )
+  workload_create_parser_optional_arguments.add_argument(
       '--num-nodes',
       type=int,
       default=1,


### PR DESCRIPTION
## Fixes / Features
- This will by default, delete completed (failed / successful) jobsets after 12 hours.
- You can also set the flag --ttl-seconds-after-finished=SECONDS to adjust this for example to 0 which would immediately delete the jobset after completion.

## Testing / Documentation
I ran two workloads on TPUs one with --ttl-seconds-after-finished=0 and the other without the flag, I see the jobset yaml having the new flag in it and i see in the --ttl-seconds-after-finished=0 case that the workload immediately is removed after completion.

This is important for avoiding overloading the api server (jobset manager) with old jobsets that are no longer needed. 

- [ y ] Tests pass
- [ y ] Appropriate changes to documentation are included in the PR
