### PR TITLE
Remove manual private network configuration from large scale instructions

### DIFF
--- a/xpk-large-scale-guide.sh
+++ b/xpk-large-scale-guide.sh
@@ -121,10 +121,8 @@ export CLUSTER_ARGUMENTS=" \
  --subnetwork=${SUBNET_NAME} \
  --scopes=storage-full,gke-default \
  --enable-ip-alias \
- --enable-private-nodes \
  --master-ipv4-cidr 172.16.0.32/28 \
  --cluster-ipv4-cidr=10.224.0.0/12 \
- --no-enable-master-authorized-networks \
 "
 
 export TPU_NODEPOOL_ARGUMENTS=" \
@@ -154,7 +152,7 @@ echo python3 xpk.py cluster create \
 # python3 xpk.py cluster create --cluster NAME \
 #  --tpu-type=v5litepod-256 --num-slices=4 \
 #  --host-maintenance-interval=PERIODIC \
-# --custom-cluster-arguments=" --network=NETWORK  --subnetwork=SUBNET  --scopes=storage-full,gke-default  --enable-ip-alias  --enable-private-nodes  --master-ipv4-cidr 172.16.0.32/28  --cluster-ipv4-cidr=10.224.0.0/12  --no-enable-master-authorized-networks"
+# --custom-cluster-arguments=" --network=NETWORK  --subnetwork=SUBNET  --scopes=storage-full,gke-default  --enable-ip-alias  --master-ipv4-cidr 172.16.0.32/28  --cluster-ipv4-cidr=10.224.0.0/12"
 # --custom-tpu-nodepool-arguments=" --scopes=storage-full,gke-default  --enable-gvnic  --max-pods-per-node 15  --disk-size=50"
 
 


### PR DESCRIPTION
Remove private network configurations to large scale instructions since it is not needed. If we want to later do this correctly we should use xpk cluster create --private --authorized-networks $KNOWN_IP_RANGE or KNOWN_IP_RANGE=0.0.0.0/0 as a hack

## Testing / Documentation
Testing details.

- [ y ] Tests pass
- [ y ] Appropriate changes to documentation are included in the PR
