### PR TITLE
Support custom Pathways args.

### DIFF
--- a/src/xpk/core/pathways.py
+++ b/src/xpk/core/pathways.py
@@ -44,6 +44,8 @@ def get_pathways_worker_args(args) -> str:
               - --resource_manager_address={rm_address}
               - --gcs_scratch_location={args.pathways_gcs_location}"""
   if args.use_pathways:
+    if args.custom_pathways_worker_args:
+      yaml = append_custom_pathways_args(yaml, args.custom_pathways_worker_args)
     return yaml.format(args=args, rm_address=get_rm_address(args))
   else:
     return ''
@@ -62,6 +64,10 @@ def get_pathways_proxy_args(args) -> str:
               - --gcs_scratch_location={args.pathways_gcs_location}"""
 
   if args.use_pathways:
+    if args.custom_pathways_proxy_server_args:
+      yaml = append_custom_pathways_args(
+          yaml, args.custom_pathways_proxy_server_args
+      )
     return yaml.format(args=args, rm_address=get_rm_address(args))
   else:
     return ''
@@ -200,6 +206,8 @@ def get_pathways_rm_args(args, system: SystemCharacteristics) -> str:
               - --instance_count={instance_count}
               - --instance_type={instance_type}"""
   if args.use_pathways:
+    if args.custom_pathways_server_args:
+      yaml = append_custom_pathways_args(yaml, args.custom_pathways_server_args)
     return yaml.format(
         args=args,
         instance_count=args.num_slices,
@@ -207,6 +215,28 @@ def get_pathways_rm_args(args, system: SystemCharacteristics) -> str:
     )
   else:
     return ''
+
+
+def append_custom_pathways_args(yaml, custom_args) -> str:
+  """Append custom Pathways args to the YAML with proper indentation.
+
+  Args:
+      yaml (string): existing yaml containing args
+
+  Returns:
+      yaml (string): yaml with additional args appended.
+  """
+  second_line = yaml.split('\n')[1]
+  if (
+      not second_line
+  ):  # to cover edge case if only one arg remains, we would have to look at the entire YAML in this case.
+    return yaml
+  # Calculate the indentation based on the second line of existing YAML.
+  indentation = ' ' * (len(second_line) - len(second_line.lstrip()))
+  custom_args = custom_args.split(' ')
+  for arg in custom_args:
+    yaml += '\n' + indentation + '- ' + arg
+  return yaml
 
 
 def get_user_workload_for_pathways(args, system: SystemCharacteristics) -> str:

--- a/src/xpk/parser/workload.py
+++ b/src/xpk/parser/workload.py
@@ -244,6 +244,39 @@ def set_workload_parsers(workload_parser):
       required=False,
   )
 
+  workload_create_pathways_parser_optional_arguments.add_argument(
+      '--custom-pathways-server-args',
+      type=str,
+      default=None,
+      help=(
+          'Provide custom Pathways server args as follows -'
+          " --custom-pathways-server-args='--arg_1=xxx --arg2=yyy'"
+      ),
+      required=False,
+  )
+
+  workload_create_pathways_parser_optional_arguments.add_argument(
+      '--custom-pathways-proxy-server-args',
+      type=str,
+      default=None,
+      help=(
+          'Provide custom Pathways proxy server args as follows -'
+          " --custom-pathways-proxy-server-args='--arg_1=xxx --arg2=yyy'"
+      ),
+      required=False,
+  )
+
+  workload_create_pathways_parser_optional_arguments.add_argument(
+      '--custom-pathways-worker-args',
+      type=str,
+      default=None,
+      help=(
+          'Provide custom Pathways worker args as follows -'
+          " --custom-pathways-worker-args='--arg_1=xxx --arg2=yyy'"
+      ),
+      required=False,
+  )
+
   add_shared_workload_create_required_arguments([
       workload_create_parser_required_arguments,
       workload_create_pathways_parser_required_arguments,


### PR DESCRIPTION
## Fixes / Features
- Adds support for adding Pathways proxy, server and worker args.
- Ensures indentation of added args is in line with the rest of the YAML.

## Testing / Documentation
Manually verified - 
Command -
```
python3 ~/xpk/xpk.py workload create-pathways \
--workload roshanin-pw-test${n} \
--num-slices=1 \
--tpu-type=$TPU_TYPE \
--project $PROJECT \
--zone $ZONE \
--cluster $CLUSTER \
--headless \
--custom-pathways-server-args='--temporary_flags_for_debugging=temporary_flag_for_debugging_worker_expected_tpu_chip_config=megachip_tccontrol'
```
YAML output -
```
template:
          spec:
            containers:
            - args:
              - --server_port=29001
              - --gcs_scratch_location=gs://cloud-pathways-staging/tmp
              - --node_type=resource_manager
              - --instance_count=1
              - --instance_type=tpuv6e:16x16
              - --temporary_flags_for_debugging=temporary_flag_for_debugging_worker_expected_tpu_chip_config=megachip_tccontrol          
```

- [ y ] Tests pass
- [ y ] Appropriate changes to documentation are included in the PR
