### PR TITLE
Fix flaky `Check created job` test

### DIFF
--- a/.github/workflows/build_tests.yaml
+++ b/.github/workflows/build_tests.yaml
@@ -157,6 +157,10 @@ jobs:
     - name: Run a job
       run: |
         python xpk.py run --cluster $TPU_CLUSTER_NAME --zone=us-central2-b workload.sh | awk '/Starting log streaming for pod xpk-def-app-profile-slurm-[a-zA-Z0-9]+-[0-9]+-[a-zA-Z0-9]+.../,/Job logs streaming finished./ { print }'
+    - name: Delete the job
+      run: |
+        JOB_NAME=$(python3 xpk.py job ls --cluster $TPU_CLUSTER_NAME --zone=us-central2-b | grep 'xpk-def-app-profile-slurm-' | head -1 | awk '{print $1}')
+        kubectl delete job ${JOB_NAME}
     - name: Run a base-docker-image workload
       run: python xpk.py workload create --cluster $TPU_CLUSTER_NAME --workload $WORKLOAD_NAME  --command "bash workload.sh"  --tpu-type=$TPU_TYPE --num-slices=2 --zone=us-central2-b
     - name: Run xpk inspector with the workload created above
@@ -215,8 +219,3 @@ jobs:
     - name: Delete the cluster created
       if: always()
       run: python xpk.py cluster delete --cluster $TPU_CLUSTER_NAME --zone=us-central2-b --force
-
-
-
-
-


### PR DESCRIPTION
## Fixes / Features
- Fixes the flaky test Check created job in build tests: https://github.com/AI-Hypercomputer/xpk/actions/runs/13116378278/job/36592290305. This test assumes there is only one job in the cluster. However, because a previous job created with xpk run was not deleted, Check created job was retrieving the wrong job name.

## Testing / Documentation
Testing details.

- [ y/n ] Tests pass
- [ y/n ] Appropriate changes to documentation are included in the PR
