### PR TITLE
Fix uploading to TestPyPI

### DIFF
--- a/.github/workflows/build_wheels.yaml
+++ b/.github/workflows/build_wheels.yaml
@@ -14,8 +14,7 @@
 
 name: PyPi releases
 
-on: 
-  push:
+on:
   workflow_dispatch:
     inputs:
       testpypi:
@@ -32,7 +31,7 @@ jobs:
     name: Build distribution
     runs-on: ubuntu-latest
     # to build only on push to tags or on custom dispatched workflows
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/') 
+    if: github.event_name == 'workflow_dispatch'
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/build_wheels.yaml
+++ b/.github/workflows/build_wheels.yaml
@@ -31,7 +31,7 @@ jobs:
     name: Build distribution
     runs-on: ubuntu-latest
     # to build only on push to tags or on custom dispatched workflows
-    if: github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/') 
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/build_wheels.yaml
+++ b/.github/workflows/build_wheels.yaml
@@ -82,7 +82,7 @@ jobs:
     - name: Publish distribution 📦 to TestPyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        repository-url: https://test.pypi.org/legacy/ `
+        repository-url: https://test.pypi.org/legacy/
   publish-to-pypi:
     name: Publish Python distribution to PyPI
     if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes

--- a/.github/workflows/build_wheels.yaml
+++ b/.github/workflows/build_wheels.yaml
@@ -70,7 +70,7 @@ jobs:
       # We should configure trusted publishing as specified here: 
       # https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/#configuring-trusted-publishing
       name: testpypi
-      url: https://test.pypi.org/p/xpk
+      url: https://test.pypi.org/p/xpk-testing
     permissions:
       id-token: write  # IMPORTANT: mandatory for trusted publishing
     steps:

--- a/.github/workflows/build_wheels.yaml
+++ b/.github/workflows/build_wheels.yaml
@@ -42,7 +42,7 @@ jobs:
       with:
         python-version: "3.x"
     - name: Install pypa/build
-      run: |
+      run: >-
         python3 -m
         pip install
         build

--- a/.github/workflows/build_wheels.yaml
+++ b/.github/workflows/build_wheels.yaml
@@ -67,12 +67,10 @@ jobs:
     - build
     runs-on: ubuntu-latest
     environment:
-      # We should configure trusted publishing as specified here: 
-      # https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/#configuring-trusted-publishing
       name: testpypi
       url: https://test.pypi.org/p/xpk-testing
     permissions:
-      id-token: write  # IMPORTANT: mandatory for trusted publishing
+      id-token: write
     steps:
     - name: Download all the dists
       uses: actions/download-artifact@v4
@@ -83,6 +81,7 @@ jobs:
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         repository-url: https://test.pypi.org/legacy/
+        verbose: true
   publish-to-pypi:
     name: Publish Python distribution to PyPI
     if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 [project]
-name = "xpk"
+name = "xpk-testing"
 dynamic = ["version"]
 authors = [
   { name="Cloud TPU Team", email="cloud-tpu-eng@google.com" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 [project]
-name = "xpk-testing"
+name = "xpk"
 dynamic = ["version"]
 authors = [
   { name="Cloud TPU Team", email="cloud-tpu-eng@google.com" },


### PR DESCRIPTION
## Fixes / Features
- Fix uploading to TestPyPI
- To deploy to TestPyPI it is now required to change project name to xpk-testing in pyproject.toml. This will be fixed soon.
## Testing / Documentation
Testing details.

- [ y/n ] Tests pass
- [ y/n ] Appropriate changes to documentation are included in the PR
