### PR TITLE
Set min-master-version for A3-Ultra clusters

### DIFF
--- a/src/xpk/core/blueprint/blueprint_generator.py
+++ b/src/xpk/core/blueprint/blueprint_generator.py
@@ -482,6 +482,7 @@ class BlueprintGenerator:
         use=[net_0_id],
         settings={
             "release_channel": "RAPID",
+            "min_master_version": "1.31.4-gke.1072000",
             "prefix_with_deployment_name": False,
             "name_suffix": cluster_name,
             "system_node_pool_machine_type": system_node_pool_machine_type,

--- a/src/xpk/core/tests/data/a3_ultra.yaml
+++ b/src/xpk/core/tests/data/a3_ultra.yaml
@@ -86,6 +86,7 @@ deployment_groups:
     use: [gke-a3-ultra-net-0]
     settings:
       release_channel: "RAPID"
+      min_master_version: "1.31.4-gke.1072000"
       prefix_with_deployment_name: false
       name_suffix: gke-a3-ultra
       system_node_pool_machine_type: "e2-standard-16"


### PR DESCRIPTION
## Fixes / Features
From GKE 1.31.4-gke.1072000, the DEFAULT version points to 550 (min required gpu driver version) for H200 GPU. In the lower versions the gpu driver will have an error and workloads cannot be scheduled.

## Testing / Documentation
Testing details.

- [ y/n ] Tests pass
- [ y/n ] Appropriate changes to documentation are included in the PR
