### PR TITLE
Implement version command

### DIFF
--- a/src/xpk/commands/version.py
+++ b/src/xpk/commands/version.py
@@ -23,11 +23,6 @@ from ..utils.console import xpk_print
 
 
 def version(_: Namespace) -> None:
-  """Run batch task.
-     This function runs passed script in non-blocking manner.
-  Args:
-    args: user provided arguments for running the command.
-  Returns:
-    None
+  """Get version of xpk.
   """
   xpk_print("xpk version:", XPK_VERSION)

--- a/src/xpk/commands/version.py
+++ b/src/xpk/commands/version.py
@@ -23,6 +23,5 @@ from ..utils.console import xpk_print
 
 
 def version(_: Namespace) -> None:
-  """Get version of xpk.
-  """
+  """Get version of xpk."""
   xpk_print("xpk version:", XPK_VERSION)

--- a/src/xpk/commands/version.py
+++ b/src/xpk/commands/version.py
@@ -17,7 +17,7 @@ limitations under the License.
 from argparse import Namespace
 
 
-XPK_VERSION = "0.6.0"
+XPK_VERSION = "0.4.1"
 
 from ..utils.console import xpk_print
 

--- a/src/xpk/commands/version.py
+++ b/src/xpk/commands/version.py
@@ -17,12 +17,12 @@ limitations under the License.
 from argparse import Namespace
 
 
-XPK_VERSION="0.6.0"
+XPK_VERSION = "0.6.0"
 
 from ..utils.console import xpk_print
 
 
-def version(args: Namespace) -> None:
+def version(_: Namespace) -> None:
   """Run batch task.
      This function runs passed script in non-blocking manner.
   Args:
@@ -30,4 +30,4 @@ def version(args: Namespace) -> None:
   Returns:
     None
   """
-  xpk_print("xpk version:",XPK_VERSION)
+  xpk_print("xpk version:", XPK_VERSION)

--- a/src/xpk/commands/version.py
+++ b/src/xpk/commands/version.py
@@ -15,13 +15,23 @@ limitations under the License.
 """
 
 from argparse import Namespace
+import os
+
+from ..core.commands import run_command_for_value
+
+XPK_VERSION = '0.4.1'
+
+from ..utils.console import xpk_exit, xpk_print
 
 
-XPK_VERSION = "0.4.1"
-
-from ..utils.console import xpk_print
-
-
-def version(_: Namespace) -> None:
+def version(args: Namespace) -> None:
   """Get version of xpk."""
-  xpk_print("xpk version:", XPK_VERSION)
+  xpk_version = XPK_VERSION
+  if os.path.exists(os.path.join(os.getcwd(),'.git')):
+    code, xpk_version = run_command_for_value(
+        'git rev-parse HEAD', task='Get latest hash', global_args=args
+    )
+    if code != 0:
+      xpk_exit(code)
+    xpk_print('xpk build from sources.')
+  xpk_print('xpk version: ', xpk_version.strip('\n'))

--- a/src/xpk/commands/version.py
+++ b/src/xpk/commands/version.py
@@ -1,0 +1,33 @@
+"""
+Copyright 2025 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from argparse import Namespace
+
+
+XPK_VERSION="0.6.0"
+
+from ..utils.console import xpk_print
+
+
+def version(args: Namespace) -> None:
+  """Run batch task.
+     This function runs passed script in non-blocking manner.
+  Args:
+    args: user provided arguments for running the command.
+  Returns:
+    None
+  """
+  xpk_print("xpk version:",XPK_VERSION)

--- a/src/xpk/commands/version.py
+++ b/src/xpk/commands/version.py
@@ -34,4 +34,4 @@ def version(args: Namespace) -> None:
     if code != 0:
       xpk_exit(code)
     xpk_print('xpk build from sources.')
-  xpk_print('xpk version: ', xpk_version.strip('\n'))
+  xpk_print('xpk version:', xpk_version.strip('\n'))

--- a/src/xpk/commands/version.py
+++ b/src/xpk/commands/version.py
@@ -27,7 +27,7 @@ from ..utils.console import xpk_exit, xpk_print
 def version(args: Namespace) -> None:
   """Get version of xpk."""
   xpk_version = XPK_VERSION
-  if os.path.exists(os.path.join(os.getcwd(),'.git')):
+  if os.path.exists(os.path.join(os.getcwd(), '.git')):
     code, xpk_version = run_command_for_value(
         'git rev-parse HEAD', task='Get latest hash', global_args=args
     )

--- a/src/xpk/parser/core.py
+++ b/src/xpk/parser/core.py
@@ -15,7 +15,6 @@ limitations under the License.
 """
 
 import argparse
-from sys import version
 
 from ..utils.console import xpk_print
 from .cluster import set_cluster_parser

--- a/src/xpk/parser/core.py
+++ b/src/xpk/parser/core.py
@@ -15,6 +15,7 @@ limitations under the License.
 """
 
 import argparse
+from sys import version
 
 from ..utils.console import xpk_print
 from .cluster import set_cluster_parser
@@ -25,6 +26,7 @@ from .job import set_job_parser
 from .info import set_info_parser
 from .kind import set_kind_parser
 from .shell import set_shell_parser
+from .version import set_version_parser
 
 
 def set_parser(parser: argparse.ArgumentParser):
@@ -60,6 +62,9 @@ def set_parser(parser: argparse.ArgumentParser):
   shell_parser = xpk_subcommands.add_parser(
       "shell", help="Commands around configuring and using interactive shell."
   )
+  version_parser = xpk_subcommands.add_parser(
+      "version", help="Command to get xpk version"
+  )
 
   def default_subcommand_function(
       _args,
@@ -80,7 +85,7 @@ def set_parser(parser: argparse.ArgumentParser):
     info_parser.print_help()
     job_parser.print_help()
     shell_parser.print_help()
-
+    version_parser.print_help()
     kind_parser.print_help()
 
     return 0
@@ -93,7 +98,7 @@ def set_parser(parser: argparse.ArgumentParser):
   job_parser.set_defaults(func=default_subcommand_function)
   kind_parser.set_defaults(func=default_subcommand_function)
   shell_parser.set_defaults(func=default_subcommand_function)
-
+  version_parser.set_defaults(func=default_subcommand_function)
   set_workload_parsers(workload_parser=workload_parser)
   set_cluster_parser(cluster_parser=cluster_parser)
   set_inspector_parser(inspector_parser=inspector_parser)
@@ -102,3 +107,4 @@ def set_parser(parser: argparse.ArgumentParser):
   set_job_parser(job_parser=job_parser)
   set_kind_parser(kind_parser=kind_parser)
   set_shell_parser(shell_parser=shell_parser)
+  set_version_parser(version_parser=version_parser)

--- a/src/xpk/parser/version.py
+++ b/src/xpk/parser/version.py
@@ -15,7 +15,9 @@ limitations under the License.
 """
 
 from ..commands.version import (version)
+from .common import add_shared_arguments
 
 
 def set_version_parser(version_parser):
+  add_shared_arguments(version_parser)
   version_parser.set_defaults(func=version)

--- a/src/xpk/parser/version.py
+++ b/src/xpk/parser/version.py
@@ -1,0 +1,21 @@
+"""
+Copyright 2025 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from ..commands.version import (version)
+
+
+def set_version_parser(version_parser):
+  version_parser.set_defaults(func=version)


### PR DESCRIPTION
## Fixes / Features
- Implement xpk version command to get current version of xpk installed
```
(venvp3) ppawl@ppawldev:~/dev/xpk$ python3 xpk.py version --zone=us-east5
[XPK] Starting xpk
[XPK] Task: `Get latest hash` is implemented by `git rev-parse HEAD`, hiding output unless there is an error.
[XPK] xpk build from sources.
[XPK] xpk version:  794438c54d542b51ccfccd053f1a55530f3eb51c
[XPK] XPK Done.
```

## Testing / Documentation
Testing details.

- [ y/n ] Tests pass
- [ y/n ] Appropriate changes to documentation are included in the PR
