### PR TITLE
Fix invalid nvidia libraries mount path for A3 Mega

### DIFF
--- a/src/xpk/core/workload_decorators/tcpxo_decorator.py
+++ b/src/xpk/core/workload_decorators/tcpxo_decorator.py
@@ -137,7 +137,7 @@ def add_volumes(job_manifest):
   volumes = job_manifest['spec']['template']['spec']['volumes']
   volumes.append({
       'name': 'libraries',
-      'hostPath': {'path': '/home/kubernetes/bin/nvidia/lib64'},
+      'hostPath': {'path': '/home/kubernetes/bin/nvidia'},
   })
   volumes.append({'name': 'sys', 'hostPath': {'path': '/sys'}})
   volumes.append({'name': 'proc-sys', 'hostPath': {'path': '/proc/sys'}})
@@ -188,4 +188,7 @@ def update_gpu_containers(job_manifest):
       container.setdefault('volumeMounts', [])
       container['volumeMounts'].append(
           {'name': 'aperture-devices', 'mountPath': '/dev/aperture_devices'}
+      )
+      container['volumeMounts'].append(
+          {'name': 'libraries', 'mountPath': '/usr/local/nvidia'}
       )


### PR DESCRIPTION
## Fixes / Features
- add mounting of `/usr/local/nvidia` volume on gpu-image workloads for A3 Mega
- fix an error causing folder `/home/kubernetes/bin/nvidia/lib64` being mounted at `/usr/local/nvidia` on tcpxo-daemon

## Testing / Documentation
Run `python xpk.py workload create ...` for A3 Mega cluster and check if the jobset yaml that gets generated has correct volume paths.

- [ y/n ] Tests pass
- [ y/n ] Appropriate changes to documentation are included in the PR
