### PR TITLE
Update v6e-8 to use the correct system characteristics

### DIFF
--- a/src/xpk/core/system_characteristics.py
+++ b/src/xpk/core/system_characteristics.py
@@ -187,9 +187,9 @@ UserFacingNameToSystemCharacteristics = {
     ),
     'v6e-8': SystemCharacteristics(
         '2x4',
-        2,
+        1,
         'tpu-v6e-slice',
-        'ct6e-standard-4t',
+        'ct6e-standard-8t',
         4,
         AcceleratorType['TPU'],
         'v6e-8',


### PR DESCRIPTION
Based on https://cloud.google.com/tpu/docs/v6e, the type is ct6e-standard-8t and 1 vm per slice. 

## Fixes / Features
- Fixes v6e-8 type based on documentation
-

## Testing / Documentation
Testing details.

- [ y ] Tests pass
- [ y ] Appropriate changes to documentation are included in the PR