### PR TITLE
Skip Storages if Not Found (instead of failing)

### DIFF
--- a/src/xpk/core/storage.py
+++ b/src/xpk/core/storage.py
@@ -156,6 +156,10 @@ def list_storages(k8s_api_client: ApiClient) -> list[Storage]:
     )
   except ApiException as e:
     xpk_print(f"Kubernetes API exception while listing Storages: {e}")
+    if e.status == 404:
+      xpk_print("Storages not found, skipping")
+      return []
+    # If it's a different error, then we should just exit.
     xpk_exit(1)
 
   storages = []


### PR DESCRIPTION
## Fixes / Features

- Storages may not be defined on a cluster and hence return a 404 failure. Instead, just skip this by returning no storages.

## Testing / Documentation
Tested on v6e-16 cluster.

- [ y ] Tests pass
- [ y ] Appropriate changes to documentation are included in the PR
