### PR TITLE
Update the Cloud Logging URL pod_name query for pathways workloads

### DIFF
--- a/src/xpk/core/pathways.py
+++ b/src/xpk/core/pathways.py
@@ -174,15 +174,12 @@ def ensure_pathways_workload_prerequisites(args, system) -> bool:
 
 def get_pathways_unified_query_link(args) -> str:
   """Get the unified query link for the pathways workload."""
-  pw_suffixes = ['main', 'rm', 'proxy']
-  pw_pod_names = [f'"{args.workload}-{suffix}-0"' for suffix in pw_suffixes]
-  pw_pod_names_query = '%20OR%20'.join(pw_pod_names + ['worker-0-0'])
   query_params = (
       'resource.type%3D"k8s_container"%0A'
       f'resource.labels.project_id%3D"{args.project}"%0A'
       f'resource.labels.location%3D"{zone_to_region(args.zone)}"%0A'
       f'resource.labels.cluster_name%3D"{args.cluster}"%0A'
-      f'resource.labels.pod_name:{pw_pod_names_query}%0A'
+      f'resource.labels.pod_name:"{args.workload}-"%0A'
       'severity>%3DDEFAULT'
   )
 


### PR DESCRIPTION
## Fixes / Features
- The query for pod_names is unnecessary complex and includes "worker-0-0" without any workload prefix.

## Testing / Documentation
Testing details.

Tested locally and the URL was valid and updated correctly.

- [ y ] Tests pass
- [ y ] Appropriate changes to documentation are included in the PR
