### PR TITLE
Add installation of gke-gcloud-auth-plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ KJOB_DOCKER_CONTAINER := xpk_kjob_container
 BIN_PATH=$(PROJECT_DIR)/bin
 
 .PHONY: install
-install: check-python check-gcloud install-kueuectl install-kjobctl pip-install
+install: check-python check-gcloud install-gcloud-auth-plugin install-kueuectl install-kjobctl pip-install
 
 .PHONY: install-dev
 install-dev: check-python check-gcloud mkdir-bin install-kueuectl install-kjobctl pip-install install-pytest
@@ -56,6 +56,11 @@ install-kjobctl: mkdir-bin
 	docker cp $(KJOB_DOCKER_CONTAINER):/kjob/bin/kubectl-kjob $(BIN_PATH)/kubectl-kjob
 	docker rm -f $(KJOB_DOCKER_CONTAINER)
 	docker image rm $(KJOB_DOCKER_IMG)
+
+.PHONY: install-gcloud-auth-plugin
+install-gcloud-auth-plugin:
+	chmod +x tools/install-gke-auth-plugin.sh
+	./tools/install-gke-auth-plugin.sh
 
 .PHONY: check-gcloud
 check-gcloud:

--- a/tools/install-gke-auth-plugin.sh
+++ b/tools/install-gke-auth-plugin.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+readonly PLUGIN="gke-gcloud-auth-plugin"
+
+# Officially supported installation methods
+readonly GCLOUD_INSTALLER="gcloud"
+readonly APT_INSTALLER="apt"
+readonly YUM_INSTALLER="yum"
+
+IS_GCLOUD_INSTALLER=false
+INSTALL_CMD=""
+
+function set_install_command() {
+    OS=$(uname -s)
+    case "$OS" in
+    "Linux")
+        if command -v ${APT_INSTALLER} &> /dev/null
+        then
+            INSTALL_CMD="apt-get install -y google-cloud-sdk-gke-gcloud-auth-plugin"
+        elif command -v ${YUM_INSTALLER} &> /dev/null
+        then
+            INSTALL_CMD="yum install -y google-cloud-sdk-gke-gcloud-auth-plugin"
+        else
+            echo "Neither apt nor yum is available, using gcloud to install."
+            IS_GCLOUD_INSTALLER=true
+            INSTALL_CMD="gcloud components install gke-gcloud-auth-plugin"
+        fi
+        ;;
+    "Darwin")
+        IS_GCLOUD_INSTALLER=true
+        INSTALL_CMD="gcloud components install gke-gcloud-auth-plugin"
+        ;;
+    *)
+        echo "Unsupported OS: $OS"
+        exit 1
+        ;;
+    esac
+}
+
+function install_plugin() {
+  if [ "${IS_GCLOUD_INSTALLER}" = true ] && ! command -v ${GCLOUD_INSTALLER} &> /dev/null
+  then
+    echo "gcloud command could not be found, please install Google Cloud SDK first."
+    exit 1
+  fi
+
+  echo "Installing ${PLUGIN}..."
+  eval $INSTALL_CMD
+}
+
+function verify_plugin_installation() {
+    if ${PLUGIN} --version &> /dev/null
+    then
+        echo "${PLUGIN} installation successful. Version info:"
+        ${PLUGIN} --version
+    else
+        echo "${PLUGIN} installation failed or the plugin is not accessible in PATH."
+        exit 1
+    fi
+}
+
+set_install_command
+install_plugin
+verify_plugin_installation


### PR DESCRIPTION
## Fixes / Features
- Add gke-gcloud-auth-plugin as a dependency to allow it to be installed from the Makefile.

## Testing / Documentation
Testing details.

- [ y/n ] Tests pass
- [ y/n ] Appropriate changes to documentation are included in the PR
