### PR TITLE
Implement Parallelstore and Hyperdisk storages attach 

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,11 @@ and the following GPU types:
 and the following CPU types:
 * n2-standard-32
 
-xpk also supports Google Cloud Storage solutions:
+xpk also supports [Google Cloud Storage solutions](#storage):
 * [Cloud Storage FUSE](#fuse)
 * [Filestore](#filestore)
 * [Parallelstore](#parallelstore)
+* [Block storage (Persistent Disk, Hyperdisk)](#block-storage-persistent-disk-hyperdisk)
 
 # Permissions needed on Cloud Console:
 
@@ -444,10 +445,11 @@ Currently, the below flags/arguments are supported for A3-Mega and A3-Ultra mach
 
 
 ## Storage
-Currently XPK supports three types of storages:
-- Cloud Storage FUSE
-- Google Cloud Filestore
-- Google Cloud Parallelstore
+Currently XPK supports the below types of storages:
+- [Cloud Storage FUSE](#fuse)
+- [Google Cloud Filestore](#filestore)
+- [Google Cloud Parallelstore](#parallelstore)
+- [Google Cloud Block storages (Persistent Disk, Hyperdisk)](#block-storage-persistent-disk-hyperdisk)
 
 ### FUSE
 A FUSE adapter lets you mount and access Cloud Storage buckets as local file systems, so applications can read and write objects in your bucket using standard file system semantics.
@@ -528,6 +530,30 @@ python3 xpk.py storage attach test-parallelstore-storage --type=parallelstore \
 Parameters:
 
 - `--type` - type of the storage `parallelstore`
+- `--auto-mount` - if set to true all workloads will have this storage mounted by default.
+- `--mount-point` - the path on which this storage should be mounted for a workload.
+- `--readonly` - if set to true, workload can only read from storage.
+- `--manifest` - path to the manifest file containing PersistentVolume and PresistentVolumeClaim definitions.
+
+### Block storage (Persistent Disk, Hyperdisk)
+
+A PersistentDisk adapter lets you mount and access Google Cloud Block storage solutions ([Persistent Disk](https://cloud.google.com/kubernetes-engine/docs/concepts/storage-overview#pd), [Hyperdisk](https://cloud.google.com/kubernetes-engine/docs/concepts/storage-overview#hyperdisk)) as local file systems, so applications can read and write files in your volumes using standard file system semantics.
+
+To use the GCE PersistentDisk with XPK you need to create a [disk in GCE](https://cloud.google.com/compute/docs/disks). Please consider that the disk type you are creating is [compatible with the VMs](https://cloud.google.com/compute/docs/machine-resource#machine_type_comparison) in the default and accelerator nodepools.
+
+Once it's ready you can use `xpk storage attach` with `--type=pd` command to attach a PersistentDisk instance to your cluster. Currently, attaching a PersistentDisk is supported only by providing a manifest file.
+
+```shell
+python3 xpk.py storage attach test-pd-storage --type=pd \
+  --project=$PROJECT --cluster=$CLUSTER --zone=$ZONE \
+  --mount-point='/test-mount-point' --readonly=false \
+  --auto-mount=true \
+  --manifest='./examples/storage/pd-manifest-attach.yaml'
+```
+
+Parameters:
+
+- `--type` - type of the storage `pd`
 - `--auto-mount` - if set to true all workloads will have this storage mounted by default.
 - `--mount-point` - the path on which this storage should be mounted for a workload.
 - `--readonly` - if set to true, workload can only read from storage.

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ and the following CPU types:
 xpk also supports Google Cloud Storage solutions:
 * [Cloud Storage FUSE](#fuse)
 * [Filestore](#filestore)
+* [Parallelstore](#parallelstore)
 
 # Permissions needed on Cloud Console:
 
@@ -443,7 +444,10 @@ Currently, the below flags/arguments are supported for A3-Mega and A3-Ultra mach
 
 
 ## Storage
-Currently XPK supports two types of storages: Cloud Storage FUSE and Google Cloud Filestore.
+Currently XPK supports three types of storages:
+- Cloud Storage FUSE
+- Google Cloud Filestore
+- Google Cloud Parallelstore
 
 ### FUSE
 A FUSE adapter lets you mount and access Cloud Storage buckets as local file systems, so applications can read and write objects in your bucket using standard file system semantics.
@@ -471,7 +475,7 @@ Parameters:
 
 ### Filestore
 
-A Filestore adapter lets you mount and access [Filestore instances](https://cloud.google.com/filestore/) as local file systems, so applications can read and write objects in your volumes using standard file system semantics.
+A Filestore adapter lets you mount and access [Filestore instances](https://cloud.google.com/filestore/) as local file systems, so applications can read and write files in your volumes using standard file system semantics.
 
 To create and attach a GCP Filestore instance to your cluster use `xpk storage create` command with `--type=gcpfilestore`:
 
@@ -504,6 +508,30 @@ Commands `xpk storage create` and `xpk storage attach` with `--type=gcpfilestore
 - `--vol` - file share name of the Filestore instance that will be created.
 - `--instance` - the name of the Filestore instance. If not set then the name parameter is used as an instance name. Useful when connecting multiple volumes from the same Filestore instance.
 - `--manifest` - path to the manifest file containing PersistentVolume, PresistentVolumeClaim and StorageClass definitions. If set, then values from manifest override the following parameters: `--access-mode`, `--size` and `--volume`.
+
+### Parallelstore
+
+A Parallelstore adapter lets you mount and access [Parallelstore instances](https://cloud.google.com/parallelstore/) as local file systems, so applications can read and write files in your volumes using standard file system semantics.
+
+To use the GCS Parallelstore with XPK you need to create a [Parallelstore Instance](https://console.cloud.google.com/parallelstore/).
+
+Once it's ready you can use `xpk storage attach` with `--type=parallelstore` command to attach a Parallelstore instance to your cluster. Currently, attaching a Parallelstore is supported only by providing a manifest file.
+
+```shell
+python3 xpk.py storage attach test-parallelstore-storage --type=parallelstore \
+  --project=$PROJECT --cluster=$CLUSTER --zone=$ZONE \
+  --mount-point='/test-mount-point' --readonly=false \
+  --auto-mount=true \
+  --manifest='./examples/storage/parallelstore-manifest-attach.yaml'
+```
+
+Parameters:
+
+- `--type` - type of the storage `parallelstore`
+- `--auto-mount` - if set to true all workloads will have this storage mounted by default.
+- `--mount-point` - the path on which this storage should be mounted for a workload.
+- `--readonly` - if set to true, workload can only read from storage.
+- `--manifest` - path to the manifest file containing PersistentVolume and PresistentVolumeClaim definitions.
 
 ### List attached storages
 

--- a/examples/storage/parallelstore-manifest-attach.yaml
+++ b/examples/storage/parallelstore-manifest-attach.yaml
@@ -1,0 +1,48 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: xpk-parallelstore-pv
+spec:
+  storageClassName: xpk-parallelstore-class
+  capacity:
+    storage: 12000Gi
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  volumeMode: Filesystem
+  csi:
+    driver: parallelstore.csi.storage.gke.io
+    volumeHandle: "supercomputer-testing/europe-west1-b/xpk-l4-12/default-pool/default-container"
+    volumeAttributes:
+      accessPoints: 10.159.112.4, 10.159.112.3, 10.159.112.2
+      network: projects/supercomputer-testing/global/networks/xpk-l4-12-net-1
+  claimRef:
+    name: xpk-parallelstore-pvc
+    namespace: default
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: xpk-parallelstore-pvc
+  namespace: default
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: xpk-parallelstore-class
+  resources:
+    requests:
+      storage: 12000Gi
+#---
+# kind: StorageClass
+# apiVersion: storage.k8s.io/v1
+# metadata:
+#   name: xpk-parallelstore-class
+#   namespace: default
+# provisioner: parallelstore.csi.storage.gke.io
+# volumeBindingMode: Immediate
+# reclaimPolicy: Delete
+# allowedTopologies:
+# - matchLabelExpressions:
+#   - key: topology.gke.io/zone
+#     values:
+#       europe-west1-b

--- a/examples/storage/parallelstore-manifest-attach.yaml
+++ b/examples/storage/parallelstore-manifest-attach.yaml
@@ -5,17 +5,17 @@ metadata:
 spec:
   storageClassName: xpk-parallelstore-class
   capacity:
-    storage: 12000Gi
+    storage: STORAGE_SIZE #ex: 12000Gi
   accessModes:
     - ReadWriteMany
   persistentVolumeReclaimPolicy: Retain
   volumeMode: Filesystem
   csi:
     driver: parallelstore.csi.storage.gke.io
-    volumeHandle: "supercomputer-testing/europe-west1-b/xpk-l4-12/default-pool/default-container"
+    volumeHandle: "PROJECT_ID/ZONE/INSTANCE_NAME/default-pool/default-container"
     volumeAttributes:
-      accessPoints: 10.159.112.4, 10.159.112.3, 10.159.112.2
-      network: projects/supercomputer-testing/global/networks/xpk-l4-12-net-1
+      accessPoints: IP_ADDRESSES #comma separated
+      network: projects/PROJECT_ID/global/networks/NETWORK_NAME #VPC Network
   claimRef:
     name: xpk-parallelstore-pvc
     namespace: default
@@ -31,18 +31,4 @@ spec:
   storageClassName: xpk-parallelstore-class
   resources:
     requests:
-      storage: 12000Gi
-#---
-# kind: StorageClass
-# apiVersion: storage.k8s.io/v1
-# metadata:
-#   name: xpk-parallelstore-class
-#   namespace: default
-# provisioner: parallelstore.csi.storage.gke.io
-# volumeBindingMode: Immediate
-# reclaimPolicy: Delete
-# allowedTopologies:
-# - matchLabelExpressions:
-#   - key: topology.gke.io/zone
-#     values:
-#       europe-west1-b
+      storage: STORAGE_SIZE #ex: 12000Gi

--- a/examples/storage/pd-manifest-attach.yaml
+++ b/examples/storage/pd-manifest-attach.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: xpk-pd-pv
+spec:
+  storageClassName: "xpk-pd-class"
+  capacity:
+    storage: STORAGE_SIZE #ex: 100G
+  accessModes:
+    - ReadWriteOnce
+  claimRef:
+    name: xpk-pd-pvc
+    namespace: default
+  csi:
+    driver: pd.csi.storage.gke.io
+    volumeHandle: projects/PROJECT_ID/zones/ZONE/disks/INSTANCE_NAME #for regional: projects/PROJECT_ID/regions/REGION/disks/INSTANCE_NAME
+    fsType: ext4
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  namespace: default
+  name: xpk-pd-pvc
+spec:
+  storageClassName: "xpk-pd-class"
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: STORAGE_SIZE #ex: 100G

--- a/src/xpk/commands/batch.py
+++ b/src/xpk/commands/batch.py
@@ -22,7 +22,7 @@ from ..core.gcloud_context import add_zone_and_project
 from ..core.kueue import LOCAL_QUEUE_NAME
 from ..utils.console import xpk_exit, xpk_print
 from .common import set_cluster_command
-from ..core.kjob import AppProfileDefaults, JobTemplateDefaults, prepare_kjob, Kueue_TAS_annotation, get_gcsfuse_annotation
+from ..core.kjob import AppProfileDefaults, JobTemplateDefaults, prepare_kjob, Kueue_TAS_annotation, get_storage_annotations
 from .kjob_common import add_gpu_networking_annotations_to_command
 from .kind import set_local_cluster_command
 import re
@@ -66,9 +66,9 @@ def submit_job(args: Namespace) -> None:
       ' --first-node-ip'
   )
   cmd = add_gpu_networking_annotations_to_command(args, cmd)
-  gcsfuse_annotation = get_gcsfuse_annotation(args)
-  if gcsfuse_annotation is not None:
-    cmd += f' --pod-template-annotation {gcsfuse_annotation}'
+
+  for annotation in get_storage_annotations(args):
+    cmd += f' --pod-template-annotation {annotation}'
 
   if args.ignore_unknown_flags:
     cmd += ' --ignore-unknown-flags'

--- a/src/xpk/commands/cluster.py
+++ b/src/xpk/commands/cluster.py
@@ -25,6 +25,8 @@ from ..core.cluster import (
     setup_k8s_env,
     update_cluster_with_gcsfuse_driver_if_necessary,
     update_cluster_with_workload_identity_if_necessary,
+    update_cluster_with_gcpfilestore_driver_if_necessary,
+    update_cluster_with_parallelstore_driver_if_necessary,
 )
 from ..core.cluster_private import authorize_private_cluster_access_if_necessary
 from ..core.commands import run_command_for_value, run_command_with_updates
@@ -64,7 +66,6 @@ from ..utils.console import get_user_input, xpk_exit, xpk_print
 from ..utils.file import write_tmp_file
 from . import cluster_gcluster
 from .common import set_cluster_command
-from ..core.cluster import update_cluster_with_gcpfilestore_driver_if_necessary
 
 
 def cluster_create(args) -> None:
@@ -117,11 +118,7 @@ def cluster_create(args) -> None:
 
   # ToDo(roshanin@) - Re-enable CloudDNS on Pathways clusters conditionally.
   # Enable WorkloadIdentity if not enabled already.
-  if (
-      args.enable_workload_identity
-      or args.enable_gcsfuse_csi_driver
-      or args.enable_gcpfilestore_csi_driver
-  ):
+  if args.enable_workload_identity or args.enable_gcsfuse_csi_driver:
     update_cluster_command_code = (
         update_cluster_with_workload_identity_if_necessary(args)
     )
@@ -139,6 +136,13 @@ def cluster_create(args) -> None:
   if args.enable_gcpfilestore_csi_driver:
     update_cluster_command_code = (
         update_cluster_with_gcpfilestore_driver_if_necessary(args)
+    )
+    if update_cluster_command_code != 0:
+      xpk_exit(update_cluster_command_code)
+
+  if args.enable_parallelstore_csi_driver:
+    update_cluster_command_code = (
+        update_cluster_with_parallelstore_driver_if_necessary(args)
     )
     if update_cluster_command_code != 0:
       xpk_exit(update_cluster_command_code)
@@ -782,11 +786,7 @@ def run_gke_cluster_create_command(
   if args.enable_ray_cluster:
     command += ' --addons RayOperator'
 
-  if (
-      args.enable_workload_identity
-      or args.enable_gcsfuse_csi_driver
-      or args.enable_gcpfilestore_csi_driver
-  ):
+  if args.enable_workload_identity or args.enable_gcsfuse_csi_driver:
     command += f' --workload-pool={args.project}.svc.id.goog'
 
   addons = []
@@ -795,6 +795,9 @@ def run_gke_cluster_create_command(
 
   if args.enable_gcpfilestore_csi_driver:
     addons.append('GcpFilestoreCsiDriver')
+
+  if args.enable_parallelstore_csi_driver:
+    addons.append('ParallelstoreCsiDriver')
 
   if len(addons) > 0:
     addons_str = ','.join(addons)

--- a/src/xpk/commands/cluster.py
+++ b/src/xpk/commands/cluster.py
@@ -27,6 +27,7 @@ from ..core.cluster import (
     update_cluster_with_workload_identity_if_necessary,
     update_cluster_with_gcpfilestore_driver_if_necessary,
     update_cluster_with_parallelstore_driver_if_necessary,
+    update_cluster_with_pd_driver_if_necessary,
 )
 from ..core.cluster_private import authorize_private_cluster_access_if_necessary
 from ..core.commands import run_command_for_value, run_command_with_updates
@@ -143,6 +144,13 @@ def cluster_create(args) -> None:
   if args.enable_parallelstore_csi_driver:
     update_cluster_command_code = (
         update_cluster_with_parallelstore_driver_if_necessary(args)
+    )
+    if update_cluster_command_code != 0:
+      xpk_exit(update_cluster_command_code)
+
+  if args.enable_pd_csi_driver:
+    update_cluster_command_code = update_cluster_with_pd_driver_if_necessary(
+        args
     )
     if update_cluster_command_code != 0:
       xpk_exit(update_cluster_command_code)
@@ -798,6 +806,9 @@ def run_gke_cluster_create_command(
 
   if args.enable_parallelstore_csi_driver:
     addons.append('ParallelstoreCsiDriver')
+
+  if args.enable_pd_csi_driver:
+    addons.append('GcePersistentDiskCsiDriver')
 
   if len(addons) > 0:
     addons_str = ','.join(addons)

--- a/src/xpk/commands/kjob_common.py
+++ b/src/xpk/commands/kjob_common.py
@@ -28,9 +28,9 @@ def add_tcpxo_annotations(args, cmd) -> str:
 
 
 def add_rdma_annotations(args, cmd) -> str:
-  eth0, interfaces = get_a3ultra_pod_template_annotations(args)
-  cmd += f" --pod-template-annotation {eth0} \\\n"
-  cmd += f" --pod-template-annotation {interfaces} \\\n"
+  # eth0, interfaces = get_a3ultra_pod_template_annotations(args)
+  # cmd += f" --pod-template-annotation {eth0} \\\n"
+  # cmd += f" --pod-template-annotation {interfaces} \\\n"
   return cmd
 
 

--- a/src/xpk/commands/kjob_common.py
+++ b/src/xpk/commands/kjob_common.py
@@ -28,9 +28,9 @@ def add_tcpxo_annotations(args, cmd) -> str:
 
 
 def add_rdma_annotations(args, cmd) -> str:
-  # eth0, interfaces = get_a3ultra_pod_template_annotations(args)
-  # cmd += f" --pod-template-annotation {eth0} \\\n"
-  # cmd += f" --pod-template-annotation {interfaces} \\\n"
+  eth0, interfaces = get_a3ultra_pod_template_annotations(args)
+  cmd += f" --pod-template-annotation {eth0} \\\n"
+  cmd += f" --pod-template-annotation {interfaces} \\\n"
   return cmd
 
 

--- a/src/xpk/commands/run.py
+++ b/src/xpk/commands/run.py
@@ -22,7 +22,7 @@ from ..core.gcloud_context import add_zone_and_project
 from ..core.kueue import LOCAL_QUEUE_NAME
 from ..utils.console import xpk_exit, xpk_print
 from .common import set_cluster_command
-from ..core.kjob import JobTemplateDefaults, AppProfileDefaults, prepare_kjob, Kueue_TAS_annotation, get_gcsfuse_annotation
+from ..core.kjob import JobTemplateDefaults, AppProfileDefaults, prepare_kjob, Kueue_TAS_annotation, get_storage_annotations
 from .kjob_common import add_gpu_networking_annotations_to_command
 from .kind import set_local_cluster_command
 
@@ -64,9 +64,8 @@ def submit_job(args: Namespace) -> None:
   )
   cmd = add_gpu_networking_annotations_to_command(args, cmd)
 
-  gcsfuse_annotation = get_gcsfuse_annotation(args)
-  if gcsfuse_annotation is not None:
-    cmd += f' --pod-template-annotation {gcsfuse_annotation}'
+  for annotation in get_storage_annotations(args):
+    cmd += f' --pod-template-annotation {annotation}'
 
   if args.timeout:
     cmd += f' --wait-timeout {args.timeout}s'

--- a/src/xpk/commands/shell.py
+++ b/src/xpk/commands/shell.py
@@ -20,7 +20,7 @@ from ..core.kjob import (
     AppProfileDefaults,
     prepare_kjob,
     get_pod_template_interactive_command,
-    get_gcsfuse_annotation,
+    get_storage_annotations,
 )
 
 exit_instructions = 'To exit the shell input "exit".'
@@ -89,9 +89,8 @@ def connect_to_new_interactive_shell(args: Namespace) -> int:
       f' {AppProfileDefaults.NAME.value} --pod-running-timeout 180s'
   )
 
-  gcsfuse_annotation = get_gcsfuse_annotation(args)
-  if gcsfuse_annotation is not None:
-    cmd += f' --pod-template-annotation {gcsfuse_annotation}'
+  for annotation in get_storage_annotations(args):
+    cmd += f' --pod-template-annotation {annotation}'
 
   return run_command_with_full_controls(
       command=cmd,

--- a/src/xpk/commands/storage.py
+++ b/src/xpk/commands/storage.py
@@ -134,6 +134,7 @@ def storage_delete(args: Namespace) -> None:
 
 def storage_attach(args: Namespace) -> None:
   add_zone_and_project(args)
+  manifest = [{}]
   if args.type == GCP_FILESTORE_TYPE:
     if args.instance is None:
       args.instance = args.name

--- a/src/xpk/commands/storage.py
+++ b/src/xpk/commands/storage.py
@@ -27,6 +27,7 @@ from ..core.cluster import (
     add_zone_and_project,
     get_cluster_network,
     setup_k8s_env,
+    update_cluster_with_parallelstore_driver_if_necessary,
     update_cluster_with_gcpfilestore_driver_if_necessary,
     update_cluster_with_gcsfuse_driver_if_necessary,
     update_cluster_with_workload_identity_if_necessary,
@@ -41,6 +42,7 @@ from ..core.kjob import (
 from ..core.storage import (
     GCP_FILESTORE_TYPE,
     GCS_FUSE_TYPE,
+    PARALLELSTORE_TYPE,
     STORAGE_CRD_PLURAL,
     XPK_API_GROUP_NAME,
     XPK_API_GROUP_VERSION,
@@ -86,9 +88,10 @@ def storage_create(args: Namespace) -> None:
     create_volume_bundle_instance(
         k8s_api_client, args.name, manifest, args.readonly, args.mount_point
     )
-    return_code = update_cluster_with_workload_identity_if_necessary(args)
-    if return_code > 0:
-      xpk_exit(return_code)
+    # Not required for Filestore. Will be uncommented when adding GCSFuse create
+    # return_code = update_cluster_with_workload_identity_if_necessary(args)
+    # if return_code > 0:
+    #   xpk_exit(return_code)
     return_code = update_cluster_with_gcpfilestore_driver_if_necessary(args)
     if return_code > 0:
       xpk_exit(return_code)
@@ -151,7 +154,7 @@ def storage_attach(args: Namespace) -> None:
           args.name, args.vol, args.access_mode, filestore_network
       )
 
-  else:  # args.type == GCS_FUSE_TYPE:
+  elif args.type == GCS_FUSE_TYPE:
     if args.manifest is None and args.size is None:
       xpk_print("--size is required when attaching gcsfuse storage.")
       xpk_exit(1)
@@ -167,25 +170,48 @@ def storage_attach(args: Namespace) -> None:
           name=args.name, bucket=args.bucket, size=args.size
       )
 
+  elif args.type == PARALLELSTORE_TYPE:
+    if args.manifest is None:
+      xpk_print("Parallelstore is currently only supported with --manifest")
+      xpk_exit(1)
+
+    with open(args.manifest, "r", encoding="utf-8") as f:
+      manifest = list(yaml.safe_load_all(f))
+
+  else:
+    xpk_print(f"Storage type {args.type} is not supported.")
+    xpk_exit(1)
+
   k8s_api_client = setup_k8s_env(args)
   create_storage_crds(k8s_api_client, args, manifest)
   create_volume_bundle_instance(
       k8s_api_client, args.name, manifest, args.readonly, args.mount_point
   )
-  return_code = update_cluster_with_workload_identity_if_necessary(args)
-  if return_code > 0:
-    xpk_exit(return_code)
 
-  # args.type can have only two values after parsing
-  return_code = (
-      update_cluster_with_gcsfuse_driver_if_necessary(args)
-      if args.type == GCS_FUSE_TYPE
-      else update_cluster_with_gcpfilestore_driver_if_necessary(args)
-  )
-  if return_code > 0:
-    xpk_exit(return_code)
+  enable_csi_drivers_if_necessary(args)
 
   apply_kubectl_manifest(k8s_api_client, manifest)
+
+
+def enable_csi_drivers_if_necessary(args: Namespace) -> None:
+  if args.type == GCS_FUSE_TYPE:
+    return_code = update_cluster_with_workload_identity_if_necessary(args)
+    if return_code > 0:
+      xpk_exit(return_code)
+
+    return_code = update_cluster_with_gcsfuse_driver_if_necessary(args)
+    if return_code > 0:
+      xpk_exit(return_code)
+
+  if args.type == GCP_FILESTORE_TYPE:
+    return_code = update_cluster_with_gcpfilestore_driver_if_necessary(args)
+    if return_code > 0:
+      xpk_exit(return_code)
+
+  if args.type == PARALLELSTORE_TYPE:
+    return_code = update_cluster_with_parallelstore_driver_if_necessary(args)
+    if return_code > 0:
+      xpk_exit(return_code)
 
 
 def storage_list(args: Namespace) -> None:

--- a/src/xpk/commands/workload.py
+++ b/src/xpk/commands/workload.py
@@ -55,6 +55,7 @@ from ..core.scheduling import (
 from ..core.storage import (
     GCS_FUSE_TYPE,
     GCP_FILESTORE_TYPE,
+    PARALLELSTORE_TYPE,
     Storage,
     add_bucket_iam_members,
     get_storage_volume_mounts_yaml,
@@ -567,6 +568,9 @@ def workload_create(args) -> None:
   gcpfilestore_storages: list[Storage] = list(
       filter(lambda storage: storage.type == GCP_FILESTORE_TYPE, storages)
   )
+  parallelstore_storages: list[Storage] = list(
+      filter(lambda storage: storage.type == PARALLELSTORE_TYPE, storages)
+  )
   storage_annotations = ''
   service_account = ''
   if len(gcs_fuse_storages) > 0:
@@ -597,7 +601,9 @@ def workload_create(args) -> None:
     service_account = XPK_SA
   else:
     xpk_print('No gcp filestore instances to add detected.')
-  all_storages = gcs_fuse_storages + gcpfilestore_storages
+  all_storages = (
+      gcs_fuse_storages + gcpfilestore_storages + parallelstore_storages
+  )
   # Create the workload file based on accelerator type or workload type.
   if system.accelerator_type == AcceleratorType['GPU']:
     container, debugging_dashboard_id = get_user_workload_container(
@@ -626,7 +632,12 @@ def workload_create(args) -> None:
         sub_networks = get_subnetworks_for_a3ultra(args.cluster)
         yml_string = rdma_decorator.decorate_jobset(yml_string, sub_networks)
 
-      if len(gcs_fuse_storages) + len(gcpfilestore_storages) > 0:
+      if (
+          len(gcs_fuse_storages)
+          + len(gcpfilestore_storages)
+          + len(parallelstore_storages)
+          > 0
+      ):
         yml_string = storage_decorator.decorate_jobset(yml_string, all_storages)
     else:
       yml_string = GPU_WORKLOAD_CREATE_YAML.format(

--- a/src/xpk/commands/workload.py
+++ b/src/xpk/commands/workload.py
@@ -56,6 +56,7 @@ from ..core.storage import (
     GCS_FUSE_TYPE,
     GCP_FILESTORE_TYPE,
     PARALLELSTORE_TYPE,
+    GCE_PD_TYPE,
     Storage,
     add_bucket_iam_members,
     get_storage_volume_mounts_yaml,
@@ -571,6 +572,9 @@ def workload_create(args) -> None:
   parallelstore_storages: list[Storage] = list(
       filter(lambda storage: storage.type == PARALLELSTORE_TYPE, storages)
   )
+  pd_storages: list[Storage] = list(
+      filter(lambda storage: storage.type == GCE_PD_TYPE, storages)
+  )
   storage_annotations = ''
   service_account = ''
   if len(gcs_fuse_storages) > 0:
@@ -602,7 +606,10 @@ def workload_create(args) -> None:
   else:
     xpk_print('No gcp filestore instances to add detected.')
   all_storages = (
-      gcs_fuse_storages + gcpfilestore_storages + parallelstore_storages
+      gcs_fuse_storages
+      + gcpfilestore_storages
+      + parallelstore_storages
+      + pd_storages
   )
   # Create the workload file based on accelerator type or workload type.
   if system.accelerator_type == AcceleratorType['GPU']:
@@ -636,6 +643,7 @@ def workload_create(args) -> None:
           len(gcs_fuse_storages)
           + len(gcpfilestore_storages)
           + len(parallelstore_storages)
+          + len(pd_storages)
           > 0
       ):
         yml_string = storage_decorator.decorate_jobset(yml_string, all_storages)

--- a/src/xpk/core/cluster.py
+++ b/src/xpk/core/cluster.py
@@ -135,6 +135,26 @@ def update_cluster_with_gcpfilestore_driver_if_necessary(args) -> int:
   return 0
 
 
+def update_cluster_with_parallelstore_driver_if_necessary(args) -> int:
+  """Updates a GKE cluster to enable Parallelstore CSI driver, if not enabled already.
+  Args:
+    args: user provided arguments for running the command.
+  Returns:
+    0 if successful and error code otherwise.
+  """
+
+  if is_driver_enabled_on_cluster(args, driver='parallelstoreCsiDriver'):
+    return 0
+  cluster_update_return_code = update_gke_cluster_with_addon(
+      args, 'ParallelstoreCsiDriver'
+  )
+  if cluster_update_return_code > 0:
+    xpk_print('Updating GKE cluster to enable Parallelstore CSI driver failed!')
+    return cluster_update_return_code
+
+  return 0
+
+
 def is_driver_enabled_on_cluster(args, driver: str) -> bool:
   """Checks if GCSFuse CSI driver is enabled on the cluster.
   Args:

--- a/src/xpk/core/cluster.py
+++ b/src/xpk/core/cluster.py
@@ -142,7 +142,6 @@ def update_cluster_with_parallelstore_driver_if_necessary(args) -> int:
   Returns:
     0 if successful and error code otherwise.
   """
-
   if is_driver_enabled_on_cluster(args, driver='parallelstoreCsiDriver'):
     return 0
   cluster_update_return_code = update_gke_cluster_with_addon(
@@ -175,7 +174,7 @@ def is_driver_enabled_on_cluster(args, driver: str) -> bool:
   )
   if return_code != 0:
     xpk_exit(return_code)
-  if gcsfuse_driver_enabled.lower() == 'true':
+  if gcsfuse_driver_enabled.strip().lower() == 'true':
     xpk_print(f'{driver} driver is enabled on the cluster, no update needed.')
     return True
   return False
@@ -466,7 +465,7 @@ def is_gcsfuse_driver_enabled_on_cluster(args) -> bool:
   )
   if return_code != 0:
     xpk_exit(return_code)
-  if gcsfuse_driver_enabled.lower() == 'true':
+  if gcsfuse_driver_enabled.strip().lower() == 'true':
     xpk_print('GCSFuse CSI driver is enabled on the cluster, no update needed.')
     return True
   return False

--- a/src/xpk/core/cluster.py
+++ b/src/xpk/core/cluster.py
@@ -154,8 +154,29 @@ def update_cluster_with_parallelstore_driver_if_necessary(args) -> int:
   return 0
 
 
+def update_cluster_with_pd_driver_if_necessary(args) -> int:
+  """Updates a GKE cluster to enable PersistentDisk CSI driver, if not enabled already.
+  Args:
+    args: user provided arguments for running the command.
+  Returns:
+    0 if successful and error code otherwise.
+  """
+  if is_driver_enabled_on_cluster(args, driver='gcePersistentDiskCsiDriver'):
+    return 0
+  cluster_update_return_code = update_gke_cluster_with_addon(
+      args, 'GcePersistentDiskCsiDriver'
+  )
+  if cluster_update_return_code > 0:
+    xpk_print(
+        'Updating GKE cluster to enable PersistentDisk CSI driver failed!'
+    )
+    return cluster_update_return_code
+
+  return 0
+
+
 def is_driver_enabled_on_cluster(args, driver: str) -> bool:
-  """Checks if GCSFuse CSI driver is enabled on the cluster.
+  """Checks if the CSI driver is enabled on the cluster.
   Args:
     args: user provided arguments for running the command.
     driver (str) : name of the driver
@@ -167,14 +188,14 @@ def is_driver_enabled_on_cluster(args, driver: str) -> bool:
       f' --project={args.project} --region={zone_to_region(args.zone)}'
       f' --format="value(addonsConfig.{driver}Config.enabled)"'
   )
-  return_code, gcsfuse_driver_enabled = run_command_for_value(
+  return_code, driver_enabled = run_command_for_value(
       command,
       f'Checks if {driver} driver is enabled in cluster describe.',
       args,
   )
   if return_code != 0:
     xpk_exit(return_code)
-  if gcsfuse_driver_enabled.strip().lower() == 'true':
+  if driver_enabled.strip().lower() == 'true':
     xpk_print(f'{driver} driver is enabled on the cluster, no update needed.')
     return True
   return False

--- a/src/xpk/core/kjob.py
+++ b/src/xpk/core/kjob.py
@@ -46,7 +46,7 @@ from .resources import (
     SystemCharacteristics,
     get_cluster_system_characteristics,
 )
-from .storage import get_auto_mount_gcsfuse_storages, get_auto_mount_storages
+from .storage import get_auto_mount_gcsfuse_storages, get_auto_mount_storages, get_auto_mount_parallelstore_storages
 from .workload_decorators.tcpxo_decorator import get_tcpxo_deamon_entry
 
 KJOB_API_GROUP_NAME = "kjobctl.x-k8s.io"
@@ -449,9 +449,16 @@ def create_volume_bundle_instance(
       xpk_exit(1)
 
 
-def get_gcsfuse_annotation(args: Namespace) -> str | None:
+def get_storage_annotations(args: Namespace) -> list[str]:
+  annotations = []
   k8s_api_client = setup_k8s_env(args)
+
   gcsfuse_storages = get_auto_mount_gcsfuse_storages(k8s_api_client)
   if len(gcsfuse_storages) > 0:
-    return "gke-gcsfuse/volumes=true"
-  return None
+    annotations.append("gke-gcsfuse/volumes=true")
+
+  parallelstore_storages = get_auto_mount_parallelstore_storages(k8s_api_client)
+  if len(parallelstore_storages) > 0:
+    annotations.append("gke-parallelstore/volumes=true")
+
+  return annotations

--- a/src/xpk/core/network.py
+++ b/src/xpk/core/network.py
@@ -311,7 +311,10 @@ def get_all_networks_programmatic(args) -> tuple[list[str], int]:
   Returns:
     List of networks and 0 if successful and 1 otherwise.
   """
-  command = 'gcloud compute networks list --format="csv[no-heading](name)"'
+  command = (
+      'gcloud compute networks list --format="csv[no-heading](name)" '
+      f' --project={args.project}'
+  )
   return_code, raw_network_output = run_command_for_value(
       command, 'Get All Networks', args
   )
@@ -361,7 +364,8 @@ def get_all_firewall_rules_programmatic(args) -> tuple[list[str], int]:
     List of firewall rules and 0 if successful and 1 otherwise.
   """
   command = (
-      'gcloud compute firewall-rules list --format="csv[no-heading](name)"'
+      'gcloud compute firewall-rules list --format="csv[no-heading](name)" '
+      f' --project={args.project}'
   )
   return_code, raw_subnets_output = run_command_for_value(
       command, 'Get All Firewall Rules', args

--- a/src/xpk/core/storage.py
+++ b/src/xpk/core/storage.py
@@ -45,6 +45,7 @@ STORAGE_CRD_PLURAL = "storages"
 STORAGE_CRD_NAME = f"{XPK_API_GROUP_NAME}.{STORAGE_CRD_PLURAL}"
 GCS_FUSE_TYPE = "gcsfuse"
 GCP_FILESTORE_TYPE = "gcpfilestore"
+PARALLELSTORE_TYPE = "parallelstore"
 MANIFESTS_PATH = os.path.abspath("xpkclusters/storage-manifests")
 GCS_FUSE_ANNOTATION = 'gke-gcsfuse/volumes: "true"'
 

--- a/src/xpk/core/storage.py
+++ b/src/xpk/core/storage.py
@@ -211,6 +211,24 @@ def get_auto_mount_gcsfuse_storages(k8s_api_client: ApiClient) -> list[Storage]:
   return list(filter(lambda storage: storage.type == GCS_FUSE_TYPE, storages))
 
 
+def get_auto_mount_parallelstore_storages(
+    k8s_api_client: ApiClient,
+) -> list[Storage]:
+  """
+  Retrieves all GCS Fuse Storage resources that have --auto-mount flag set to true.
+
+  Args:
+      k8s_api_client: An ApiClient object for interacting with the Kubernetes API.
+
+  Returns:
+      A list of GCS Fuse Storage objects that have `auto_mount` set to True.
+  """
+  storages: list[Storage] = get_auto_mount_storages(k8s_api_client)
+  return list(
+      filter(lambda storage: storage.type == PARALLELSTORE_TYPE, storages)
+  )
+
+
 def get_storages(
     k8s_api_client: ApiClient, requested_storages: list[str]
 ) -> list[Storage]:

--- a/src/xpk/core/storage.py
+++ b/src/xpk/core/storage.py
@@ -46,6 +46,7 @@ STORAGE_CRD_NAME = f"{XPK_API_GROUP_NAME}.{STORAGE_CRD_PLURAL}"
 GCS_FUSE_TYPE = "gcsfuse"
 GCP_FILESTORE_TYPE = "gcpfilestore"
 PARALLELSTORE_TYPE = "parallelstore"
+GCE_PD_TYPE = "pd"
 MANIFESTS_PATH = os.path.abspath("xpkclusters/storage-manifests")
 GCS_FUSE_ANNOTATION = 'gke-gcsfuse/volumes: "true"'
 

--- a/src/xpk/core/workload_decorators/storage_decorator.py
+++ b/src/xpk/core/workload_decorators/storage_decorator.py
@@ -45,8 +45,8 @@ def add_annotations(job_manifest, storages):
   gcs_present = any(storage.type == GCS_FUSE_TYPE for storage in storages)
   if gcs_present:
     annotations.update(GCS_FUSE_ANNOTATIONS)
-  gcs_present = any(storage.type == PARALLELSTORE_TYPE for storage in storages)
-  if gcs_present:
+  parallelstore_present = any(storage.type == PARALLELSTORE_TYPE for storage in storages)
+  if parallelstore_present:
     annotations.update(PARALLELSTORE_ANNOTATIONS)
 
 

--- a/src/xpk/core/workload_decorators/storage_decorator.py
+++ b/src/xpk/core/workload_decorators/storage_decorator.py
@@ -45,7 +45,9 @@ def add_annotations(job_manifest, storages):
   gcs_present = any(storage.type == GCS_FUSE_TYPE for storage in storages)
   if gcs_present:
     annotations.update(GCS_FUSE_ANNOTATIONS)
-  parallelstore_present = any(storage.type == PARALLELSTORE_TYPE for storage in storages)
+  parallelstore_present = any(
+      storage.type == PARALLELSTORE_TYPE for storage in storages
+  )
   if parallelstore_present:
     annotations.update(PARALLELSTORE_ANNOTATIONS)
 

--- a/src/xpk/parser/cluster.py
+++ b/src/xpk/parser/cluster.py
@@ -584,10 +584,13 @@ def add_shared_cluster_create_optional_arguments(args_parsers):
     custom_parser.add_argument(
         '--enable-gcpfilestore-csi-driver',
         action='store_true',
-        help=(
-            'Enable GCPFilestore driver on the cluster. This enables Workload'
-            ' Identity Federation.'
-        ),
+        help='Enable GCPFilestore driver on the cluster.',
+    )
+
+    custom_parser.add_argument(
+        '--enable-parallelstore-csi-driver',
+        action='store_true',
+        help='Enable Parallelstore driver on the cluster.',
     )
 
 

--- a/src/xpk/parser/cluster.py
+++ b/src/xpk/parser/cluster.py
@@ -590,7 +590,13 @@ def add_shared_cluster_create_optional_arguments(args_parsers):
     custom_parser.add_argument(
         '--enable-parallelstore-csi-driver',
         action='store_true',
-        help='Enable Parallelstore driver on the cluster.',
+        help='Enable Parallelstore CSI driver on the cluster.',
+    )
+
+    custom_parser.add_argument(
+        '--enable-pd-csi-driver',
+        action='store_true',
+        help='Enable PersistentDisk CSI driver on the cluster.',
     )
 
 

--- a/src/xpk/parser/storage.py
+++ b/src/xpk/parser/storage.py
@@ -144,11 +144,6 @@ def add_storage_attach_parser(
       ),
   )
 
-  parallelstore_args = storage_attach_parser.add_argument_group(
-      'Parallelstore arguments',
-      'Arguments used when --type=gcpfilestore',
-  )
-
   opt_args = storage_attach_parser.add_argument_group(
       'Optional Arguments',
       'Optional arguments for storage create.',

--- a/src/xpk/parser/storage.py
+++ b/src/xpk/parser/storage.py
@@ -73,7 +73,7 @@ def add_storage_attach_parser(
           'The type of storage. Currently supported types: ["gcsfuse",'
           ' "gcpfilestore"]'
       ),
-      choices=['gcsfuse', 'gcpfilestore', 'parallelstore'],
+      choices=['gcsfuse', 'gcpfilestore', 'parallelstore', 'pd'],
       required=True,
   )
   add_cluster_arguments(req_args, required=True)

--- a/src/xpk/parser/storage.py
+++ b/src/xpk/parser/storage.py
@@ -73,7 +73,7 @@ def add_storage_attach_parser(
           'The type of storage. Currently supported types: ["gcsfuse",'
           ' "gcpfilestore"]'
       ),
-      choices=['gcsfuse', 'gcpfilestore'],
+      choices=['gcsfuse', 'gcpfilestore', 'parallelstore'],
       required=True,
   )
   add_cluster_arguments(req_args, required=True)
@@ -142,6 +142,11 @@ def add_storage_attach_parser(
           '(optional) Name of the filestore instance. If not set, then the'
           ' "name" parameter is infered as an instance name.'
       ),
+  )
+
+  parallelstore_args = storage_attach_parser.add_argument_group(
+      'Parallelstore arguments',
+      'Arguments used when --type=gcpfilestore',
   )
 
   opt_args = storage_attach_parser.add_argument_group(


### PR DESCRIPTION
## Fixes / Features
- Attaching Parallelstore instance implemented.
- Attaching Block storage (PersistentDisk, Hyperdisk) instances implemented
- They are currently supported only by providing a PV/PVC manifest file.

## Testing / Documentation
Testing details.

- [ y/n ] Tests pass
- [ y/n ] Appropriate changes to documentation are included in the PR
