### PR TITLE
Add v to version displayed

### DIFF
--- a/src/xpk/commands/version.py
+++ b/src/xpk/commands/version.py
@@ -19,7 +19,7 @@ import os
 
 from ..core.commands import run_command_for_value
 
-XPK_VERSION = '0.4.1'
+XPK_VERSION = 'v0.4.1'
 
 from ..utils.console import xpk_exit, xpk_print
 

--- a/src/xpk/commands/version.py
+++ b/src/xpk/commands/version.py
@@ -29,7 +29,10 @@ def version(args: Namespace) -> None:
   xpk_print('xpk_version:', XPK_VERSION)
   if os.path.exists(os.path.join(os.getcwd(), '.git')):
     code, xpk_version = run_command_for_value(
-        'git rev-parse HEAD', task='Get latest hash', global_args=args, quiet= True
+        'git rev-parse HEAD',
+        task='Get latest hash',
+        global_args=args,
+        quiet=True,
     )
     if code != 0:
       xpk_exit(code)

--- a/src/xpk/commands/version.py
+++ b/src/xpk/commands/version.py
@@ -26,12 +26,11 @@ from ..utils.console import xpk_exit, xpk_print
 
 def version(args: Namespace) -> None:
   """Get version of xpk."""
-  xpk_version = XPK_VERSION
+  xpk_print('xpk_version:', XPK_VERSION)
   if os.path.exists(os.path.join(os.getcwd(), '.git')):
     code, xpk_version = run_command_for_value(
-        'git rev-parse HEAD', task='Get latest hash', global_args=args
+        'git rev-parse HEAD', task='Get latest hash', global_args=args, quiet= True
     )
     if code != 0:
       xpk_exit(code)
-    xpk_print('xpk build from sources.')
-  xpk_print('xpk version:', xpk_version.strip('\n'))
+    xpk_print('git commit:', xpk_version.strip('\n'))

--- a/src/xpk/core/commands.py
+++ b/src/xpk/core/commands.py
@@ -227,7 +227,7 @@ def run_command_for_value(
     dry_run_return_val='0',
     print_timer=False,
     hide_error=False,
-    quiet = False
+    quiet=False,
 ) -> tuple[int, str]:
   """Runs the command and returns the error code and stdout.
 
@@ -280,8 +280,8 @@ def run_command_for_value(
   else:
     if not quiet:
       xpk_print(
-        f'Task: `{task}` is implemented by `{command}`, hiding output unless'
-        ' there is an error.'
+          f'Task: `{task}` is implemented by `{command}`, hiding output unless'
+          ' there is an error.'
       )
     try:
       output = subprocess.check_output(

--- a/src/xpk/core/commands.py
+++ b/src/xpk/core/commands.py
@@ -227,6 +227,7 @@ def run_command_for_value(
     dry_run_return_val='0',
     print_timer=False,
     hide_error=False,
+    quiet = False
 ) -> tuple[int, str]:
   """Runs the command and returns the error code and stdout.
 
@@ -254,7 +255,8 @@ def run_command_for_value(
     return 0, dry_run_return_val
 
   if print_timer:
-    xpk_print(f'Task: `{task}` is implemented by `{command}`')
+    if not quiet:
+      xpk_print(f'Task: `{task}` is implemented by `{command}`')
     with subprocess.Popen(
         command,
         stdout=subprocess.PIPE,
@@ -265,19 +267,22 @@ def run_command_for_value(
       while True:
         return_code = child.poll()
         if return_code is None:
-          xpk_print(f'Waiting for `{task}`, for {i} seconds')
+          if not quiet:
+            xpk_print(f'Waiting for `{task}`, for {i} seconds')
           time.sleep(1)
           i += 1
         else:
-          xpk_print(f'Task: `{task}` terminated with code `{return_code}`')
+          if not quiet:
+            xpk_print(f'Task: `{task}` terminated with code `{return_code}`')
           out, err = child.communicate()
           out, err = str(out, 'UTF-8'), str(err, 'UTF-8')
           return return_code, f'{out}\n{err}'
   else:
-    xpk_print(
+    if not quiet:
+      xpk_print(
         f'Task: `{task}` is implemented by `{command}`, hiding output unless'
         ' there is an error.'
-    )
+      )
     try:
       output = subprocess.check_output(
           command,
@@ -285,10 +290,11 @@ def run_command_for_value(
           stderr=subprocess.STDOUT if not hide_error else None,
       )
     except subprocess.CalledProcessError as e:
-      xpk_print(f'Task {task} failed with {e.returncode}')
-      xpk_print('*' * 80)
-      xpk_print(e.output)
-      xpk_print('*' * 80)
+      if not quiet:
+        xpk_print(f'Task {task} failed with {e.returncode}')
+        xpk_print('*' * 80)
+        xpk_print(e.output)
+        xpk_print('*' * 80)
       return e.returncode, str(e.output, 'UTF-8')
     return 0, str(output, 'UTF-8')
 


### PR DESCRIPTION
## Fixes / Features
- version displayed by version command is changed from 0.x.y to v0.x.y

## Testing / Documentation
Testing details.
```
[XPK] Starting xpk
[XPK] xpk_version: v0.4.1
[XPK] git commit: 15a1d056c8dd19b2d580680b66b70490cc409361
[XPK] XPK Done.
```
- [ y/n ] Tests pass
- [ y/n ] Appropriate changes to documentation are included in the PR
