### PR TITLE
Cluster Toolkit updated to v1.45.0

### DIFF
--- a/src/xpk/blueprints/a3ultra/mlgru-disable.yaml
+++ b/src/xpk/blueprints/a3ultra/mlgru-disable.yaml
@@ -40,14 +40,14 @@ spec:
         - -c
         - |
           echo n | tee /sys/kernel/mm/lru_gen/enabled
-          sysctl -w net.ipv4.conf.eth2.log_martians=0
-          sysctl -w net.ipv4.conf.eth3.log_martians=0
-          sysctl -w net.ipv4.conf.eth4.log_martians=0
-          sysctl -w net.ipv4.conf.eth5.log_martians=0
-          sysctl -w net.ipv4.conf.eth6.log_martians=0
-          sysctl -w net.ipv4.conf.eth7.log_martians=0
-          sysctl -w net.ipv4.conf.eth8.log_martians=0
-          sysctl -w net.ipv4.conf.eth9.log_martians=0
+          sysctl -w net.ipv4.conf.gpu0rdma0.log_martians=0
+          sysctl -w net.ipv4.conf.gpu1rdma0.log_martians=0
+          sysctl -w net.ipv4.conf.gpu2rdma0.log_martians=0
+          sysctl -w net.ipv4.conf.gpu3rdma0.log_martians=0
+          sysctl -w net.ipv4.conf.gpu4rdma0.log_martians=0
+          sysctl -w net.ipv4.conf.gpu5rdma0.log_martians=0
+          sysctl -w net.ipv4.conf.gpu6rdma0.log_martians=0
+          sysctl -w net.ipv4.conf.gpu7rdma0.log_martians=0
           sleep infinity
         volumeMounts:
         - name: sys-kernel-mm-lru-gen

--- a/src/xpk/blueprints/a3ultra/nccl-installer.yaml
+++ b/src/xpk/blueprints/a3ultra/nccl-installer.yaml
@@ -36,45 +36,60 @@ spec:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
-              - matchExpressions:
-                  - key: cloud.google.com/gke-accelerator
-                    operator: In
-                    values:
-                      - nvidia-h200-141gb
+            - matchExpressions:
+              - key: cloud.google.com/gke-accelerator
+                operator: In
+                values:
+                - nvidia-h200-141gb
       tolerations:
-        - operator: "Exists"
+      - operator: "Exists"
       hostNetwork: true
       hostPID: true
       volumes:
-        - name: library-dir-host
-          hostPath:
-            path: /home/kubernetes/bin/nvidia/lib64
-            type: DirectoryOrCreate
-        - name: gib
-          hostPath:
-            path: /home/kubernetes/bin/gib
+      - name: library-dir-host
+        hostPath:
+          path: /home/kubernetes/bin/nvidia/lib64
+          type: DirectoryOrCreate
+      - name: gib
+        hostPath:
+          path: /home/kubernetes/bin/gib
       initContainers:
-        - image: us-docker.pkg.dev/gce-ai-infra/gpudirect-gib/nccl-plugin-gib:v1.0.2
-          name: nccl-rdma-installer
-          resources:
-            requests:
-              cpu: 150m
-          securityContext:
-            privileged: true
-          volumeMounts:
-            - name: library-dir-host
-              mountPath: /usr/local/home/kubernetes/bin/nvidia/lib64
-            - name: gib
-              mountPath: /usr/local/home/kubernetes/bin/gib
-          command: ["/bin/sh", "-c"]
-          args:
-            - |
-              set -ex
-              /scripts/container_entry.sh install --install-nccl
-              cp -r /var/lib/gib/lib64/. /usr/local/home/kubernetes/bin/nvidia/lib64
-              cp -r /var/lib/gib/. /usr/local/home/kubernetes/bin/gib
-              ibv_devinfo || exit 1
-              echo "installation finishes"
+      - name: disable-log-martian
+        image: alpine:latest
+        command: ["/bin/sh"]
+        securityContext:
+          privileged: true
+        args:
+        - -c
+        - |
+          sysctl -w net.ipv4.conf.gpu0rdma0.log_martians=0
+          sysctl -w net.ipv4.conf.gpu1rdma0.log_martians=0
+          sysctl -w net.ipv4.conf.gpu2rdma0.log_martians=0
+          sysctl -w net.ipv4.conf.gpu3rdma0.log_martians=0
+          sysctl -w net.ipv4.conf.gpu4rdma0.log_martians=0
+          sysctl -w net.ipv4.conf.gpu5rdma0.log_martians=0
+          sysctl -w net.ipv4.conf.gpu6rdma0.log_martians=0
+          sysctl -w net.ipv4.conf.gpu7rdma0.log_martians=0
+      - image: us-docker.pkg.dev/gce-ai-infra/gpudirect-gib/nccl-plugin-gib:v1.0.3
+        name: nccl-rdma-installer
+        resources:
+          requests:
+            cpu: 150m
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: library-dir-host
+          mountPath: /usr/local/home/kubernetes/bin/nvidia/lib64
+        - name: gib
+          mountPath: /usr/local/home/kubernetes/bin/gib
+        command: ["/bin/sh", "-c"]
+        args:
+        - |
+          set -ex
+          /scripts/container_entry.sh install --install-nccl
+          cp -r /var/lib/gib/lib64/. /usr/local/home/kubernetes/bin/nvidia/lib64
+          cp -r /var/lib/gib/. /usr/local/home/kubernetes/bin/gib
+          echo "installation finishes"
       containers:
-        - image: "gke.gcr.io/pause:3.8@sha256:880e63f94b145e46f1b1082bb71b85e21f16b99b180b9996407d61240ceb9830"
-          name: pause
+      - image: "gke.gcr.io/pause:3.8@sha256:880e63f94b145e46f1b1082bb71b85e21f16b99b180b9996407d61240ceb9830"
+        name: pause

--- a/src/xpk/core/docker_manager.py
+++ b/src/xpk/core/docker_manager.py
@@ -30,7 +30,7 @@ import time
 DockerRunCommandExitCode = 135
 dockerBuildErrorCode = 134
 ctk_dockerfile_path = "Dockerfile"
-ctk_build_ref = "develop"
+ctk_build_ref = "v1.45.0"
 ctk_docker_image = "xpk-ctk"
 ctk_container_name = "xpk-ctk-container"
 gcloud_cfg_mount_path = "/root/.config/gcloud"

--- a/src/xpk/core/docker_manager.py
+++ b/src/xpk/core/docker_manager.py
@@ -35,7 +35,7 @@ ctk_docker_image = "xpk-ctk"
 ctk_container_name = "xpk-ctk-container"
 gcloud_cfg_mount_path = "/root/.config/gcloud"
 working_dir_mount_path = "/out"
-dockerfile_gh_path = "https://raw.githubusercontent.com/GoogleCloudPlatform/cluster-toolkit/refs/tags/v1.45.0/tools/cloud-build/images/cluster-toolkit-dockerfile/Dockerfile"
+dockerfile_gh_path = f"https://raw.githubusercontent.com/GoogleCloudPlatform/cluster-toolkit/refs/tags/{ctk_build_ref}/tools/cloud-build/images/cluster-toolkit-dockerfile/Dockerfile"
 upload_dir_name = "uploads"
 
 


### PR DESCRIPTION
## Fixes / Features
- Cluster Toolkit updated to v1.45.0
- mlgru-disable.yaml and nccl-installer.yaml files in a3ultra dependencies updated with [the latest changes](https://github.com/GoogleCloudPlatform/cluster-toolkit/tree/v1.45.0/examples/gke-a3-ultragpu).

## Testing / Documentation
Testing details.

- [ y/n ] Tests pass
- [ y/n ] Appropriate changes to documentation are included in the PR
