### PR TITLE
gcluster version error fixed in tests

### DIFF
--- a/src/xpk/core/tests/integration/test_docker_manager.py
+++ b/src/xpk/core/tests/integration/test_docker_manager.py
@@ -26,7 +26,7 @@ test_deployment_dir = '/tmp/xpk_deployment'
 test_gcluster_cmd = 'gcluster --version'
 test_ctk_xpk_img = 'gcluster-xpk'
 test_ctk_xpk_container = 'xpk-test-container'
-gcluster_version = 'develop'
+gcluster_version = 'v1.45.0'
 
 
 def remove_img():


### PR DESCRIPTION
## Fixes / Features
- gcluster version updated to v1.45.0 in tests 

## Testing / Documentation
Testing details.

- [ y/n ] Tests pass
- [ y/n ] Appropriate changes to documentation are included in the PR
