### PR TITLE
Validate cluster name

### DIFF
--- a/src/xpk/parser/batch.py
+++ b/src/xpk/parser/batch.py
@@ -18,6 +18,7 @@ import argparse
 
 from .common import add_shared_arguments
 from ..commands.batch import batch
+from .validators import name_type
 
 
 def set_batch_parser(batch_parser):
@@ -34,7 +35,7 @@ def set_batch_parser(batch_parser):
   )
   batch_optional_arguments.add_argument(
       '--cluster',
-      type=str,
+      type=name_type,
       default=None,
       help='Cluster to which command applies.',
   )

--- a/src/xpk/parser/cluster.py
+++ b/src/xpk/parser/cluster.py
@@ -25,6 +25,7 @@ from ..commands.cluster import (
 )
 from ..core.core import DEFAULT_VERTEX_TENSORBOARD_NAME
 from .common import add_shared_arguments
+from .validators import name_type
 
 
 def set_cluster_parser(cluster_parser):
@@ -269,7 +270,7 @@ def set_cluster_parser(cluster_parser):
   ### Required arguments
   cluster_delete_required_arguments.add_argument(
       '--cluster',
-      type=str,
+      type=name_type,
       default=None,
       help='The name of the cluster to be deleted.',
       required=True,
@@ -326,7 +327,7 @@ def set_cluster_parser(cluster_parser):
   ### Required arguments
   cluster_cacheimage_required_arguments.add_argument(
       '--cluster',
-      type=str,
+      type=name_type,
       default=None,
       help='The name of the cluster to cache the image.',
       required=True,
@@ -370,7 +371,7 @@ def set_cluster_parser(cluster_parser):
   ### Required arguments
   cluster_describe_required_arguments.add_argument(
       '--cluster',
-      type=str,
+      type=name_type,
       default=None,
       help='The name of the cluster to be describe.',
       required=True,
@@ -402,7 +403,7 @@ def add_shared_cluster_create_required_arguments(args_parsers):
   for custom_parser in args_parsers:
     custom_parser.add_argument(
         '--cluster',
-        type=str,
+        type=name_type,
         default=None,
         help=(
             'The name of the cluster. Will be used as the prefix for internal'

--- a/src/xpk/parser/info.py
+++ b/src/xpk/parser/info.py
@@ -16,6 +16,7 @@ limitations under the License.
 
 from ..commands.info import info
 from .common import add_shared_arguments
+from .validators import name_type
 import argparse
 
 
@@ -29,7 +30,7 @@ def set_info_parser(info_parser: argparse.ArgumentParser) -> None:
 
   info_required_arguments.add_argument(
       '--cluster',
-      type=str,
+      type=name_type,
       default=None,
       help='Cluster to which command applies.',
       required=True,

--- a/src/xpk/parser/inspector.py
+++ b/src/xpk/parser/inspector.py
@@ -15,7 +15,7 @@ limitations under the License.
 """
 
 from ..commands.inspector import inspector
-from .validators import workload_name_type
+from .validators import name_type
 from .common import add_shared_arguments
 
 
@@ -37,7 +37,7 @@ def set_inspector_parser(inspector_parser):
 
   inspector_parser_required_arguments.add_argument(
       '--cluster',
-      type=str,
+      type=name_type,
       default=None,
       help='The name of the cluster to investigate.',
       required=True,
@@ -48,7 +48,7 @@ def set_inspector_parser(inspector_parser):
 
   inspector_parser_optional_arguments.add_argument(
       '--workload',
-      type=workload_name_type,
+      type=name_type,
       default=None,
       help='The name of the workload to investigate.',
   )

--- a/src/xpk/parser/job.py
+++ b/src/xpk/parser/job.py
@@ -18,6 +18,7 @@ import argparse
 from ..commands.job import job_info, job_list, job_cancel
 
 from .common import add_shared_arguments
+from .validators import name_type
 
 
 def set_job_parser(job_parser: argparse.ArgumentParser):
@@ -71,7 +72,7 @@ def set_job_list_parser(job_list_parser: argparse.ArgumentParser):
   ### Required arguments
   job_list_required_arguments.add_argument(
       '--cluster',
-      type=str,
+      type=name_type,
       default=None,
       help='The name of the cluster to list jobs on.',
       required=True,
@@ -108,7 +109,7 @@ def set_job_cancel_parser(job_cancel_parser: argparse.ArgumentParser):
 
   job_cancel_required_arguments.add_argument(
       '--cluster',
-      type=str,
+      type=name_type,
       default=None,
       help='The name of the cluster to delete the job on.',
       required=True,

--- a/src/xpk/parser/kind.py
+++ b/src/xpk/parser/kind.py
@@ -20,6 +20,7 @@ from ..commands.kind import (
     cluster_list,
 )
 from .common import add_global_arguments
+from .validators import name_type
 
 
 def set_kind_parser(kind_parser):
@@ -40,7 +41,7 @@ def set_kind_parser(kind_parser):
   ### Optional Arguments
   cluster_create_parser.add_argument(
       '--cluster',
-      type=str,
+      type=name_type,
       default='kind',
       help=(
           'The name of the cluster. Will be used as the prefix for internal'
@@ -74,7 +75,7 @@ def set_kind_parser(kind_parser):
   ### Required arguments
   cluster_delete_required_arguments.add_argument(
       '--cluster',
-      type=str,
+      type=name_type,
       default=None,
       help='The name of the cluster to be deleted.',
       required=True,

--- a/src/xpk/parser/validators.py
+++ b/src/xpk/parser/validators.py
@@ -19,12 +19,12 @@ import os
 import re
 
 
-def workload_name_type(value, pat=re.compile(r'[a-z]([-a-z0-9]*[a-z0-9])?')):
-  """Validate that the workload name matches the expected pattern."""
+def name_type(value, pat=re.compile(r'[a-z]([-a-z0-9]*[a-z0-9])?')):
+  """Validate that the name matches the expected pattern."""
   match = pat.fullmatch(value)
   if not match or len(match.group(0)) > 40:
     raise argparse.ArgumentTypeError(
-        'Workload name must be less than 40 characters and match the pattern'
+        'Name must be less than 40 characters and match the pattern'
         f' `{pat.pattern}`'
         f' Name is currently {value}'
     )

--- a/src/xpk/parser/workload.py
+++ b/src/xpk/parser/workload.py
@@ -21,7 +21,7 @@ from ..commands.workload import (
     workload_list,
 )
 from ..core.core import default_docker_image, default_script_dir
-from .validators import directory_path_type, workload_name_type
+from .validators import directory_path_type, name_type
 from .common import add_shared_arguments
 
 
@@ -293,7 +293,7 @@ def set_workload_parsers(workload_parser):
   ### "workload delete" Required arguments
   workload_delete_parser_required_arguments.add_argument(
       '--cluster',
-      type=str,
+      type=name_type,
       default=None,
       help='The name of the cluster to delete the job on.',
       required=True,
@@ -301,7 +301,7 @@ def set_workload_parsers(workload_parser):
   ### "workload delete" Optional arguments
   workload_delete_parser_optional_arguments.add_argument(
       '--workload',
-      type=workload_name_type,
+      type=name_type,
       default=None,
       help=(
           'The name of the workload to delete. If the workload is not'
@@ -352,7 +352,7 @@ def set_workload_parsers(workload_parser):
 
   workload_list_parser.add_argument(
       '--cluster',
-      type=str,
+      type=name_type,
       default=None,
       help='The name of the cluster to list jobs on.',
       required=True,
@@ -428,14 +428,14 @@ def add_shared_workload_create_required_arguments(args_parsers):
   for custom_parser in args_parsers:
     custom_parser.add_argument(
         '--workload',
-        type=workload_name_type,
+        type=name_type,
         default=None,
         help='The name of the workload to run.',
         required=True,
     )
     custom_parser.add_argument(
         '--cluster',
-        type=str,
+        type=name_type,
         default=None,
         help='The name of the cluster to run the job on.',
         required=True,


### PR DESCRIPTION
## Fixes / Features
- Validate cluster name. Example:

```
python xpk.py cluster create --cluster x#pk-test --device-type=n2-standard-32-1 --default-pool-cpu-num-nodes=1 --on-demand
[XPK] Starting xpk
usage: xpk cluster create [-h] (--tpu-type TPU_TYPE | --device-type DEVICE_TYPE) [--num-nodes NUM_NODES] [--enable-pathways] [--enable-autoprovisioning] [--autoprovisioning-min-chips AUTOPROVISIONING_MIN_CHIPS]
                          [--autoprovisioning-max-chips AUTOPROVISIONING_MAX_CHIPS] --cluster CLUSTER [--project PROJECT] [--zone ZONE] [--dry-run | --no-dry-run] [--host-maintenance-interval {AS_NEEDED,PERIODIC}]
                          [--gke-version GKE_VERSION] [--num-slices NUM_SLICES] [--pathways-gce-machine-type PATHWAYS_GCE_MACHINE_TYPE] [--default-pool-cpu-machine-type DEFAULT_POOL_CPU_MACHINE_TYPE]
                          [--cluster-cpu-machine-type CLUSTER_CPU_MACHINE_TYPE] [--default-pool-cpu-num-nodes DEFAULT_POOL_CPU_NUM_NODES] [--custom-cluster-arguments CUSTOM_CLUSTER_ARGUMENTS]
                          [--custom-nodepool-arguments CUSTOM_NODEPOOL_ARGUMENTS] [--force] [--custom-tpu-nodepool-arguments CUSTOM_TPU_NODEPOOL_ARGUMENTS] [--private]
                          [--authorized-networks AUTHORIZED_NETWORKS [AUTHORIZED_NETWORKS ...]] [--on-demand] [--reservation RESERVATION] [--spot] [--create-vertex-tensorboard]
                          [--tensorboard-region TENSORBOARD_REGION] [--tensorboard-name TENSORBOARD_NAME]
xpk cluster create: error: argument --cluster: Name must be less than 40 characters and match the pattern `[a-z]([-a-z0-9]*[a-z0-9])?` Name is currently x#pk-test
```

## Testing / Documentation
Testing details.

- [ y/n ] Tests pass
- [ y/n ] Appropriate changes to documentation are included in the PR
