### PR TITLE
[DO NOT MERGE] [Only for the long running PW job] Pathways gcsfuse intergation

### DIFF
--- a/src/xpk/commands/workload.py
+++ b/src/xpk/commands/workload.py
@@ -546,7 +546,10 @@ def workload_create(args) -> None:
         - PodFailurePolicy"""
   restart_on_exit_codes = get_restart_exit_codes(args)
   restart_on_exit_codes = ','.join(map(str, restart_on_exit_codes))
-  pod_failure_policy = f"""
+  if args.use_pathways == True:
+    pod_failure_policy = ''
+  else:
+    pod_failure_policy = f"""
           podFailurePolicy:
             rules:
             - action: FailJob

--- a/src/xpk/core/docker_container.py
+++ b/src/xpk/core/docker_container.py
@@ -149,9 +149,6 @@ def get_main_container(args, system, docker_image, resource_type) -> str:
   if volume_mounts != '':
     yaml += """
                 volumeMounts:
-                - mountPath: /tmp/dataset
-                  name: gcs-dataset-pvc
-                  readOnly: false
                 {volume_mounts}
 """
   return yaml.format(

--- a/src/xpk/core/docker_container.py
+++ b/src/xpk/core/docker_container.py
@@ -149,6 +149,9 @@ def get_main_container(args, system, docker_image, resource_type) -> str:
   if volume_mounts != '':
     yaml += """
                 volumeMounts:
+                - mountPath: /tmp/dataset
+                  name: gcs-dataset-pvc
+                  readOnly: false
                 {volume_mounts}
 """
   return yaml.format(

--- a/src/xpk/core/docker_resources.py
+++ b/src/xpk/core/docker_resources.py
@@ -237,6 +237,12 @@ def get_volume_mounts(args, system: SystemCharacteristics) -> str:
   if args.use_pathways:
     volume_mount_yaml = """- mountPath: /tmp
                   name: shared-tmp
+                - mountPath: /tmp/dataset
+                  name: gcs-dataset-pvc
+                  readOnly: false
+                - mountPath: /tmp/gcsfuse
+                  name: gcs-ckpt-pvc
+                  readOnly: false
                 """
   elif (
       system.accelerator_type == AcceleratorType['TPU']

--- a/src/xpk/core/nodepool.py
+++ b/src/xpk/core/nodepool.py
@@ -318,7 +318,7 @@ def run_gke_node_pool_create_command(
     create_commands.append(command)
     create_task_names.append(task)
 
-  desired_pw_cpu_node_pools = ['cpu-user-np', 'cpu-rm-np', 'cpu-proxy-np']
+  desired_pw_cpu_node_pools = ['cpu-user-np', 'cpu-rm-np', 'cpu-proxy-np', 'high-mem-pool']
   if args.enable_pathways:
     # Pathways needs CPU nodepools in addition to TPU nodepools
     for node_pool_name in desired_pw_cpu_node_pools:

--- a/src/xpk/core/pathways.py
+++ b/src/xpk/core/pathways.py
@@ -318,9 +318,9 @@ def get_user_workload_for_pathways(
               annotations:
                 {gcs_fuse_annotation}
                 gke-gcsfuse/volumes: "true"
-                gke-gcsfuse/cpu-limit: "0"
+                gke-gcsfuse/cpu-limit: "500m"
                 gke-gcsfuse/memory-limit: "0"
-                gke-gcsfuse/ephemeral-storage-limit: "0"
+                gke-gcsfuse/ephemeral-storage-limit: "40Gi"
             spec:
               containers:
               - name: gke-gcsfuse-sidecar
@@ -336,9 +336,15 @@ def get_user_workload_for_pathways(
                   path: /tmp
                   type: DirectoryOrCreate
                 name: shared-tmp
+              - name: gke-gcsfuse-cache
+                emptyDir:
+                  medium: Memory
               - name: gcs-dataset-pvc
                 persistentVolumeClaim:
-                  claimName: dataset-bucket-pvc
+                  claimName: cached-dataset-bucket-pvc
+              - name: gcs-ckpt-pvc
+                persistentVolumeClaim:
+                  claimName: ckpt-bucket-pvc
               {storage_volumes}"""
   if args.headless:
     return ''


### PR DESCRIPTION
## Fixes / Features
- This enables memory mounted gcsfuse buckets for the large scale cluster
- Changes the startup policy of the Pathways pods
- Removes podFailurePolicy from pathways containers

## Testing / Documentation
Verified on a large scale run

The startupPolicy and podFailurePolicy related changes can be merged into main

The gcsfuse related changes are not ready to be merged into main and needs further work:
1. We need to integrate with the [xpk storage API](https://github.com/AI-Hypercomputer/xpk/pull/370) to properly plumb gcsfuse related volumes/volume mounts/annotations into PW container definitions.
2. The changes rely on PV and PVC resources to be already present on the cluster. The storage API integration would also ensure that those resources are created by XPK automatically
