### PR TITLE
Integrate PathwaysJob into XPK.

### DIFF
--- a/.github/workflows/reusable_workload_tests.yaml
+++ b/.github/workflows/reusable_workload_tests.yaml
@@ -84,7 +84,7 @@ jobs:
     - name: List out the workloads on the cluster
       run: python3 xpk.py workload list --cluster ${{inputs.cluster-name}} --zone=${{inputs.zone}}
     - name: Run xpk info
-      run: python3 xpk.py info --cluster ${{inputs.cluster-name}} --zone=${{inputs.zone}} | tee output.txt | grep -P "^(?=.*QUEUE)(?=.*PENDING_WORKLOADS)(?=.*ADMITTED_WORKLOADS)(?=.*1x${{inputs.tpu-type}}:google.com/tpu)(?=.*cpu-rm:cpu)(?=.*cpu-rm:memory)(?=.*cpu-proxy:cpu)(?=.*cpu-proxy:memory)(?=.*cpu-user:cpu)(?=.*cpu-user:memory)" || (echo 'Invalid command output' && cat output.txt && exit 1)
+      run: python3 xpk.py info --cluster ${{inputs.cluster-name}} --zone=${{inputs.zone}} | tee output.txt | grep -P "^(?=.*QUEUE)(?=.*PENDING_WORKLOADS)(?=.*ADMITTED_WORKLOADS)(?=.*1x${{inputs.tpu-type}}:google.com/tpu)(?=.*cpu-user:cpu)(?=.*cpu-user:memory)" || (echo 'Invalid command output' && cat output.txt && exit 1)
     - name: Delete the workload on the cluster
       run: python3 xpk.py workload delete --workload $WORKLOAD_NAME --cluster ${{inputs.cluster-name}} --zone=${{inputs.zone}}
     - name: Delete the Pathways workload on the cluster

--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ all zones.
     --num-slices=4 --on-demand \
     --tpu-type=v5litepod-16
     ```
+    Note that Pathways clusters need a CPU nodepool of n2-standard-64 or higher.
 
 *   Cluster Create for Ray:
     A cluster with KubeRay enabled and a RayCluster can be created using `cluster create-ray`.

--- a/src/xpk/commands/cluster.py
+++ b/src/xpk/commands/cluster.py
@@ -22,6 +22,7 @@ from ..core.cluster import (
     get_cluster_credentials,
     install_nccl_on_cluster,
     set_jobset_on_cluster,
+    set_pathways_job_on_cluster,
     setup_k8s_env,
     update_cluster_with_gcsfuse_driver_if_necessary,
     update_cluster_with_workload_identity_if_necessary,
@@ -205,6 +206,10 @@ def cluster_create(args) -> None:
   set_jobset_on_cluster_code = set_jobset_on_cluster(args)
   if set_jobset_on_cluster_code != 0:
     xpk_exit(set_jobset_on_cluster_code)
+
+  set_pathways_job_on_cluster_code = set_pathways_job_on_cluster(args)
+  if set_pathways_job_on_cluster_code != 0:
+    xpk_exit(set_pathways_job_on_cluster_code)
 
   xpk_print('Enabling Kueue on the cluster')
   install_kueue_on_cluster_code = install_kueue_on_cluster(args)
@@ -792,10 +797,8 @@ def run_gke_cluster_create_command(
   addons = []
   if args.enable_gcsfuse_csi_driver:
     addons.append('GcsFuseCsiDriver')
-
   if args.enable_gcpfilestore_csi_driver:
     addons.append('GcpFilestoreCsiDriver')
-
   if len(addons) > 0:
     addons_str = ','.join(addons)
     command += f' --addons={addons_str}'

--- a/src/xpk/commands/workload.py
+++ b/src/xpk/commands/workload.py
@@ -36,19 +36,23 @@ from ..core.nap import (
     is_autoprovisioning_enabled,
 )
 from ..core.pathways import (
+    check_if_pathways_job_is_installed,
     ensure_pathways_workload_prerequisites,
-    get_pathways_proxy_args,
-    get_pathways_rm_args,
-    get_pathways_sidecar_container,
     get_pathways_unified_query_link,
-    get_pathways_worker_args,
+    append_custom_pathways_proxy_server,
+    append_custom_pathways_server,
+    append_custom_pathways_worker,
+    append_custom_colocated_python_sidecar,
     get_user_workload_for_pathways,
+    try_to_delete_pathwaysjob_first,
 )
 from ..core.resources import CLUSTER_METADATA_CONFIGMAP, get_cluster_configmap
 from ..core.scheduling import (
     check_if_workload_can_schedule,
     create_accelerator_label,
     create_machine_label,
+    create_tpu_topology,
+    create_tpu_machine_type,
     get_cpu_affinity,
     get_gpu_scheduler,
 )
@@ -57,8 +61,6 @@ from ..core.storage import (
     GCP_FILESTORE_TYPE,
     Storage,
     add_bucket_iam_members,
-    get_storage_volume_mounts_yaml,
-    get_storage_volumes_yaml,
     get_storages_to_mount,
     get_storage_volume_mounts_yaml_for_gpu,
     get_storage_volumes_yaml_for_gpu,
@@ -66,7 +68,6 @@ from ..core.storage import (
 )
 from ..core.system_characteristics import (
     AcceleratorType,
-    AcceleratorTypeToAcceleratorCharacteristics,
     get_system_characteristics,
 )
 from ..core.vertex import create_vertex_experiment
@@ -241,219 +242,37 @@ spec:
               containers:
               {container}
 """
-
-PW_WORKLOAD_CREATE_YAML = """apiVersion: jobset.x-k8s.io/v1alpha2
-kind: JobSet
-metadata:
-  name: {args.workload}
-  labels:
-    kueue.x-k8s.io/queue-name: {local_queue_name}  # Name of the LocalQueue
-    xpk.google.com/workload: {args.workload}
-spec:
-  ttlSecondsAfterFinished: {args.ttl_seconds_after_finished}
-  failurePolicy:
-    {failure_policy_rules}
-    maxRestarts: {args.max_restarts}
-  successPolicy:
-    operator: "All"
-    targetReplicatedJobs:
-    - {args.targetReplicatedJob}
-  replicatedJobs:
-    - name: worker
-      replicas: {args.num_slices}
-      template:
-        metadata:
-          annotations:
-            alpha.jobset.sigs.k8s.io/exclusive-topology: cloud.google.com/gke-nodepool
-          labels:
-            xpk.google.com/workload: {args.workload}
-        spec:
-          backoffLimit: {backoff_limit}
-          completions: {system.vms_per_slice}
-          parallelism: {system.vms_per_slice}
-          template:
-            metadata:
-              annotations:
-                {storage_annotations}
-            spec:
-              terminationGracePeriodSeconds: {args.termination_grace_period_seconds}
-              serviceAccountName: {service_account}
-              containers:
-              - args:
-                {pathways_worker_args}
-                image: {args.server_image}
-                imagePullPolicy: Always
-                name: pathways-worker
-                ports:
-                - containerPort: 29001
-                - containerPort: 8471
-                - containerPort: 8080
-                resources:
-                  limits:
-                    {resource_type}: {system.chips_per_vm}
-                securityContext:
-                  privileged: true
-                volumeMounts:
-                - mountPath: /tmp
-                  name: shared-tmp
-                {storage_volume_mounts}
-                env:
-                  - name: PROJECT_ID
-                    value: {args.project}
-                  - name: LOCATION
-                    value: {args.zone}
-                  - name: CLUSTER_NAME
-                    value: {args.cluster}
-                  - name: POD_NAME
-                    valueFrom:
-                      fieldRef:
-                        fieldPath: metadata.name
-                  - name: CONTAINER_NAME
-                    value: "pathways-worker"
-                  - name: NAMESPACE
-                    valueFrom:
-                      fieldRef:
-                        fieldPath: metadata.namespace
-                  # Workaround for v6e
-                  - name: MEGASCALE_GRPC_ENABLE_XOR_TRACER
-                    value: "false"
-                  - name: MEGASCALE_NUM_SLICES
-                    valueFrom:
-                      fieldRef:
-                        fieldPath: "metadata.labels['jobset.sigs.k8s.io/replicatedjob-replicas']"
-                  - name: JOBSET_NAME
-                    valueFrom:
-                      fieldRef:
-                        fieldPath: metadata.annotations['jobset.sigs.k8s.io/jobset-name']
-                  - name: REPLICATED_JOB_NAME
-                    valueFrom:
-                      fieldRef:
-                        fieldPath: metadata.annotations['jobset.sigs.k8s.io/replicatedjob-name']
-                  - name: MEGASCALE_SLICE_ID
-                    valueFrom:
-                      fieldRef:
-                        fieldPath: "metadata.labels['jobset.sigs.k8s.io/job-index']"
-                  - name: MEGASCALE_COORDINATOR_ADDRESS
-                    value: "$(JOBSET_NAME)-$(REPLICATED_JOB_NAME)-$(MEGASCALE_SLICE_ID)-0.$(JOBSET_NAME)"
-              {pathways_sidecar_container}
-              nodeSelector:
-                {accelerator_label}
-                {machine_label}
-                {autoprovisioning_args}
-              priorityClassName: {args.priority}
-              hostNetwork: true
-              dnsPolicy: ClusterFirstWithHostNet
-              volumes:
-              - hostPath:
-                  path: /tmp
-                  type: DirectoryOrCreate
-                name: shared-tmp
-              {storage_volumes}
-    - name: rm
-      replicas: 1
-      template:
-        metadata:
-          labels:
-            xpk.google.com/workload: {args.workload}
-        spec:
-          backoffLimit: 0
-          completions: 1
-          parallelism: 1
-          template:
-            spec:
-              containers:
-              - args:
-                {pathways_rm_args}
-                env:
-                - name: PROJECT_ID
-                  value: {args.project}
-                - name: LOCATION
-                  value: {args.zone}
-                - name: CLUSTER_NAME
-                  value: {args.cluster}
-                - name: POD_NAME
-                  valueFrom:
-                    fieldRef:
-                      fieldPath: metadata.name
-                - name: CONTAINER_NAME
-                  value: "pathways-rm"
-                - name: NAMESPACE
-                  valueFrom:
-                    fieldRef:
-                      fieldPath: metadata.namespace
-                - name: REPLICATED_JOB_NAME
-                  valueFrom:
-                    fieldRef:
-                      fieldPath: metadata.annotations['jobset.sigs.k8s.io/replicatedjob-name']
-                - name: JOBSET_NAME
-                  valueFrom:
-                    fieldRef:
-                      fieldPath: metadata.annotations['jobset.sigs.k8s.io/jobset-name']
-                - name: HOST_ADDRESS
-                  value: $(JOBSET_NAME)-$(REPLICATED_JOB_NAME)-0-0.$(JOBSET_NAME)
-                - name: TPU_SKIP_MDS_QUERY
-                  value: "true"
-                image: {args.server_image}
-                imagePullPolicy: Always
-                name: pathways-rm
-                ports:
-                - containerPort: 29001
-                securityContext:
-                  privileged: true
-                volumeMounts:
-                - mountPath: /tmp
-                  name: shared-tmp
-              nodeSelector:
-                cloud.google.com/gke-nodepool: cpu-rm-np
-              hostNetwork: true
-              dnsPolicy: ClusterFirstWithHostNet
-              volumes:
-              - hostPath:
-                  path: /tmp
-                  type: DirectoryOrCreate
-                name: shared-tmp
-    - name: proxy
-      replicas: 1
-      template:
-        metadata:
-          labels:
-            xpk.google.com/workload: {args.workload}
-        spec:
-          backoffLimit: 0
-          completions: 1
-          parallelism: 1
-          template:
-            spec:
-              containers:
-              - args:
-                {pathways_proxy_args}
-                env:
-                - name: PROJECT_ID
-                  value: {args.project}
-                - name: LOCATION
-                  value: {args.zone}
-                - name: CLUSTER_NAME
-                  value: {args.cluster}
-                - name: POD_NAME
-                  valueFrom:
-                    fieldRef:
-                      fieldPath: metadata.name
-                - name: CONTAINER_NAME
-                  value: "pathways-proxy"
-                - name: NAMESPACE
-                  valueFrom:
-                    fieldRef:
-                      fieldPath: metadata.namespace
-                image: {args.proxy_server_image}
-                imagePullPolicy: Always
-                name: pathways-proxy
-                ports:
-                - containerPort: 29000
-              hostNetwork: true
-              dnsPolicy: ClusterFirstWithHostNet
-              nodeSelector:
-                cloud.google.com/gke-nodepool: cpu-proxy-np
-    {user_workload}
+# The indentation of PW_WORKLOAD_CREATE_YAML is intentional to allow reusing the user workload container YAML.
+PW_WORKLOAD_CREATE_YAML = """
+    apiVersion: pathways-job.pathways.domain/v1
+    kind: PathwaysJob
+    metadata:
+      name: {args.workload}
+      labels:
+        kueue.x-k8s.io/queue-name: {local_queue_name}  # Name of the LocalQueue
+        xpk.google.com/workload: {args.workload}
+    spec:
+      maxRestarts: {args.max_restarts}
+      customComponents:
+      {custom_pathways_proxy_server}
+      {custom_pathways_server}
+      {custom_pathways_worker}
+      {colocated_python_sidecar}
+      workers:
+      - type: {machine_type}
+        topology: {topology}
+        numSlices: {args.num_slices}
+        maxSliceRestarts: {args.max_slice_restarts}
+        terminationGracePeriodSeconds: {args.termination_grace_period_seconds}
+        priorityClassName: {args.priority}
+      pathwaysDir: {args.pathways_gcs_location} #This bucket needs to be created in advance.
+      controller:
+        # #Pod template for training, default mode.
+        deploymentMode: default
+        mainContainerName: {args.docker_name}
+        elasticSlices: {args.elastic_slices}
+        template:
+      {user_workload}
 """
 
 
@@ -545,7 +364,6 @@ def workload_create(args) -> None:
 
   parse_env_config(args, tensorboard_config, system)
 
-  # Currently autoprovisioning is not enabled for Pathways workloads.
   autoprovisioning_args = ''
   autoprovisioning_enabled, return_code = is_autoprovisioning_enabled(
       args, system
@@ -560,28 +378,47 @@ def workload_create(args) -> None:
     if return_code != 0:
       xpk_exit(return_code)
 
-  storages: list[Storage] = get_storages_to_mount(k8s_api_client, args.storage)
-  gcs_fuse_storages = list(
-      filter(lambda storage: storage.type == GCS_FUSE_TYPE, storages)
-  )
-  gcpfilestore_storages: list[Storage] = list(
-      filter(lambda storage: storage.type == GCP_FILESTORE_TYPE, storages)
-  )
+  # Currently storage customization is not supported for Pathways workloads. b/408468941
   storage_annotations = ''
   service_account = ''
-  if len(gcs_fuse_storages) > 0:
-    storage_annotations = GCS_FUSE_ANNOTATION
-    service_account = XPK_SA
-    xpk_print(f'Detected gcsfuse Storages to add: {gcs_fuse_storages}')
-  else:
-    xpk_print('No gcsfuse Storages to add detected')
-  failure_policy_rules = """rules:
+  all_storages = ''
+  if not args.use_pathways:
+    storages: list[Storage] = get_storages_to_mount(
+        k8s_api_client, args.storage
+    )
+    gcs_fuse_storages = list(
+        filter(lambda storage: storage.type == GCS_FUSE_TYPE, storages)
+    )
+    gcpfilestore_storages: list[Storage] = list(
+        filter(lambda storage: storage.type == GCP_FILESTORE_TYPE, storages)
+    )
+    if len(gcs_fuse_storages) > 0:
+      storage_annotations = GCS_FUSE_ANNOTATION
+      service_account = XPK_SA
+      xpk_print(f'Detected gcsfuse Storages to add: {gcs_fuse_storages}')
+    else:
+      xpk_print('No gcsfuse Storages to add detected')
+
+    if len(gcpfilestore_storages) > 0:
+      xpk_print(
+          f'Detected gcp filestores instances to add: {gcpfilestore_storages}'
+      )
+      service_account = XPK_SA
+    else:
+      xpk_print('No gcp filestore instances to add detected.')
+    all_storages = gcs_fuse_storages + gcpfilestore_storages
+
+  # Currently failure policy rules are supported for Pathways workloads. b/408465881
+  failure_policy_rules = ''
+  pod_failure_policy = ''
+  if not args.use_pathways:
+    failure_policy_rules = """rules:
       - action: FailJobSet
-        onJobFailureReasons: 
+        onJobFailureReasons:
         - PodFailurePolicy"""
-  restart_on_exit_codes = get_restart_exit_codes(args)
-  restart_on_exit_codes = ','.join(map(str, restart_on_exit_codes))
-  pod_failure_policy = f"""
+    restart_on_exit_codes = get_restart_exit_codes(args)
+    restart_on_exit_codes = ','.join(map(str, restart_on_exit_codes))
+    pod_failure_policy = f"""
           podFailurePolicy:
             rules:
             - action: FailJob
@@ -590,14 +427,6 @@ def workload_create(args) -> None:
                 operator: NotIn
                 values: [{restart_on_exit_codes}]"""
 
-  if len(gcpfilestore_storages) > 0:
-    xpk_print(
-        f'Detected gcp filestores instances to add: {gcpfilestore_storages}'
-    )
-    service_account = XPK_SA
-  else:
-    xpk_print('No gcp filestore instances to add detected.')
-  all_storages = gcs_fuse_storages + gcpfilestore_storages
   # Create the workload file based on accelerator type or workload type.
   if system.accelerator_type == AcceleratorType['GPU']:
     container, debugging_dashboard_id = get_user_workload_container(
@@ -655,29 +484,14 @@ def workload_create(args) -> None:
     yml_string = PW_WORKLOAD_CREATE_YAML.format(
         args=args,
         system=system,
-        accelerator_label=create_accelerator_label(
-            system.accelerator_type, system
-        ),
-        machine_label=create_machine_label(system.accelerator_type, system),
-        pathways_worker_args=get_pathways_worker_args(args),
-        pathways_proxy_args=get_pathways_proxy_args(args),
-        pathways_sidecar_container=get_pathways_sidecar_container(args),
-        user_workload=get_user_workload_for_pathways(
-            args, system, pod_failure_policy, storages
-        ),
-        resource_type=AcceleratorTypeToAcceleratorCharacteristics[
-            system.accelerator_type
-        ].resource_type,
+        topology=create_tpu_topology(system.accelerator_type, system),
+        machine_type=create_tpu_machine_type(system.accelerator_type, system),
+        custom_pathways_proxy_server=append_custom_pathways_proxy_server(args),
+        custom_pathways_server=append_custom_pathways_server(args),
+        custom_pathways_worker=append_custom_pathways_worker(args),
+        colocated_python_sidecar=append_custom_colocated_python_sidecar(args),
+        user_workload=get_user_workload_for_pathways(args, system),
         local_queue_name=LOCAL_QUEUE_NAME,
-        autoprovisioning_args=autoprovisioning_args,
-        backoff_limit=system.vms_per_slice * 4,
-        storage_annotations=storage_annotations,
-        storage_volumes=get_storage_volumes_yaml(all_storages),
-        storage_volume_mounts=get_storage_volume_mounts_yaml(all_storages),
-        pathways_rm_args=get_pathways_rm_args(args, system),
-        service_account=service_account,
-        failure_policy_rules=failure_policy_rules,
-        pod_failure_policy=pod_failure_policy,
     )
   else:
     container, debugging_dashboard_id = get_user_workload_container(
@@ -708,7 +522,9 @@ def workload_create(args) -> None:
     xpk_print(f'Create Workload request returned ERROR {return_code}')
     xpk_exit(return_code)
 
-  add_bucket_iam_members(args, storages)
+  if not args.use_pathways:
+    add_bucket_iam_members(args, storages)
+
   # Get GKE outlier dashboard for TPU
   outlier_dashboard_id = None
   if system.accelerator_type == AcceleratorType['TPU']:
@@ -833,6 +649,12 @@ def workload_delete(args) -> None:
   elif not will_delete:
     xpk_print('Skipping delete command.')
   else:
+    # If PathwaysJob exists, delete it.
+    if check_if_pathways_job_is_installed(
+        args
+    ) and try_to_delete_pathwaysjob_first(args, workloads):
+      xpk_exit(0)
+    # PathwaysJob workload does not exist, delete JobSet
     commands = []
     task_names = []
     for workload in workloads:

--- a/src/xpk/core/cluster.py
+++ b/src/xpk/core/cluster.py
@@ -33,6 +33,7 @@ from .nodepool import upgrade_gke_nodepools_version
 from .system_characteristics import SystemCharacteristics
 
 JOBSET_VERSION = 'v0.8.0'
+PATHWAYS_JOB_VERSION = 'v0.1.0'
 INSTALLER_NCC_TCPX = 'https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/master/gpudirect-tcpx/nccl-tcpx-installer.yaml'
 INSTALLER_NCC_TCPXO = 'https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/master/gpudirect-tcpxo/nccl-tcpxo-installer.yaml'
 
@@ -56,6 +57,35 @@ def set_jobset_on_cluster(args) -> int:
       f' https://github.com/kubernetes-sigs/jobset/releases/download/{JOBSET_VERSION}/manifests.yaml'
   )
   task = f'Install Jobset on {args.cluster}'
+  return_code = run_command_with_updates_retry(command, task, args)
+
+  if return_code != 0:
+    xpk_print(f'{task} returned with ERROR {return_code}.\n')
+    xpk_print(
+        "This LIKELY means you're missing Kubernetes Permissions, you can"
+        ' validate this by checking if the error references permission problems'
+        ' such as `requires one of ["container.*"] permission(s)`. Follow our'
+        ' readme:'
+        ' https://github.com/google/xpk/blob/main/README.md#troubleshooting for'
+        ' instructions on how to fix these permissions.'
+    )
+  return return_code
+
+
+def set_pathways_job_on_cluster(args) -> int:
+  """Add PathwaysJob command on server side and ask user to verify it is created.
+
+  Args:
+    args: user provided arguments for running the command.
+
+  Returns:
+    0 if successful and 1 otherwise.
+  """
+  command = (
+      'kubectl apply --server-side -f'
+      f' https://github.com/google/pathways-job/releases/download/{PATHWAYS_JOB_VERSION}/install.yaml'
+  )
+  task = f'Install PathwaysJob on {args.cluster}'
   return_code = run_command_with_updates_retry(command, task, args)
 
   if return_code != 0:

--- a/src/xpk/core/docker_resources.py
+++ b/src/xpk/core/docker_resources.py
@@ -64,22 +64,6 @@ def get_env_container(args, system: SystemCharacteristics) -> str:
     str:
       YAML with the env config for the main container, as a YAML string.
   """
-  pw_env_yaml = """
-                - name: XCLOUD_ENVIRONMENT
-                  value: GCP
-                - name: JAX_PLATFORMS
-                  value: proxy
-                - name: JAX_BACKEND_TARGET
-                  value: {proxy_address}
-                - name: JOBSET_NAME
-                  valueFrom:
-                    fieldRef:
-                      fieldPath: metadata.annotations['jobset.sigs.k8s.io/jobset-name']"""
-  if args.use_pathways:
-    return pw_env_yaml.format(
-        args=args, proxy_address=args.pathways_proxy_address
-    )
-
   gpu_env_yaml = """
                   - name: REPLICATED_JOB_NAME
                     valueFrom:

--- a/src/xpk/core/nap.py
+++ b/src/xpk/core/nap.py
@@ -255,6 +255,10 @@ def is_autoprovisioning_enabled(
     bool is true if autoprovisioning is enabled, false otherwise.
     int of 0 if successful and 1 otherwise.
   """
+  # Currently autoprovisioning is not enabled for Pathways workloads. b/360898087
+  if args.use_pathways:
+    return False, 0
+
   resources_configmap_name = f'{args.cluster}-{CLUSTER_RESOURCES_CONFIGMAP}'
   cluster_config_map = get_cluster_configmap(args, resources_configmap_name)
 

--- a/src/xpk/core/pathways.py
+++ b/src/xpk/core/pathways.py
@@ -14,97 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from .cluster import XPK_SA
+from ..core.commands import run_command_for_value, run_command_with_updates, run_commands
 from ..core.docker_container import get_user_workload_container
 from ..core.gcloud_context import zone_to_region
 from ..core.nodepool import get_all_nodepools_programmatic
 from ..utils.console import xpk_exit, xpk_print
 from .config import AcceleratorType
-from .storage import Storage, get_storage_volumes_yaml, GCS_FUSE_ANNOTATION
 from .system_characteristics import SystemCharacteristics
-
-PathwaysExpectedInstancesMap = {
-    'v6e': 'tpuv6e',
-    'v5p': 'tpuv5',
-    'v5litepod': 'tpuv5e',
-    'v4': 'tpuv4',
-    'v3': 'tpuv3',
-}
-
-
-def get_pathways_worker_args(args) -> str:
-  """Arguments for the Pathways workers.
-  Args:
-    args: user provided arguments for running the command.
-
-  Returns:
-    str: yaml containing arguments for the Pathways workers.
-  """
-  yaml = """- --server_port=29001
-                - --resource_manager_address={rm_address}
-                - --gcs_scratch_location={args.pathways_gcs_location}"""
-  if args.use_pathways:
-    if args.custom_pathways_worker_args:
-      yaml = append_custom_pathways_args(yaml, args.custom_pathways_worker_args)
-    return yaml.format(args=args, rm_address=get_rm_address(args))
-  else:
-    return ''
-
-
-def get_pathways_proxy_args(args) -> str:
-  """Arguments for the Pathways proxy.
-  Args:
-    args: user provided arguments for running the command.
-
-  Returns:
-    str: yaml containing arguments for the Pathways proxy.
-  """
-  yaml = """- --server_port=29000
-                - --resource_manager_address={rm_address}
-                - --gcs_scratch_location={args.pathways_gcs_location}"""
-
-  if args.use_pathways:
-    if args.custom_pathways_proxy_server_args:
-      yaml = append_custom_pathways_args(
-          yaml, args.custom_pathways_proxy_server_args
-      )
-    return yaml.format(args=args, rm_address=get_rm_address(args))
-  else:
-    return ''
-
-
-def get_pathways_sidecar_container(args) -> str:
-  """This is a sidecar container that runs the remote python server.
-
-      It is a special case of the initContainer (designated by restartPolicy:
-      Always)
-      See https://kubernetes.io/docs/concepts/workloads/pods/sidecar-containers/
-      for more details.
-  Args:
-    args: user provided arguments for running the command.
-
-  Returns:
-    str: yaml containing arguments for the Pathways sidecar container.
-  """
-  yaml = """initContainers:
-              - name: remote-python-sidecar
-                image: {args.remote_python_sidecar_image}
-                imagePullPolicy: Always
-                securityContext:
-                  privileged: true
-                volumeMounts:
-                - mountPath: /tmp  # Shared volume mount with the main container.
-                  name: shared-tmp
-                restartPolicy: Always
-                ports:
-                - containerPort: 50051
-                env:
-                - name: GRPC_SERVER_ADDRESS
-                  value: '0.0.0.0:50051'"""
-  if args.use_pathways and args.remote_python_sidecar_image is not None:
-    return yaml.format(args=args)
-  else:
-    return ''
 
 
 def add_pw_resource_flavors(args):
@@ -112,26 +28,10 @@ def add_pw_resource_flavors(args):
   resource_flavor_yaml = """apiVersion: kueue.x-k8s.io/v1beta1
 kind: ResourceFlavor
 metadata:
-  name: cpu-rm
-spec:
-  nodeLabels:
-    cloud.google.com/gke-nodepool: cpu-rm-np
----
-apiVersion: kueue.x-k8s.io/v1beta1
-kind: ResourceFlavor
-metadata:
-  name: cpu-proxy
-spec:
-  nodeLabels:
-    cloud.google.com/gke-nodepool: cpu-proxy-np
----
-apiVersion: kueue.x-k8s.io/v1beta1
-kind: ResourceFlavor
-metadata:
   name: cpu-user
 spec:
   nodeLabels:
-    cloud.google.com/gke-nodepool: cpu-user-np
+    cloud.google.com/gke-nodepool: cpu-np
 ---"""
   if args.enable_pathways:
     return resource_flavor_yaml
@@ -142,18 +42,6 @@ def add_pw_resources_to_kueue(args):
   """Add resource flavors required for Pathways, to the cluster queue."""
   resources_yaml = """- coveredResources: ["cpu", "memory"]
     flavors:
-    - name: cpu-rm
-      resources:
-      - name: "cpu"
-        nominalQuota: 480
-      - name: "memory"
-        nominalQuota: 2000G
-    - name: cpu-proxy
-      resources:
-      - name: "cpu"
-        nominalQuota: 480
-      - name: "memory"
-        nominalQuota: 2000G
     - name: cpu-user
       resources:
       - name: "cpu"
@@ -175,6 +63,10 @@ def ensure_pathways_workload_prerequisites(args, system) -> bool:
   Returns:
     True once conditions satisfy and variables are set. Exits otherwise.
   """
+  # Ensure that PathwaysJob is installed and available on the cluster.
+  if not check_if_pathways_job_is_installed(args):
+    xpk_exit(1)
+
   # Ensure command is provided if not using Pathways in headless mode
   if args.command is None and not args.headless:
     xpk_print(
@@ -187,7 +79,7 @@ def ensure_pathways_workload_prerequisites(args, system) -> bool:
 
   # Ensure the cluster and CPU nodepools were created with create-pathways
   all_node_pools = get_all_nodepools_programmatic(args)
-  desired_pw_cpu_node_pools = {'cpu-user-np', 'cpu-rm-np', 'cpu-proxy-np'}
+  desired_pw_cpu_node_pools = {'cpu-np'}
   if not desired_pw_cpu_node_pools.issubset(set(all_node_pools[0])):
     xpk_print(
         'Cluster needs to be created with `xpk create-pathways` to run'
@@ -209,6 +101,35 @@ def ensure_pathways_workload_prerequisites(args, system) -> bool:
   return True
 
 
+def check_if_pathways_job_is_installed(args) -> bool:
+  """Check if PathwaysJob is installed on the cluster.
+  Args:
+    args: user provided arguments for running the command.
+  Returns:
+    0 if successful and 1 otherwise.
+  """
+  command = (
+      'kubectl get pods -n pathways-job-system --no-headers -o'
+      ' custom-columns=NAME:.metadata.name'
+  )
+  task = f'Check if PathwaysJob is installed on {args.cluster}'
+  return_code, return_msg = run_command_for_value(command, task, args)
+  # return_msg contains the name of the controller pod, if found.
+  xpk_print('check_if_pathways_job_is_installed', return_code, return_msg)
+
+  if return_code != 0:
+    xpk_print(f'{task} returned with ERROR {return_code}.\n')
+    return False
+  if not return_msg:
+    xpk_print(
+        'You are using a new version of XPK, which uses PathwaysJob'
+        ' for Pathways workloads. Please update the cluster using'
+        ' `cluster create-pathways` to enjoy the upgrade!'
+    )
+    return False
+  return True
+
+
 def get_pathways_unified_query_link(args) -> str:
   """Get the unified query link for the pathways workload."""
   query_params = (
@@ -223,58 +144,106 @@ def get_pathways_unified_query_link(args) -> str:
   return f'https://console.cloud.google.com/logs/query;query={query_params}'
 
 
-def get_pathways_rm_args(args, system: SystemCharacteristics) -> str:
-  """Arguments for the Pathways resource manager.
-  Args:
-    args: user provided arguments for running the command.
+def append_custom_pathways_flags(custom_args, prev_indentation=8) -> str:
+  """Append custom Pathways args to Pathways components using a YAML with proper indentation.
 
   Returns:
-    str: yaml containing arguments for the Pathways resource manager.
+    yaml (string): yaml with additional args appended.
   """
-  yaml = """- --server_port=29001
-                - --gcs_scratch_location={args.pathways_gcs_location}
-                - --node_type=resource_manager
-                - --instance_count={instance_count}
-                - --instance_type={instance_type}"""
-  if args.use_pathways:
-    if args.custom_pathways_server_args:
-      yaml = append_custom_pathways_args(yaml, args.custom_pathways_server_args)
-    return yaml.format(
-        args=args,
-        instance_count=args.num_slices,
-        instance_type=f'{get_pathways_expected_tpu_type(system.device_type)}:{system.topology}',
+  yaml = """"""
+  indentation = ' ' * (prev_indentation + 2)
+  if custom_args:
+    custom_args = custom_args.split(' ')
+    for arg in custom_args:
+      yaml += '\n' + indentation + '- ' + arg
+  return yaml
+
+
+def append_custom_pathways_proxy_server(args) -> str:
+  """Append custom Pathways proxy server component using a YAML with proper indentation.
+
+  Returns:
+      yaml (string): yaml with custom proxy server appended.
+  """
+  yaml = """"""
+  if args.proxy_server_image or args.custom_pathways_proxy_server_args:
+    yaml = """- componentType: proxy_server"""
+  indentation = (
+      ' ' * 8
+  )  # Currently 8, based on the YAML, may need to update in the future.
+  if args.proxy_server_image:
+    yaml += '\n' + indentation + 'image: ' + args.proxy_server_image
+  if args.custom_pathways_proxy_server_args:
+    yaml += '\n' + indentation + 'customFlags: '
+    yaml += append_custom_pathways_flags(
+        args.custom_pathways_proxy_server_args, len(indentation)
     )
-  else:
-    return ''
+  return yaml
 
 
-def append_custom_pathways_args(yaml, custom_args) -> str:
-  """Append custom Pathways args to the YAML with proper indentation.
-
-  Args:
-      yaml (string): existing yaml containing args
+def append_custom_pathways_server(args) -> str:
+  """Append custom Pathways server component using a YAML with proper indentation.
 
   Returns:
-      yaml (string): yaml with additional args appended.
+      yaml (string): yaml with custom pathways server appended.
   """
-  second_line = yaml.split('\n')[1]
-  if (
-      not second_line
-  ):  # to cover edge case if only one arg remains, we would have to look at the entire YAML in this case.
-    return yaml
-  # Calculate the indentation based on the second line of existing YAML.
-  indentation = ' ' * (len(second_line) - len(second_line.lstrip()))
-  custom_args = custom_args.split(' ')
-  for arg in custom_args:
-    yaml += '\n' + indentation + '- ' + arg
+  yaml = """"""
+  if args.server_image or args.custom_pathways_server_args:
+    yaml = """- componentType: pathways_server"""
+  indentation = (
+      ' ' * 8
+  )  # Currently 8, based on the YAML, may need to update in the future.
+  if args.server_image:
+    yaml += '\n' + indentation + 'image: ' + args.server_image
+  if args.custom_pathways_server_args:
+    yaml += '\n' + indentation + 'customFlags: '
+    yaml += append_custom_pathways_flags(
+        args.custom_pathways_server_args, len(indentation)
+    )
+  return yaml
+
+
+def append_custom_pathways_worker(args) -> str:
+  """Append custom Pathways worker component using a YAML with proper indentation.
+
+  Returns:
+      yaml (string): yaml with custom pathways server appended.
+  """
+  yaml = """"""
+  if args.server_image or args.custom_pathways_worker_args:
+    yaml = """- componentType: pathways_worker"""
+  indentation = (
+      ' ' * 8
+  )  # Currently 8, based on the YAML, may need to update in the future.
+  if args.server_image:
+    yaml += '\n' + indentation + 'image: ' + args.server_image
+  if args.custom_pathways_worker_args:
+    yaml += '\n' + indentation + 'customFlags: '
+    yaml += append_custom_pathways_flags(
+        args.custom_pathways_worker_args, len(indentation)
+    )
+  return yaml
+
+
+def append_custom_colocated_python_sidecar(args) -> str:
+  """Append custom Pathways colocated python sidecar component using a YAML with proper indentation.
+
+  Returns:
+      yaml (string): yaml with custom pathways server appended.
+  """
+  yaml = """"""
+  if args.colocated_python_sidecar_image:
+    yaml = """- componentType: colocated_python_sidecar"""
+    indentation = (
+        ' ' * 8
+    )  # Currently 8, based on the YAML, may need to update in the future.
+    yaml += '\n' + indentation + 'image: ' + args.colocated_python_sidecar_image
   return yaml
 
 
 def get_user_workload_for_pathways(
     args,
     system: SystemCharacteristics,
-    pod_failure_policy,
-    storages: list[Storage],
 ) -> str:
   """
   Create a user workload container for Pathways.
@@ -289,61 +258,30 @@ def get_user_workload_for_pathways(
     str:
       Pathways server port as a YAML string
   """
-  user_workload_yaml = """- name: main
-      replicas: 1
-      template:
-        metadata:
-          labels:
-            xpk.google.com/workload: {args.workload}
-        spec:
-          backoffLimit: 0
-          completions: 1
-          parallelism: 1
-          {pod_failure_policy}
-          template:
-            metadata:
-              annotations:
-                {gcs_fuse_annotation}
-            spec:
-              containers:
+  user_workload_yaml = """
+          metadata:
+          spec:
+            containers:
               {container}
-              serviceAccountName: {service_account}
-              nodeSelector:
-                cloud.google.com/gke-nodepool: cpu-user-np
-              hostNetwork: true
-              dnsPolicy: ClusterFirstWithHostNet
-              restartPolicy: Never
-              volumes:
-              - hostPath:
-                  path: /tmp
-                  type: DirectoryOrCreate
-                name: shared-tmp
-              {storage_volumes}"""
+            nodeSelector:
+              cloud.google.com/gke-nodepool: cpu-np
+            hostNetwork: true
+            dnsPolicy: ClusterFirstWithHostNet
+            restartPolicy: Never
+            volumes:
+            - hostPath:
+                path: /tmp
+                type: DirectoryOrCreate
+              name: shared-tmp
+    """
   if args.headless:
     return ''
   else:
     container, _ = get_user_workload_container(args, system)
-    storage_volumes = get_storage_volumes_yaml(storages)
     return user_workload_yaml.format(
         args=args,
         container=container,
-        storage_volumes=storage_volumes,
-        pod_failure_policy=pod_failure_policy,
-        service_account=XPK_SA,
-        gcs_fuse_annotation=GCS_FUSE_ANNOTATION,
     )
-
-
-def get_rm_address(args) -> str:
-  """Generates the Pathways resource manager address.
-  Args:
-    args: user provided arguments for running the command.
-
-  Returns:
-    str: Fully qualified RM address.
-  """
-  rm_address = f'{args.workload}-rm-0-0.{args.workload}:29001'
-  return rm_address
 
 
 def get_proxy_address(args) -> str:
@@ -354,24 +292,41 @@ def get_proxy_address(args) -> str:
   Returns:
     str: Fully qualified proxy address.
   """
-  proxy_address = f'grpc://{args.workload}-proxy-0-0.{args.workload}:29000'
+  proxy_address = (
+      f'grpc://{args.workload}-pathways-head-0-0.{args.workload}:29000'
+  )
   return proxy_address
 
 
-def get_pathways_expected_tpu_type(device_type: str) -> str:
-  """Returns the device type expected by Pathways
+def try_to_delete_pathwaysjob_first(args, workloads) -> bool:
+  """Function to delete PathwaysJob workload. This is needed as PathwaysJob
+  owns the JobSet it creates.
+
   Args:
-    device_type: the system characteristic device type
+    args: user provided arguments for running the command.
+    workloads: list of workloads that match the delete filter.
 
   Returns:
-    str: the device type expected by pathways.
+    True if successful and False otherwise.
   """
-  raw_type = device_type.split('-')[0].lower()
-  pathways_expected_instance = PathwaysExpectedInstancesMap[raw_type]
-  if not pathways_expected_instance:
-    xpk_print(
-        f'Passed in device_type {device_type} is incorrect. Please pass in a'
-        ' valid device type'
+  commands = []
+  task_names = []
+  for workload in workloads:
+    args.workload = workload
+    command = f'kubectl delete pathwaysjob {workload} -n default'
+    task_name = f'PathwaysWorkloadDelete-{workload}'
+    commands.append(command)
+    task_names.append(task_name)
+
+  # Not batching deletion for single workload
+  if len(workloads) == 1:
+    return_code = run_command_with_updates(commands[0], 'Delete Workload', args)
+  else:
+    return_code = run_commands(
+        commands, 'Delete Workload', task_names, batch=100
     )
-    xpk_exit(1)
-  return pathways_expected_instance
+
+  if return_code != 0:
+    xpk_print(f'Delete Workload request returned ERROR {return_code}')
+    return False
+  return True

--- a/src/xpk/core/scheduling.py
+++ b/src/xpk/core/scheduling.py
@@ -229,6 +229,21 @@ def create_accelerator_label(accelerator_type, system) -> str:
   )
 
 
+def create_tpu_machine_type(accelerator_type, system) -> str:
+  """Generates TPU machine type..
+
+  Args:
+    accelerator_type: type of accelerator.
+    system: system characteristics.
+
+  Returns:
+    The accelerator label.
+  """
+  if accelerator_type == AcceleratorType['TPU']:
+    return f'{system.gce_machine_type}'
+  return ''
+
+
 def create_machine_label(
     accelerator_type, system, autoprovisioning_enabled: bool = False
 ) -> str:
@@ -250,4 +265,25 @@ def create_machine_label(
         f'{AcceleratorTypeToAcceleratorCharacteristics[accelerator_type].machine_label}:'
         f' {system.topology}'
     )
+  return ''
+
+
+def create_tpu_topology(
+    accelerator_type, system, autoprovisioning_enabled: bool = False
+) -> str:
+  """Generates TPU topology.
+
+  Args:
+    accelerator_type: type of accelerator.
+    system: system characteristics.
+    autoprovisioning_enabled: describes autoprovisioning enablement.
+
+  Returns:
+    The machine label.
+  """
+  if (
+      accelerator_type == AcceleratorType['TPU']
+      and not autoprovisioning_enabled
+  ):
+    return f'{system.topology}'
   return ''

--- a/src/xpk/parser/cluster.py
+++ b/src/xpk/parser/cluster.py
@@ -107,6 +107,7 @@ def set_cluster_parser(cluster_parser):
           ' enable cluster to accept Pathways workloads.'
       ),
   )
+
   ### Autoprovisioning arguments specific to "cluster create"
   cluster_create_autoprovisioning_arguments = (
       cluster_create_parser.add_argument_group(
@@ -462,7 +463,7 @@ def add_shared_cluster_create_optional_arguments(args_parsers):
     custom_parser.add_argument(
         '--pathways-gce-machine-type',
         type=str,
-        default='n1-standard-32',
+        default='n2-standard-64',
         help='The CPU type for Pathways CPU nodepools',
     )
     custom_parser.add_argument(
@@ -580,7 +581,6 @@ def add_shared_cluster_create_optional_arguments(args_parsers):
             ' Identity is enabled by default.'
         ),
     )
-
     custom_parser.add_argument(
         '--enable-gcpfilestore-csi-driver',
         action='store_true',

--- a/src/xpk/parser/workload.py
+++ b/src/xpk/parser/workload.py
@@ -179,6 +179,19 @@ def set_workload_parsers(workload_parser):
           ' create Pathways workloads.'
       ),
   )
+  workload_create_parser_optional_arguments.add_argument(
+      '--restart-on-exit-codes',
+      type=str,
+      default=None,
+      help=(
+          'Adding this argument specifies additional user-defined exit codes'
+          ' that allow restarting the workload when --max-restarts is set to'
+          ' a value greater than 0. By default, workloads restart on exit'
+          ' codes 42 and 127-255. Any exit codes provided through this flag'
+          ' will be included alongside the default codes for restarting'
+          ' conditions.'
+      ),
+  )
 
   # Autoprovisioning workload arguments
   workload_create_autoprovisioning_arguments.add_argument(
@@ -262,9 +275,7 @@ def set_workload_parsers(workload_parser):
   workload_create_pathways_parser_optional_arguments.add_argument(
       '--proxy-server-image',
       type=str,
-      default=(
-          'us-docker.pkg.dev/cloud-tpu-v2-images/pathways/proxy_server:latest'
-      ),
+      default='',
       help=(
           'Please provide the proxy server image for Pathways. This arg can'
           ' only be used in `xpk workload create-pathways`.'
@@ -273,7 +284,7 @@ def set_workload_parsers(workload_parser):
   workload_create_pathways_parser_optional_arguments.add_argument(
       '--server-image',
       type=str,
-      default='us-docker.pkg.dev/cloud-tpu-v2-images/pathways/server:latest',
+      default='',
       help=(
           'Please provide the server image for Pathways. This arg can only be'
           ' used in `xpk workload create-pathways`.'
@@ -311,7 +322,7 @@ def set_workload_parsers(workload_parser):
   workload_create_pathways_parser_optional_arguments.add_argument(
       '--custom-pathways-server-args',
       type=str,
-      default=None,
+      default='',
       help=(
           'Provide custom Pathways server args as follows -'
           " --custom-pathways-server-args='--arg_1=xxx --arg2=yyy'"
@@ -322,7 +333,7 @@ def set_workload_parsers(workload_parser):
   workload_create_pathways_parser_optional_arguments.add_argument(
       '--custom-pathways-proxy-server-args',
       type=str,
-      default=None,
+      default='',
       help=(
           'Provide custom Pathways proxy server args as follows -'
           " --custom-pathways-proxy-server-args='--arg_1=xxx --arg2=yyy'"
@@ -333,10 +344,31 @@ def set_workload_parsers(workload_parser):
   workload_create_pathways_parser_optional_arguments.add_argument(
       '--custom-pathways-worker-args',
       type=str,
-      default=None,
+      default='',
       help=(
           'Provide custom Pathways worker args as follows -'
           " --custom-pathways-worker-args='--arg_1=xxx --arg2=yyy'"
+      ),
+      required=False,
+  )
+
+  workload_create_pathways_parser_optional_arguments.add_argument(
+      '--elastic-slices',
+      type=int,
+      default=0,
+      help=(
+          'Enable elastic slices in Pathways and specify'
+          ' the number of slices the workload could lose.'
+      ),
+      required=False,
+  )
+  workload_create_pathways_parser_optional_arguments.add_argument(
+      '--max-slice-restarts',
+      type=int,
+      default=1,
+      help=(
+          'Specify the maximum times the workers in a slice can be'
+          ' restarted. Used with --elastic-slices for Pathways workloads.'
       ),
       required=False,
   )
@@ -601,9 +633,9 @@ def add_shared_workload_create_optional_arguments(args_parsers):
         ),
     )
     custom_parser.add_argument(
-        '--remote-python-sidecar-image',
+        '--colocated-python-sidecar-image',
         type=str,
-        default=None,
+        default='',
         help='Remote Python sidecar server image.',
     )
     custom_parser.add_argument(
@@ -612,19 +644,6 @@ def add_shared_workload_create_optional_arguments(args_parsers):
         help=(
             'Set this flag to get verbose logging to investigate the issue in'
             ' the workload.'
-        ),
-    )
-    custom_parser.add_argument(
-        '--restart-on-exit-codes',
-        type=str,
-        default=None,
-        help=(
-            'Adding this argument specifies additional user-defined exit codes'
-            ' that allow restarting the workload when --max-restarts is set to'
-            ' a value greater than 0. By default, workloads restart on exit'
-            ' codes 42 and 127-255. Any exit codes provided through this flag'
-            ' will be included alongside the default codes for restarting'
-            ' conditions.'
         ),
     )
 


### PR DESCRIPTION
## Fixes / Features
- Using PathwaysJob CRD https://github.com/google/pathways-job/ instead of JobSet CRD for PathwaysJob workloads.
- - Installed PathwaysJob CRD as part of cluster create.
- Removing storage, failure policy rules and other unsupported , untested features from the `xpk workload create-pathways` flow.
- Adding custom components to Pathways workload flows conditionally.
- Modifying workload delete to also cater to PathwaysJob workloads.
- Adding support for elasticity in Pathways workloads in XPK, by introducing new args.
- Bug fix to correct default remote python image and other string default types from None to ""
- Removed cpu-rm, cpu-proxy. Retained cpu-user and changed its machine type to n2-standard-64 to allow Pathways workloads with huge pods named Pathways head.
- Updated `xpk cluster delete` flow to support deletion of PathwaysJobs as well.
- Ensuring backward compatibility and prompting users to upgrade to use PathwaysJob for pathways workloads.

## Testing / Documentation
Testing details.

- [ y ] Tests pass
- [ y ] Appropriate changes to documentation are included in the PR
