### PR TITLE
Cluster Toolkit upgraded to v1.45.1

### DIFF
--- a/src/xpk/core/blueprint/blueprint_definitions.py
+++ b/src/xpk/core/blueprint/blueprint_definitions.py
@@ -56,4 +56,6 @@ class Blueprint:
 
   deployment_groups: list[DeploymentGroup]
   blueprint_name: Optional[str]
+  toolkit_modules_url: str
+  toolkit_modules_version: str
   vars: dict[str, str | list[str]] | None

--- a/src/xpk/core/blueprint/blueprint_generator.py
+++ b/src/xpk/core/blueprint/blueprint_generator.py
@@ -35,6 +35,9 @@ blueprint_dependencies_dir = {
     a3ultra_device_type: "src/xpk/blueprints/a3ultra",
 }
 
+cluster_toolkit_url = "github.com/GoogleCloudPlatform/cluster-toolkit"
+cluster_toolkit_version = "v1.45.1"
+
 
 class BlueprintGeneratorOutput:
   """BlueprintGeneratorOutput is a class containing fields with output blueprint file path and path to blueprint dependencies.
@@ -234,6 +237,8 @@ class BlueprintGenerator:
     )
     xpk_blueprint = Blueprint(
         blueprint_name=blueprint_name,
+        toolkit_modules_url=cluster_toolkit_url,
+        toolkit_modules_version=cluster_toolkit_version,
         deployment_groups=[primary_group],
         vars={
             "project_id": project_id,
@@ -314,6 +319,8 @@ class BlueprintGenerator:
     )
     ml_gke = Blueprint(
         blueprint_name=blueprint_name,
+        toolkit_modules_url=cluster_toolkit_url,
+        toolkit_modules_version=cluster_toolkit_version,
         deployment_groups=[primary_group],
         vars={
             "project_id": project_id,
@@ -617,6 +624,8 @@ class BlueprintGenerator:
     )
     a3_ultra_blueprint = Blueprint(
         blueprint_name=blueprint_name,
+        toolkit_modules_url=cluster_toolkit_url,
+        toolkit_modules_version=cluster_toolkit_version,
         deployment_groups=[primary_group],
         vars={
             "project_id": project_id,

--- a/src/xpk/core/docker_manager.py
+++ b/src/xpk/core/docker_manager.py
@@ -30,7 +30,7 @@ import time
 DockerRunCommandExitCode = 135
 dockerBuildErrorCode = 134
 ctk_dockerfile_path = "Dockerfile"
-ctk_build_ref = "v1.45.0"
+ctk_build_ref = "v1.45.1"
 ctk_docker_image = "xpk-ctk"
 ctk_container_name = "xpk-ctk-container"
 gcloud_cfg_mount_path = "/root/.config/gcloud"

--- a/src/xpk/core/tests/data/a3_mega.yaml
+++ b/src/xpk/core/tests/data/a3_mega.yaml
@@ -15,6 +15,8 @@
 ---
 !Blueprint
 blueprint_name: xpk-gke-a3-megagpu
+toolkit_modules_url: github.com/GoogleCloudPlatform/cluster-toolkit
+toolkit_modules_version: v1.45.1
 
 vars:
   project_id: "foo"

--- a/src/xpk/core/tests/data/a3_ultra.yaml
+++ b/src/xpk/core/tests/data/a3_ultra.yaml
@@ -13,6 +13,8 @@
 # limitations under the License.
 !Blueprint
 blueprint_name: xpk-gke-a3-ultra
+toolkit_modules_url: github.com/GoogleCloudPlatform/cluster-toolkit
+toolkit_modules_version: v1.45.1
 
 vars:
 

--- a/src/xpk/core/tests/unit/test_blueprint.py
+++ b/src/xpk/core/tests/unit/test_blueprint.py
@@ -62,6 +62,10 @@ def test_generate_a3_mega_blueprint():
     with open(bp.blueprint_file, encoding="utf-8") as generated_blueprint:
       ctk_test = yaml.load(generated_blueprint)
       assert ctk_yaml.blueprint_name == ctk_test.blueprint_name
+      assert ctk_yaml.toolkit_modules_url == ctk_test.toolkit_modules_url
+      assert (
+          ctk_yaml.toolkit_modules_version == ctk_test.toolkit_modules_version
+      )
       assert ctk_yaml.vars == ctk_test.vars
       assert ctk_test.deployment_groups == ctk_yaml.deployment_groups
       assert os.path.exists(
@@ -98,6 +102,10 @@ def test_generate_a3_ultra_blueprint():
     with open(bp.blueprint_file, encoding="utf-8") as generated_blueprint:
       ctk_test = yaml.load(generated_blueprint)
       assert ctk_yaml.blueprint_name == ctk_test.blueprint_name
+      assert ctk_yaml.toolkit_modules_url == ctk_test.toolkit_modules_url
+      assert (
+          ctk_yaml.toolkit_modules_version == ctk_test.toolkit_modules_version
+      )
       assert ctk_test.deployment_groups == ctk_yaml.deployment_groups
       assert os.path.exists(
           os.path.join(tmp_test_dir, blueprint_name, "mlgru-disable.yaml")


### PR DESCRIPTION
## Fixes / Features
- Cluster Toolkit upgraded to v1.45.1
- Cluster Toolkit's [version pinned in blueprints](https://github.com/GoogleCloudPlatform/cluster-toolkit/tree/main/examples#top-level-parameters)

## Testing / Documentation
Testing details.

- [ y/n ] Tests pass
- [ y/n ] Appropriate changes to documentation are included in the PR
