### PR TITLE
fix `xpk version` showing invalid git commit hash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,11 +16,17 @@ KJOB_DOCKER_IMG := xpk_kjob
 KJOB_DOCKER_CONTAINER := xpk_kjob_container
 BIN_PATH=$(PROJECT_DIR)/bin
 
+GIT_COMMIT_HASH := $(shell git rev-parse HEAD)
+
 .PHONY: install
-install: check-python check-gcloud install-kueuectl install-kjobctl pip-install
+install: save-git-hash check-python check-gcloud install-kueuectl install-kjobctl pip-install
 
 .PHONY: install-dev
-install-dev: check-python check-gcloud mkdir-bin install-kueuectl install-kjobctl pip-install install-pytest
+install-dev: save-git-hash check-python check-gcloud mkdir-bin install-kueuectl install-kjobctl pip-install install-pytest
+
+.PHONY: save-git-hash
+save-git-hash:
+	sed -i -e "s/__git_commit_hash__ = .*/__git_commit_hash__ = '${GIT_COMMIT_HASH}'/" src/xpk/core/core.py
 
 .PHONY: pip-install
 pip-install:

--- a/src/xpk/commands/version.py
+++ b/src/xpk/commands/version.py
@@ -15,25 +15,14 @@ limitations under the License.
 """
 
 from argparse import Namespace
-import os
 
-from ..core.commands import run_command_for_value
+from ..core.core import __git_commit_hash__
+from ..utils.console import xpk_print
 
 XPK_VERSION = 'v0.6.0'
-
-from ..utils.console import xpk_exit, xpk_print
 
 
 def version(args: Namespace) -> None:
   """Get version of xpk."""
   xpk_print('xpk_version:', XPK_VERSION)
-  if os.path.exists(os.path.join(os.getcwd(), '.git')):
-    code, xpk_version = run_command_for_value(
-        'git rev-parse HEAD',
-        task='Get latest hash',
-        global_args=args,
-        quiet=True,
-    )
-    if code != 0:
-      xpk_exit(code)
-    xpk_print('git commit:', xpk_version.strip('\n'))
+  xpk_print('git commit hash:', __git_commit_hash__)

--- a/src/xpk/core/core.py
+++ b/src/xpk/core/core.py
@@ -61,6 +61,7 @@ default_docker_image = 'python:3.10'
 default_script_dir = os.getcwd()
 # This is the version for XPK PyPI package
 __version__ = '0.6.0'
+__git_commit_hash__ = '<git-commit-hash>'
 xpk_current_version = __version__
 
 h100_device_type = 'h100-80gb-8'


### PR DESCRIPTION
Add script in make install to save git commit hash in core.py when installing.


## Fixes / Features
Fixes #342

## Testing / Documentation
Run `xpk version` in different folders (outside of xpk repository) and check if git commit hash is always correctly shown
