### PR TITLE
Update JOBSET_VERSION from 0.7.2 to 0.8.0

### DIFF
--- a/src/xpk/core/cluster.py
+++ b/src/xpk/core/cluster.py
@@ -32,7 +32,7 @@ from .gcloud_context import add_zone_and_project, get_gke_server_config, zone_to
 from .nodepool import upgrade_gke_nodepools_version
 from .system_characteristics import SystemCharacteristics
 
-JOBSET_VERSION = 'v0.7.2'
+JOBSET_VERSION = 'v0.8.0'
 INSTALLER_NCC_TCPX = 'https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/master/gpudirect-tcpx/nccl-tcpx-installer.yaml'
 INSTALLER_NCC_TCPXO = 'https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/master/gpudirect-tcpxo/nccl-tcpxo-installer.yaml'
 


### PR DESCRIPTION
## Fixes / Features

Upgrades the JOBSET_VERSION used from 0.7.2 to 0.8.0.

For large scale clusters, the jobset controller manager tends to OOM and results in failures that manifest as webhook errors. This is due to memory limit constraints that are fixed in the latest version of jobset. 

## Testing / Documentation
N/A - jobset upgrade.

- [ y ] Tests pass
- [ y ] Appropriate changes to documentation are included in the PR
