### PR TITLE
De-dupe Superfluous Exit Codes Provided by the User

### DIFF
--- a/src/xpk/commands/workload.py
+++ b/src/xpk/commands/workload.py
@@ -744,7 +744,8 @@ def get_restart_exit_codes(args) -> list:
       else:
         exit_codes.append(int(item))
 
-  return exit_codes
+  # Remove duplicates that the user may have added.
+  return list(set(exit_codes))
 
 
 def workload_delete(args) -> None:


### PR DESCRIPTION
## Fixes / Features

- For `--restart-on-exit-codes`, there are default values already set by XPK, but the user may want to put in a range of many status codes that overlap with the default range (e.g. `range(1, 133, 1)` which overwrites the default values of 42, and 127-132). This PR just de-dupes the exit codes so it's easier for the user to easier express the full range without relying on knowing the internal defaults.

```
[XPK] Waiting for `Creating Workload`, for 0 seconds                                                            
The JobSet "sujin-test-workload" is invalid:                                                 
* spec.replicatedJobs[3].template.spec.podFailurePolicy.rules[0].onExitCodes.values[171]: Duplicate value: 42 
* spec.replicatedJobs[3].template.spec.podFailurePolicy.rules[0].onExitCodes.values[256]: Duplicate value: 127
* spec.replicatedJobs[3].template.spec.podFailurePolicy.rules[0].onExitCodes.values[257]: Duplicate value: 128
* spec.replicatedJobs[3].template.spec.podFailurePolicy.rules[0].onExitCodes.values[258]: Duplicate value: 129
* spec.replicatedJobs[3].template.spec.podFailurePolicy.rules[0].onExitCodes.values[259]: Duplicate value: 130
* spec.replicatedJobs[3].template.spec.podFailurePolicy.rules[0].onExitCodes.values[260]: Duplicate value: 131  
* spec.replicatedJobs[3].template.spec.podFailurePolicy.rules[0].onExitCodes.values[261]: Duplicate value: 132
```

## Testing / Documentation

Tested on v6e cluster.

- [ y ] Tests pass
- [ y ] Appropriate changes to documentation are included in the PR
