### PR TITLE
Add Host Networking with Cluster First DNS to Main Job

### DIFF
--- a/src/xpk/core/pathways.py
+++ b/src/xpk/core/pathways.py
@@ -309,6 +309,8 @@ def get_user_workload_for_pathways(
               serviceAccountName: {service_account}
               nodeSelector:
                 cloud.google.com/gke-nodepool: cpu-user-np
+              hostNetwork: true
+              dnsPolicy: ClusterFirstWithHostNet
               restartPolicy: Never
               volumes:
               - hostPath:


### PR DESCRIPTION
## Fixes / Features

Add Host Networking with Cluster First DNS to Main Job

## Testing / Documentation
Tested at multiple scales on v6e-256 cluster.

- [ y ] Tests pass
- [ y ] Appropriate changes to documentation are included in the PR
