### PR TITLE
Remove sudo requirement from make

### DIFF
--- a/.github/workflows/build_tests.yaml
+++ b/.github/workflows/build_tests.yaml
@@ -90,16 +90,7 @@ jobs:
     - uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Check if cache exists
-      id: check-cache
-      uses: actions/cache@v3
-      with:
-        path: |
-          usr/local/bin/
-          ~/.cache/pip
-          ${{env.pythonLocation}}
-        key: xpk-deps-${{ matrix.python-version }}-${{needs.set-variables.outputs.run-id}}
-        lookup-only: true
+
     - name: install dependencies
       if : steps.check-cache.outputs.cache-hit != 'true'
       run: make install-lint && make install-dev && cp ./bin/kubectl-kueue /usr/local/bin/kubectl-kueue && cp ./bin/kubectl-kjob /usr/local/bin/kubectl-kjob

--- a/.github/workflows/build_tests.yaml
+++ b/.github/workflows/build_tests.yaml
@@ -102,7 +102,7 @@ jobs:
         lookup-only: true
     - name: install dependencies
       if : steps.check-cache.outputs.cache-hit != 'true'
-      run: make install-lint && make install-dev
+      run: make install-lint && make install-dev && cp ./bin/kubectl-kueue /usr/local/bin/kubectl-kueue && cp ./bin/kubectl-kjob /usr/local/bin/kubectl-kjob
     - name: Cache dependencies
       if : steps.check-cache.outputs.cache-hit != 'true'
       uses: actions/cache/save@v3

--- a/.github/workflows/build_tests.yaml
+++ b/.github/workflows/build_tests.yaml
@@ -90,7 +90,16 @@ jobs:
     - uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-
+    - name: Check if cache exists
+      id: check-cache
+      uses: actions/cache@v3
+      with:
+        path: |
+          usr/local/bin/
+          ~/.cache/pip
+          ${{env.pythonLocation}}
+        key: xpk-deps-${{ matrix.python-version }}-${{github.run_id	}}-${{github.run_attempt}}
+        lookup-only: true
     - name: install dependencies
       if : steps.check-cache.outputs.cache-hit != 'true'
       run: make install-lint && make install-dev && cp ./bin/kubectl-kueue /usr/local/bin/kubectl-kueue && cp ./bin/kubectl-kjob /usr/local/bin/kubectl-kjob
@@ -103,7 +112,7 @@ jobs:
           /usr/local/bin/kubectl-kjob
           ~/.cache/pip
           ${{env.pythonLocation}}
-        key: xpk-deps-${{ matrix.python-version }}-${{needs.set-variables.outputs.run-id}}
+        key: xpk-deps-${{ matrix.python-version }}-${{github.run_id	}}-${{github.run_attempt}}
   linter:
     needs: [install-dependencies, set-variables]
     concurrency: # We support one build or nightly test to run at a time currently.

--- a/.github/workflows/build_tests.yaml
+++ b/.github/workflows/build_tests.yaml
@@ -98,7 +98,7 @@ jobs:
           usr/local/bin/
           ~/.cache/pip
           ${{env.pythonLocation}}
-        key: xpk-deps-${{ matrix.python-version }}-${{github.run_id	}}-${{github.run_attempt}}
+        key: xpk-deps-${{ matrix.python-version }}-${{github.run_id}}-${{github.run_attempt}}
         lookup-only: true
     - name: install dependencies
       if : steps.check-cache.outputs.cache-hit != 'true'
@@ -112,7 +112,7 @@ jobs:
           /usr/local/bin/kubectl-kjob
           ~/.cache/pip
           ${{env.pythonLocation}}
-        key: xpk-deps-${{ matrix.python-version }}-${{github.run_id	}}-${{github.run_attempt}}
+        key: xpk-deps-${{ matrix.python-version }}-${{github.run_id}}-${{github.run_attempt}}
   linter:
     needs: [install-dependencies, set-variables]
     concurrency: # We support one build or nightly test to run at a time currently.

--- a/.github/workflows/reusable_batch_tests.yaml
+++ b/.github/workflows/reusable_batch_tests.yaml
@@ -56,7 +56,7 @@ jobs:
           /usr/local/bin/kubectl-kjob
           ~/.cache/pip
           ${{env.pythonLocation}}
-        key: xpk-deps-3.10-${{github.run_id	}}-${{github.run_attempt}}
+        key: xpk-deps-3.10-${{github.run_id}}-${{github.run_attempt}}
         restore-keys: xpk-deps-3.10
     - name: Install expect package
       run: sudo apt-get install expect

--- a/.github/workflows/reusable_batch_tests.yaml
+++ b/.github/workflows/reusable_batch_tests.yaml
@@ -56,7 +56,7 @@ jobs:
           /usr/local/bin/kubectl-kjob
           ~/.cache/pip
           ${{env.pythonLocation}}
-        key: xpk-deps-3.10-${{inputs.run-id}}
+        key: xpk-deps-3.10-${{github.run_id	}}-${{github.run_attempt}}
         restore-keys: xpk-deps-3.10
     - name: Install expect package
       run: sudo apt-get install expect

--- a/.github/workflows/reusable_cluster_create.yaml
+++ b/.github/workflows/reusable_cluster_create.yaml
@@ -59,7 +59,7 @@ jobs:
           /usr/local/bin/kubectl-kjob
           ~/.cache/pip
           ${{env.pythonLocation}}
-        key: xpk-deps-3.10-${{github.run_id	}}-${{github.run_attempt}}
+        key: xpk-deps-3.10-${{github.run_id}}-${{github.run_attempt}}
         restore-keys: xpk-deps-3.10-
     - uses: 'google-github-actions/auth@v2'
       with:

--- a/.github/workflows/reusable_cluster_create.yaml
+++ b/.github/workflows/reusable_cluster_create.yaml
@@ -59,7 +59,7 @@ jobs:
           /usr/local/bin/kubectl-kjob
           ~/.cache/pip
           ${{env.pythonLocation}}
-        key: xpk-deps-3.10-${{inputs.run-id}}
+        key: xpk-deps-3.10-${{github.run_id	}}-${{github.run_attempt}}
         restore-keys: xpk-deps-3.10-
     - uses: 'google-github-actions/auth@v2'
       with:

--- a/.github/workflows/reusable_cluster_delete.yaml
+++ b/.github/workflows/reusable_cluster_delete.yaml
@@ -55,7 +55,7 @@ jobs:
           /usr/local/bin/kubectl-kjob
           ~/.cache/pip
           ${{env.pythonLocation}}
-        key: xpk-deps-3.10-${{github.run_id	}}-${{github.run_attempt}}
+        key: xpk-deps-3.10-${{github.run_id}}-${{github.run_attempt}}
         restore-keys: xpk-deps-3.10
     - name: Check xpk installation
       run: xpk --help

--- a/.github/workflows/reusable_cluster_delete.yaml
+++ b/.github/workflows/reusable_cluster_delete.yaml
@@ -55,7 +55,7 @@ jobs:
           /usr/local/bin/kubectl-kjob
           ~/.cache/pip
           ${{env.pythonLocation}}
-        key: xpk-deps-3.10-${{inputs.run-id}}
+        key: xpk-deps-3.10-${{github.run_id	}}-${{github.run_attempt}}
         restore-keys: xpk-deps-3.10
     - name: Check xpk installation
       run: xpk --help

--- a/.github/workflows/reusable_cluster_private.yaml
+++ b/.github/workflows/reusable_cluster_private.yaml
@@ -67,7 +67,7 @@ jobs:
           /usr/local/bin/kubectl-kjob
           ~/.cache/pip
           ${{env.pythonLocation}}
-        key: xpk-deps-3.10-${{github.run_id	}}-${{github.run_attempt}}
+        key: xpk-deps-3.10-${{github.run_id}}-${{github.run_attempt}}
         restore-keys: xpk-deps-3.10
     - name: Set Google Cloud CLI properties to a unused zone to verify --zone arg is passed properly in commands.
       run: |

--- a/.github/workflows/reusable_cluster_private.yaml
+++ b/.github/workflows/reusable_cluster_private.yaml
@@ -67,7 +67,7 @@ jobs:
           /usr/local/bin/kubectl-kjob
           ~/.cache/pip
           ${{env.pythonLocation}}
-        key: xpk-deps-3.10-${{inputs.run-id}}
+        key: xpk-deps-3.10-${{github.run_id	}}-${{github.run_attempt}}
         restore-keys: xpk-deps-3.10
     - name: Set Google Cloud CLI properties to a unused zone to verify --zone arg is passed properly in commands.
       run: |

--- a/.github/workflows/reusable_integration_tests.yaml
+++ b/.github/workflows/reusable_integration_tests.yaml
@@ -46,7 +46,7 @@ jobs:
             /usr/local/bin/kubectl-kjob
             ~/.cache/pip
             ${{env.pythonLocation}}
-          key: xpk-deps-3.10-${{github.run_id	}}-${{github.run_attempt}}
+          key: xpk-deps-3.10-${{github.run_id}}-${{github.run_attempt}}
           restore-keys: xpk-deps-3.10
       - name: "Set auth cidr"
         run: echo "AUTH_CIDR=$(curl api.ipify.org)/32" >> $GITHUB_ENV

--- a/.github/workflows/reusable_integration_tests.yaml
+++ b/.github/workflows/reusable_integration_tests.yaml
@@ -46,7 +46,7 @@ jobs:
             /usr/local/bin/kubectl-kjob
             ~/.cache/pip
             ${{env.pythonLocation}}
-          key: xpk-deps-3.10-${{inputs.run-id}}
+          key: xpk-deps-3.10-${{github.run_id	}}-${{github.run_attempt}}
           restore-keys: xpk-deps-3.10
       - name: "Set auth cidr"
         run: echo "AUTH_CIDR=$(curl api.ipify.org)/32" >> $GITHUB_ENV

--- a/.github/workflows/reusable_lint_and_format.yml
+++ b/.github/workflows/reusable_lint_and_format.yml
@@ -43,7 +43,7 @@ jobs:
           /usr/local/bin/kubectl-kjob
           ~/.cache/pip
           ${{env.pythonLocation}}
-        key: xpk-deps-${{matrix.python-version}}-${{inputs.run-id}}
+        key: xpk-deps-${{matrix.python-version}}-${{github.run_id	}}-${{github.run_attempt}}
         restore-keys: xpk-deps-${{matrix.python-version}}-
     - name: Run pylint
       run: make pylint

--- a/.github/workflows/reusable_lint_and_format.yml
+++ b/.github/workflows/reusable_lint_and_format.yml
@@ -43,7 +43,7 @@ jobs:
           /usr/local/bin/kubectl-kjob
           ~/.cache/pip
           ${{env.pythonLocation}}
-        key: xpk-deps-${{matrix.python-version}}-${{github.run_id	}}-${{github.run_attempt}}
+        key: xpk-deps-${{matrix.python-version}}-${{github.run_id}}-${{github.run_attempt}}
         restore-keys: xpk-deps-${{matrix.python-version}}-
     - name: Run pylint
       run: make pylint

--- a/.github/workflows/reusable_storage_tests_by_type.yaml
+++ b/.github/workflows/reusable_storage_tests_by_type.yaml
@@ -108,7 +108,7 @@ jobs:
             /usr/local/bin/kubectl-kjob
             ~/.cache/pip
             ${{env.pythonLocation}}
-        key: xpk-deps-3.10-${{inputs.run-id}}
+        key: xpk-deps-3.10-${{github.run_id	}}-${{github.run_attempt}}
         restore-keys: xpk-deps-3.10-
     - name: Verify xpk installation
       run: xpk --help

--- a/.github/workflows/reusable_storage_tests_by_type.yaml
+++ b/.github/workflows/reusable_storage_tests_by_type.yaml
@@ -108,7 +108,7 @@ jobs:
             /usr/local/bin/kubectl-kjob
             ~/.cache/pip
             ${{env.pythonLocation}}
-        key: xpk-deps-3.10-${{github.run_id	}}-${{github.run_attempt}}
+        key: xpk-deps-3.10-${{github.run_id}}-${{github.run_attempt}}
         restore-keys: xpk-deps-3.10-
     - name: Verify xpk installation
       run: xpk --help

--- a/.github/workflows/reusable_unit_tests.yaml
+++ b/.github/workflows/reusable_unit_tests.yaml
@@ -37,7 +37,7 @@ jobs:
           /usr/local/bin/kubectl-kjob
           ~/.cache/pip
           ${{env.pythonLocation}}
-        key: xpk-deps-3.10-${{github.run_id	}}-${{github.run_attempt}}
+        key: xpk-deps-3.10-${{github.run_id}}-${{github.run_attempt}}
         restore-keys: xpk-deps-3.10-
     # - name: Install dependecies
     #   run: make install-dev

--- a/.github/workflows/reusable_unit_tests.yaml
+++ b/.github/workflows/reusable_unit_tests.yaml
@@ -37,7 +37,7 @@ jobs:
           /usr/local/bin/kubectl-kjob
           ~/.cache/pip
           ${{env.pythonLocation}}
-        key: xpk-deps-3.10-${{inputs.run-id}}
+        key: xpk-deps-3.10-${{github.run_id	}}-${{github.run_attempt}}
         restore-keys: xpk-deps-3.10-
     # - name: Install dependecies
     #   run: make install-dev

--- a/.github/workflows/reusable_workload_tests.yaml
+++ b/.github/workflows/reusable_workload_tests.yaml
@@ -59,7 +59,7 @@ jobs:
           /usr/local/bin/kubectl-kjob
           ~/.cache/pip
           ${{env.pythonLocation}}
-        key: xpk-deps-3.10-${{github.run_id	}}-${{github.run_attempt}}
+        key: xpk-deps-3.10-${{github.run_id}}-${{github.run_attempt}}
         restore-keys: xpk-deps-3.10-
     - name: Set Google Cloud CLI properties to a unused zone to verify --zone arg is passed properly in commands.
       run: |

--- a/.github/workflows/reusable_workload_tests.yaml
+++ b/.github/workflows/reusable_workload_tests.yaml
@@ -59,7 +59,7 @@ jobs:
           /usr/local/bin/kubectl-kjob
           ~/.cache/pip
           ${{env.pythonLocation}}
-        key: xpk-deps-3.10-${{inputs.run-id}}
+        key: xpk-deps-3.10-${{github.run_id	}}-${{github.run_attempt}}
         restore-keys: xpk-deps-3.10-
     - name: Set Google Cloud CLI properties to a unused zone to verify --zone arg is passed properly in commands.
       run: |

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,6 @@ PROJECT_DIR := $(realpath $(shell dirname $(firstword $(MAKEFILE_LIST))))
 KJOB_DOCKER_IMG := xpk_kjob
 KJOB_DOCKER_CONTAINER := xpk_kjob_container
 BIN_PATH=$(PROJECT_DIR)/bin
-USR_BIN_PATH=/usr/local/bin
 
 .PHONY: install
 install: check-python check-gcloud install-gcloud-auth-plugin install-kueuectl install-kjobctl pip-install

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,6 @@ mkdir-bin:
 install-kueuectl: mkdir-bin
 	curl -Lo $(BIN_PATH)/kubectl-kueue $(KUEUECTL_URL);
 	chmod +x $(BIN_PATH)/kubectl-kueue;
-	sudo mv -f $(BIN_PATH)/kubectl-kueue $(USR_BIN_PATH)/kubectl-kueue;
 
 .PHONY: install-kjobctl
 install-kjobctl: mkdir-bin
@@ -58,7 +57,6 @@ install-kjobctl: mkdir-bin
 	docker cp $(KJOB_DOCKER_CONTAINER):/kjob/bin/kubectl-kjob $(BIN_PATH)/kubectl-kjob;
 	docker rm -f $(KJOB_DOCKER_CONTAINER);
 	docker image rm $(KJOB_DOCKER_IMG);
-	sudo mv -f $(BIN_PATH)/kubectl-kjob $(USR_BIN_PATH)/kubectl-kjob;
 
 .PHONY: install-gcloud-auth-plugin
 install-gcloud-auth-plugin:


### PR DESCRIPTION
## Fixes / Features
- To avoid requirement for `export PATH=$PATH:$PWD/bin` we used to copy kjob and kueuectl binaries to user's bin directory. It needed `sudo`. Now sudo is removed because it made problems for the users scripts.
- Now it's required to run `export PATH=$PATH:$PWD/bin` 

## Testing / Documentation
Testing details.

- [ y/n ] Tests pass
- [ y/n ] Appropriate changes to documentation are included in the PR
