### PR TITLE
Remove Pathways specific args from workload create flow.

### DIFF
--- a/src/xpk/commands/workload.py
+++ b/src/xpk/commands/workload.py
@@ -352,6 +352,13 @@ def workload_create_pathways(args) -> None:
     0 if successful and 1 otherwise.
   """
   args.use_pathways = True
+  if args.headless:
+    xpk_print(
+        'Please use kubectl port forwarding to connect to the Pathways proxy.'
+        ' kubectl get pods kubectl port-forward <proxy-pod-name> 29000:29000'
+        ' JAX_PLATFORMS=proxy JAX_BACKEND_TARGET=grpc://127.0.0.1:29000 python'
+        " -c 'import pathwaysutils; import jax; print(jax.devices())'"
+    )
   workload_create(args)
 
 
@@ -365,14 +372,6 @@ def workload_create(args) -> None:
     0 if successful and 1 otherwise.
   """
   add_zone_and_project(args)
-
-  if args.headless:
-    xpk_print(
-        'Please use kubectl port forwarding to connect to the Pathways proxy.'
-        ' kubectl get pods kubectl port-forward <proxy-pod-name> 29000:29000'
-        ' JAX_PLATFORMS=proxy JAX_BACKEND_TARGET=grpc://127.0.0.1:29000 python'
-        " -c 'import pathwaysutils; import jax; print(jax.devices())'"
-    )
 
   set_cluster_command_code = set_cluster_command(args)
   if set_cluster_command_code != 0:

--- a/src/xpk/parser/cluster.py
+++ b/src/xpk/parser/cluster.py
@@ -89,14 +89,6 @@ def set_cluster_parser(cluster_parser):
       help='The number of nodes for a cluster, defaults to 2.',
       required=False,
   )
-  cluster_create_optional_arguments.add_argument(
-      '--enable-pathways',
-      action='store_true',
-      help=(
-          'DEPRECATING SOON!!! Please use `xpk cluster create-pathways`.'
-          ' Enable cluster to accept Pathways workloads.'
-      ),
-  )
 
   ### Autoprovisioning arguments specific to "cluster create"
   cluster_create_autoprovisioning_arguments = (
@@ -216,14 +208,6 @@ def set_cluster_parser(cluster_parser):
       default=None,
       help="The Ray version to use, e.g. '2.38.0'",
       required=True,
-  )
-  cluster_create_ray_cluster_optional_arguments.add_argument(
-      '--enable-pathways',
-      action='store_true',
-      help=(
-          'DEPRECATING SOON!!! Please use `xpk cluster create-pathways`.'
-          ' Enable cluster to accept Pathways workloads.'
-      ),
   )
 
   add_shared_cluster_create_required_arguments([

--- a/src/xpk/parser/cluster.py
+++ b/src/xpk/parser/cluster.py
@@ -89,7 +89,14 @@ def set_cluster_parser(cluster_parser):
       help='The number of nodes for a cluster, defaults to 2.',
       required=False,
   )
-
+  cluster_create_optional_arguments.add_argument(
+      '--enable-pathways',
+      action='store_true',
+      help=(
+          'Please use `xpk cluster create-pathways` instead to'
+          ' enable cluster to accept Pathways workloads.'
+      ),
+  )
   ### Autoprovisioning arguments specific to "cluster create"
   cluster_create_autoprovisioning_arguments = (
       cluster_create_parser.add_argument_group(
@@ -208,6 +215,14 @@ def set_cluster_parser(cluster_parser):
       default=None,
       help="The Ray version to use, e.g. '2.38.0'",
       required=True,
+  )
+  cluster_create_ray_cluster_optional_arguments.add_argument(
+      '--enable-pathways',
+      action='store_true',
+      help=(
+          'DEPRECATING SOON!!! Please use `xpk cluster create-pathways`.'
+          ' Enable cluster to accept Pathways workloads.'
+      ),
   )
 
   add_shared_cluster_create_required_arguments([

--- a/src/xpk/parser/workload.py
+++ b/src/xpk/parser/workload.py
@@ -147,6 +147,15 @@ def set_workload_parsers(workload_parser):
       ),
   )
 
+  workload_create_parser_optional_arguments.add_argument(
+      '--use-pathways',
+      action='store_true',
+      help=(
+          'Please use `xpk workload create-pathways` instead to'
+          ' create Pathways workloads.'
+      ),
+  )
+
   # Autoprovisioning workload arguments
   workload_create_autoprovisioning_arguments.add_argument(
       '--on-demand',

--- a/src/xpk/parser/workload.py
+++ b/src/xpk/parser/workload.py
@@ -230,6 +230,52 @@ def set_workload_parsers(workload_parser):
       help='The tpu type to use, v5litepod-16, etc.',
   )
 
+  ### "workload create-pathways" Optional arguments, specific to Pathways
+  workload_create_pathways_parser_optional_arguments.add_argument(
+      '--headless',
+      action='store_true',
+      help=(
+          'Please provide this argument to create Pathways workloads in'
+          ' headless mode. This arg can only be used in `xpk workload'
+          ' create-pathways`(preferred) or `xpk workload create'
+          ' --use-pathways.` (--use-pathways will be deprecated soon).'
+      ),
+  )
+  workload_create_pathways_parser_optional_arguments.add_argument(
+      '--proxy-server-image',
+      type=str,
+      default=(
+          'us-docker.pkg.dev/cloud-tpu-v2-images/pathways/proxy_server:latest'
+      ),
+      help=(
+          'Please provide the proxy server image for Pathways. This arg can'
+          ' only be used in `xpk workload create-pathways`(preferred) or `xpk'
+          ' workload create --use-pathways.` (--use-pathways will be'
+          ' deprecated soon).'
+      ),
+  )
+  workload_create_pathways_parser_optional_arguments.add_argument(
+      '--server-image',
+      type=str,
+      default='us-docker.pkg.dev/cloud-tpu-v2-images/pathways/server:latest',
+      help=(
+          'Please provide the server image for Pathways. This arg can only be'
+          ' used in `xpk workload create-pathways`(preferred) or `xpk'
+          ' workload create --use-pathways.` (--use-pathways will be'
+          ' deprecated soon).'
+      ),
+  )
+  workload_create_pathways_parser_optional_arguments.add_argument(
+      '--pathways-gcs-location',
+      type=str,
+      default='gs://cloud-pathways-staging/tmp',
+      help=(
+          'Please provide the GCS location to store Pathways artifacts. This'
+          ' arg can only be used in `xpk workload create-pathways`(preferred)'
+          ' or `xpk workload create --use-pathways.` (--use-pathways will be'
+          ' deprecated soon).'
+      ),
+  )
   workload_create_pathways_parser_optional_arguments.add_argument(
       '--command',
       type=str,
@@ -553,51 +599,6 @@ def add_shared_workload_create_optional_arguments(args_parsers):
             ' greater than 0. By default, this is not enabled, and workloads'
             ' will not restart from user code failures. This is enabled by'
             ' default on Pathways workloads.'
-        ),
-    )
-    custom_parser.add_argument(
-        '--headless',
-        action='store_true',
-        help=(
-            'Please provide this argument to create Pathways workloads in'
-            ' headless mode. This arg can only be used in `xpk workload'
-            ' create-pathways`(preferred) or `xpk workload create'
-            ' --use-pathways.` (--use-pathways will be deprecated soon).'
-        ),
-    )
-    custom_parser.add_argument(
-        '--proxy-server-image',
-        type=str,
-        default=(
-            'us-docker.pkg.dev/cloud-tpu-v2-images/pathways/proxy_server:latest'
-        ),
-        help=(
-            'Please provide the proxy server image for Pathways. This arg can'
-            ' only be used in `xpk workload create-pathways`(preferred) or `xpk'
-            ' workload create --use-pathways.` (--use-pathways will be'
-            ' deprecated soon).'
-        ),
-    )
-    custom_parser.add_argument(
-        '--server-image',
-        type=str,
-        default='us-docker.pkg.dev/cloud-tpu-v2-images/pathways/server:latest',
-        help=(
-            'Please provide the server image for Pathways. This arg can only be'
-            ' used in `xpk workload create-pathways`(preferred) or `xpk'
-            ' workload create --use-pathways.` (--use-pathways will be'
-            ' deprecated soon).'
-        ),
-    )
-    custom_parser.add_argument(
-        '--pathways-gcs-location',
-        type=str,
-        default='gs://cloud-pathways-staging/tmp',
-        help=(
-            'Please provide the GCS location to store Pathways artifacts. This'
-            ' arg can only be used in `xpk workload create-pathways`(preferred)'
-            ' or `xpk workload create --use-pathways.` (--use-pathways will be'
-            ' deprecated soon).'
         ),
     )
     custom_parser.add_argument(

--- a/src/xpk/parser/workload.py
+++ b/src/xpk/parser/workload.py
@@ -67,11 +67,7 @@ def set_workload_parsers(workload_parser):
           'Arguments for configuring autoprovisioning.',
       )
   )
-  workload_pathways_workload_arguments = workload_create_parser.add_argument_group(
-      'Pathways Image Arguments',
-      'If --use-pathways is provided, user wants to set up a'
-      'Pathways workload on xpk.',
-  )
+
   workload_vertex_tensorboard_arguments = (
       workload_create_parser.add_argument_group(
           'Vertex Tensorboard Arguments',
@@ -178,16 +174,6 @@ def set_workload_parsers(workload_parser):
       ),
   )
 
-  # Pathways workload arguments
-  workload_pathways_workload_arguments.add_argument(
-      '--use-pathways',
-      action='store_true',
-      help=(
-          'DECRATING SOON!!! Please use `xpk workload create-pathways` instead.'
-          ' Provide this argument to create Pathways workloads.'
-      ),
-  )
-
   # "workload create-pathways" command parser.
   workload_create_pathways_parser = workload_subcommands.add_parser(
       'create-pathways', help='Create a new job.'
@@ -237,8 +223,7 @@ def set_workload_parsers(workload_parser):
       help=(
           'Please provide this argument to create Pathways workloads in'
           ' headless mode. This arg can only be used in `xpk workload'
-          ' create-pathways`(preferred) or `xpk workload create'
-          ' --use-pathways.` (--use-pathways will be deprecated soon).'
+          ' create-pathways`.'
       ),
   )
   workload_create_pathways_parser_optional_arguments.add_argument(
@@ -249,9 +234,7 @@ def set_workload_parsers(workload_parser):
       ),
       help=(
           'Please provide the proxy server image for Pathways. This arg can'
-          ' only be used in `xpk workload create-pathways`(preferred) or `xpk'
-          ' workload create --use-pathways.` (--use-pathways will be'
-          ' deprecated soon).'
+          ' only be used in `xpk workload create-pathways`.'
       ),
   )
   workload_create_pathways_parser_optional_arguments.add_argument(
@@ -260,9 +243,7 @@ def set_workload_parsers(workload_parser):
       default='us-docker.pkg.dev/cloud-tpu-v2-images/pathways/server:latest',
       help=(
           'Please provide the server image for Pathways. This arg can only be'
-          ' used in `xpk workload create-pathways`(preferred) or `xpk'
-          ' workload create --use-pathways.` (--use-pathways will be'
-          ' deprecated soon).'
+          ' used in `xpk workload create-pathways`.'
       ),
   )
   workload_create_pathways_parser_optional_arguments.add_argument(
@@ -271,9 +252,7 @@ def set_workload_parsers(workload_parser):
       default='gs://cloud-pathways-staging/tmp',
       help=(
           'Please provide the GCS location to store Pathways artifacts. This'
-          ' arg can only be used in `xpk workload create-pathways`(preferred)'
-          ' or `xpk workload create --use-pathways.` (--use-pathways will be'
-          ' deprecated soon).'
+          ' arg can only be used in `xpk workload create-pathways`.'
       ),
   )
   workload_create_pathways_parser_optional_arguments.add_argument(


### PR DESCRIPTION
## Fixes / Features
- Four args `--headless`,`--proxy-server-image`,`--server-image`,`--pathways-gcs-location` got included in the `xpk workload create` flow, but are not intended to be used there. Retained them in `xpk workload create-pathways` flow.

## Testing / Documentation
See b/394352418 for more details.

- [ y ] Tests pass
- [ y ] Appropriate changes to documentation are included in the PR
