### PR TITLE
Remove sidecar limits for GCS fuse storages

### DIFF
--- a/src/xpk/commands/batch.py
+++ b/src/xpk/commands/batch.py
@@ -66,7 +66,9 @@ def submit_job(args: Namespace) -> None:
       ' --first-node-ip'
   )
   cmd = add_gpu_networking_annotations_to_command(args, cmd)
-  cmd += get_gcsfuse_annotations(args)
+
+  for annotation in get_gcsfuse_annotations(args):
+    cmd += f' --pod-template-annotation {annotation}'
 
   if args.ignore_unknown_flags:
     cmd += ' --ignore-unknown-flags'

--- a/src/xpk/commands/batch.py
+++ b/src/xpk/commands/batch.py
@@ -22,7 +22,7 @@ from ..core.gcloud_context import add_zone_and_project
 from ..core.kueue import LOCAL_QUEUE_NAME
 from ..utils.console import xpk_exit, xpk_print
 from .common import set_cluster_command
-from ..core.kjob import AppProfileDefaults, JobTemplateDefaults, prepare_kjob, Kueue_TAS_annotation, get_gcsfuse_annotation
+from ..core.kjob import AppProfileDefaults, JobTemplateDefaults, prepare_kjob, Kueue_TAS_annotation, get_gcsfuse_annotations
 from .kjob_common import add_gpu_networking_annotations_to_command
 from .kind import set_local_cluster_command
 import re
@@ -66,9 +66,7 @@ def submit_job(args: Namespace) -> None:
       ' --first-node-ip'
   )
   cmd = add_gpu_networking_annotations_to_command(args, cmd)
-  gcsfuse_annotation = get_gcsfuse_annotation(args)
-  if gcsfuse_annotation is not None:
-    cmd += f' --pod-template-annotation {gcsfuse_annotation}'
+  cmd += get_gcsfuse_annotations(args)
 
   if args.ignore_unknown_flags:
     cmd += ' --ignore-unknown-flags'

--- a/src/xpk/commands/run.py
+++ b/src/xpk/commands/run.py
@@ -22,7 +22,7 @@ from ..core.gcloud_context import add_zone_and_project
 from ..core.kueue import LOCAL_QUEUE_NAME
 from ..utils.console import xpk_exit, xpk_print
 from .common import set_cluster_command
-from ..core.kjob import JobTemplateDefaults, AppProfileDefaults, prepare_kjob, Kueue_TAS_annotation, get_gcsfuse_annotation
+from ..core.kjob import JobTemplateDefaults, AppProfileDefaults, prepare_kjob, Kueue_TAS_annotation, get_gcsfuse_annotations
 from .kjob_common import add_gpu_networking_annotations_to_command
 from .kind import set_local_cluster_command
 
@@ -63,10 +63,7 @@ def submit_job(args: Namespace) -> None:
       ' --wait --rm  --first-node-ip'
   )
   cmd = add_gpu_networking_annotations_to_command(args, cmd)
-
-  gcsfuse_annotation = get_gcsfuse_annotation(args)
-  if gcsfuse_annotation is not None:
-    cmd += f' --pod-template-annotation {gcsfuse_annotation}'
+  cmd += get_gcsfuse_annotations(args)
 
   if args.timeout:
     cmd += f' --wait-timeout {args.timeout}s'

--- a/src/xpk/commands/run.py
+++ b/src/xpk/commands/run.py
@@ -63,7 +63,9 @@ def submit_job(args: Namespace) -> None:
       ' --wait --rm  --first-node-ip'
   )
   cmd = add_gpu_networking_annotations_to_command(args, cmd)
-  cmd += get_gcsfuse_annotations(args)
+
+  for annotation in get_gcsfuse_annotations(args):
+    cmd += f' --pod-template-annotation {annotation}'
 
   if args.timeout:
     cmd += f' --wait-timeout {args.timeout}s'

--- a/src/xpk/commands/shell.py
+++ b/src/xpk/commands/shell.py
@@ -88,7 +88,9 @@ def connect_to_new_interactive_shell(args: Namespace) -> int:
       'kubectl-kjob create interactive --profile'
       f' {AppProfileDefaults.NAME.value} --pod-running-timeout 180s'
   )
-  cmd += get_gcsfuse_annotations(args)
+
+  for annotation in get_gcsfuse_annotations(args):
+    cmd += f' --pod-template-annotation {annotation}'
 
   return run_command_with_full_controls(
       command=cmd,

--- a/src/xpk/commands/shell.py
+++ b/src/xpk/commands/shell.py
@@ -20,7 +20,7 @@ from ..core.kjob import (
     AppProfileDefaults,
     prepare_kjob,
     get_pod_template_interactive_command,
-    get_gcsfuse_annotation,
+    get_gcsfuse_annotations,
 )
 
 exit_instructions = 'To exit the shell input "exit".'
@@ -88,10 +88,7 @@ def connect_to_new_interactive_shell(args: Namespace) -> int:
       'kubectl-kjob create interactive --profile'
       f' {AppProfileDefaults.NAME.value} --pod-running-timeout 180s'
   )
-
-  gcsfuse_annotation = get_gcsfuse_annotation(args)
-  if gcsfuse_annotation is not None:
-    cmd += f' --pod-template-annotation {gcsfuse_annotation}'
+  cmd += get_gcsfuse_annotations(args)
 
   return run_command_with_full_controls(
       command=cmd,

--- a/src/xpk/commands/workload.py
+++ b/src/xpk/commands/workload.py
@@ -62,7 +62,7 @@ from ..core.storage import (
     get_storages_to_mount,
     get_storage_volume_mounts_yaml_for_gpu,
     get_storage_volumes_yaml_for_gpu,
-    get_storage_annotations_yaml,
+    get_storage_annotations,
 )
 from ..core.system_characteristics import (
     AcceleratorType,
@@ -641,7 +641,9 @@ def workload_create(args) -> None:
           storage_volume_mounts=get_storage_volume_mounts_yaml_for_gpu(
               all_storages
           ),
-          storage_annotations=get_storage_annotations_yaml(all_storages, 12),
+          storage_annotations=('\n' + (' ' * 12)).join(
+              get_storage_annotations(all_storages)
+          ),
           service_account=service_account,
           failure_policy_rules=failure_policy_rules,
           pod_failure_policy=pod_failure_policy,
@@ -669,7 +671,9 @@ def workload_create(args) -> None:
         local_queue_name=LOCAL_QUEUE_NAME,
         autoprovisioning_args=autoprovisioning_args,
         backoff_limit=system.vms_per_slice * 4,
-        storage_annotations=get_storage_annotations_yaml(all_storages, 16),
+        storage_annotations=('\n' + (' ' * 16)).join(
+            get_storage_annotations(all_storages)
+        ),
         storage_volumes=get_storage_volumes_yaml(all_storages),
         storage_volume_mounts=get_storage_volume_mounts_yaml(all_storages),
         pathways_rm_args=get_pathways_rm_args(args, system),
@@ -693,7 +697,9 @@ def workload_create(args) -> None:
         local_queue_name=LOCAL_QUEUE_NAME,
         autoprovisioning_args=autoprovisioning_args,
         volumes=get_volumes(args, system),
-        storage_annotations=get_storage_annotations_yaml(all_storages, 16),
+        storage_annotations=('\n' + (' ' * 16)).join(
+            get_storage_annotations(all_storages)
+        ),
         service_account=service_account,
         failure_policy_rules=failure_policy_rules,
         pod_failure_policy=pod_failure_policy,

--- a/src/xpk/commands/workload.py
+++ b/src/xpk/commands/workload.py
@@ -378,20 +378,6 @@ def workload_create(args) -> None:
     if return_code != 0:
       xpk_exit(return_code)
 
-  storages: list[Storage] = get_storages_to_mount(k8s_api_client, args.storage)
-  gcs_fuse_storages = list(
-      filter(lambda storage: storage.type == GCS_FUSE_TYPE, storages)
-  )
-  gcpfilestore_storages: list[Storage] = list(
-      filter(lambda storage: storage.type == GCP_FILESTORE_TYPE, storages)
-  )
-  service_account = ''
-  if len(gcs_fuse_storages) > 0:
-    service_account = XPK_SA
-    xpk_print(f'Detected gcsfuse Storages to add: {gcs_fuse_storages}')
-  else:
-    xpk_print('No gcsfuse Storages to add detected')
-
   service_account = ''
   all_storages = []
   # Currently storage customization is not supported for Pathways workloads. b/408468941

--- a/src/xpk/commands/workload.py
+++ b/src/xpk/commands/workload.py
@@ -62,7 +62,7 @@ from ..core.storage import (
     get_storages_to_mount,
     get_storage_volume_mounts_yaml_for_gpu,
     get_storage_volumes_yaml_for_gpu,
-    GCS_FUSE_ANNOTATION,
+    get_storage_annotations_yaml,
 )
 from ..core.system_characteristics import (
     AcceleratorType,
@@ -567,10 +567,8 @@ def workload_create(args) -> None:
   gcpfilestore_storages: list[Storage] = list(
       filter(lambda storage: storage.type == GCP_FILESTORE_TYPE, storages)
   )
-  storage_annotations = ''
   service_account = ''
   if len(gcs_fuse_storages) > 0:
-    storage_annotations = GCS_FUSE_ANNOTATION
     service_account = XPK_SA
     xpk_print(f'Detected gcsfuse Storages to add: {gcs_fuse_storages}')
   else:
@@ -643,7 +641,7 @@ def workload_create(args) -> None:
           storage_volume_mounts=get_storage_volume_mounts_yaml_for_gpu(
               all_storages
           ),
-          storage_annotations=storage_annotations,
+          storage_annotations=get_storage_annotations_yaml(all_storages, 12),
           service_account=service_account,
           failure_policy_rules=failure_policy_rules,
           pod_failure_policy=pod_failure_policy,
@@ -671,7 +669,7 @@ def workload_create(args) -> None:
         local_queue_name=LOCAL_QUEUE_NAME,
         autoprovisioning_args=autoprovisioning_args,
         backoff_limit=system.vms_per_slice * 4,
-        storage_annotations=storage_annotations,
+        storage_annotations=get_storage_annotations_yaml(all_storages, 16),
         storage_volumes=get_storage_volumes_yaml(all_storages),
         storage_volume_mounts=get_storage_volume_mounts_yaml(all_storages),
         pathways_rm_args=get_pathways_rm_args(args, system),
@@ -695,7 +693,7 @@ def workload_create(args) -> None:
         local_queue_name=LOCAL_QUEUE_NAME,
         autoprovisioning_args=autoprovisioning_args,
         volumes=get_volumes(args, system),
-        storage_annotations=storage_annotations,
+        storage_annotations=get_storage_annotations_yaml(all_storages, 16),
         service_account=service_account,
         failure_policy_rules=failure_policy_rules,
         pod_failure_policy=pod_failure_policy,

--- a/src/xpk/commands/workload.py
+++ b/src/xpk/commands/workload.py
@@ -391,7 +391,6 @@ def workload_create(args) -> None:
     gcpfilestore_storages: list[Storage] = list(
         filter(lambda storage: storage.type == GCP_FILESTORE_TYPE, storages)
     )
-    service_account = ''
     if len(gcs_fuse_storages) > 0:
       service_account = XPK_SA
       xpk_print(f'Detected gcsfuse Storages to add: {gcs_fuse_storages}')

--- a/src/xpk/core/kjob.py
+++ b/src/xpk/core/kjob.py
@@ -450,7 +450,7 @@ def create_volume_bundle_instance(
       xpk_exit(1)
 
 
-def get_gcsfuse_annotations(args: Namespace) -> str:
+def get_gcsfuse_annotations(args: Namespace) -> list[str]:
   k8s_api_client = setup_k8s_env(args)
   gcsfuse_storages = get_auto_mount_gcsfuse_storages(k8s_api_client)
   annotations = []

--- a/src/xpk/core/kjob.py
+++ b/src/xpk/core/kjob.py
@@ -455,8 +455,6 @@ def get_gcsfuse_annotations(args: Namespace) -> str:
   gcsfuse_storages = get_auto_mount_gcsfuse_storages(k8s_api_client)
   annotations = []
   if len(gcsfuse_storages) > 0:
-    annotations = [
-        f" --pod-template-annotation {key}={value}"
-        for key, value in GCS_FUSE_ANNOTATIONS.items()
-    ]
-  return "".join(annotations)
+    for key, value in GCS_FUSE_ANNOTATIONS.items():
+      annotations.append(f"{key}={value}")
+  return annotations

--- a/src/xpk/core/kjob.py
+++ b/src/xpk/core/kjob.py
@@ -23,6 +23,7 @@ from kubernetes.client import ApiClient
 from kubernetes.client.rest import ApiException
 
 from ..core.capacity import H100_MEGA_DEVICE_TYPE, H200_DEVICE_TYPE
+from ..core.storage import GCS_FUSE_ANNOTATIONS
 from ..core.workload_decorators import rdma_decorator, tcpxo_decorator
 from ..utils import templates
 from ..utils.console import xpk_exit, xpk_print
@@ -449,9 +450,13 @@ def create_volume_bundle_instance(
       xpk_exit(1)
 
 
-def get_gcsfuse_annotation(args: Namespace) -> str | None:
+def get_gcsfuse_annotations(args: Namespace) -> str:
   k8s_api_client = setup_k8s_env(args)
   gcsfuse_storages = get_auto_mount_gcsfuse_storages(k8s_api_client)
+  annotations = []
   if len(gcsfuse_storages) > 0:
-    return "gke-gcsfuse/volumes=true"
-  return None
+    annotations = [
+        f" --pod-template-annotation {key}={value}"
+        for key, value in GCS_FUSE_ANNOTATIONS.items()
+    ]
+  return "".join(annotations)

--- a/src/xpk/core/pathways.py
+++ b/src/xpk/core/pathways.py
@@ -22,7 +22,7 @@ from .cluster import XPK_SA
 from .config import AcceleratorType
 from .storage import (
     Storage,
-    get_storage_annotations_yaml,
+    get_storage_annotations,
     get_storage_volumes_yaml,
 )
 from .system_characteristics import SystemCharacteristics
@@ -328,14 +328,15 @@ def get_user_workload_for_pathways(
   else:
     container, _ = get_user_workload_container(args, system)
     storage_volumes = get_storage_volumes_yaml(storages)
-    storage_annotations = get_storage_annotations_yaml(storages, 16)
     return user_workload_yaml.format(
         args=args,
         container=container,
         storage_volumes=storage_volumes,
         pod_failure_policy=pod_failure_policy,
         service_account=XPK_SA,
-        storage_annotations=storage_annotations,
+        storage_annotations=('\n' + (' ' * 16)).join(
+            get_storage_annotations(storages)
+        ),
     )
 
 

--- a/src/xpk/core/pathways.py
+++ b/src/xpk/core/pathways.py
@@ -14,13 +14,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from .cluster import XPK_SA
 from ..core.docker_container import get_user_workload_container
 from ..core.gcloud_context import zone_to_region
 from ..core.nodepool import get_all_nodepools_programmatic
 from ..utils.console import xpk_exit, xpk_print
+from .cluster import XPK_SA
 from .config import AcceleratorType
-from .storage import Storage, get_storage_volumes_yaml, GCS_FUSE_ANNOTATION
+from .storage import (
+    Storage,
+    get_storage_annotations_yaml,
+    get_storage_volumes_yaml,
+)
 from .system_characteristics import SystemCharacteristics
 
 PathwaysExpectedInstancesMap = {
@@ -303,7 +307,7 @@ def get_user_workload_for_pathways(
           template:
             metadata:
               annotations:
-                {gcs_fuse_annotation}
+                {storage_annotations}
             spec:
               containers:
               {container}
@@ -324,13 +328,14 @@ def get_user_workload_for_pathways(
   else:
     container, _ = get_user_workload_container(args, system)
     storage_volumes = get_storage_volumes_yaml(storages)
+    storage_annotations = get_storage_annotations_yaml(storages, 16)
     return user_workload_yaml.format(
         args=args,
         container=container,
         storage_volumes=storage_volumes,
         pod_failure_policy=pod_failure_policy,
         service_account=XPK_SA,
-        gcs_fuse_annotation=GCS_FUSE_ANNOTATION,
+        storage_annotations=storage_annotations,
     )
 
 

--- a/src/xpk/core/storage.py
+++ b/src/xpk/core/storage.py
@@ -319,7 +319,7 @@ def install_storage_crd(k8s_api_client: ApiClient) -> None:
       xpk_exit(1)
 
 
-def get_storage_annotations_yaml(storages: list[Storage], offset: int) -> str:
+def get_storage_annotations(storages: list[Storage]) -> list[str]:
   """
   Generates the storage annotations for workloads in the format of a YAML snippet.
 
@@ -330,13 +330,10 @@ def get_storage_annotations_yaml(storages: list[Storage], offset: int) -> str:
   Returns:
       A string containing the YAML representation of the storage annotations.
   """
-  sep = "\n" + (" " * offset)
   if any(storage.type == GCS_FUSE_TYPE for storage in storages):
-    return sep.join(
-        f'{key}: "{value}"' for key, value in GCS_FUSE_ANNOTATIONS.items()
-    )
+    return [f'{key}: "{value}"' for key, value in GCS_FUSE_ANNOTATIONS.items()]
   else:
-    return ""
+    return []
 
 
 def get_storage_volume_mounts_yaml(storages: list[Storage]) -> str:

--- a/src/xpk/core/storage.py
+++ b/src/xpk/core/storage.py
@@ -330,10 +330,11 @@ def get_storage_annotations(storages: list[Storage]) -> list[str]:
   Returns:
       A string containing the YAML representation of the storage annotations.
   """
+  annotations = []
   if any(storage.type == GCS_FUSE_TYPE for storage in storages):
-    return [f'{key}: "{value}"' for key, value in GCS_FUSE_ANNOTATIONS.items()]
-  else:
-    return []
+    for key, value in GCS_FUSE_ANNOTATIONS.items():
+      annotations.append(f'{key}: "{value}"')
+  return annotations
 
 
 def get_storage_volume_mounts_yaml(storages: list[Storage]) -> str:

--- a/src/xpk/core/workload_decorators/storage_decorator.py
+++ b/src/xpk/core/workload_decorators/storage_decorator.py
@@ -16,7 +16,7 @@ limitations under the License.
 
 import yaml
 
-from ...core.storage import GCS_FUSE_TYPE, get_storage_volumes_yaml_dict, GCS_FUSE_ANNOTATION
+from ...core.storage import GCS_FUSE_TYPE, get_storage_volumes_yaml_dict, GCS_FUSE_ANNOTATIONS
 
 
 def decorate_jobset(jobset_manifest_str, storages) -> str:
@@ -42,9 +42,9 @@ def decorate_jobset(jobset_manifest_str, storages) -> str:
 def add_annotations(job_manifest, storages):
   """Adds or updates storage annotations in the Pod template."""
   annotations = job_manifest['spec']['template']['metadata']['annotations']
-  gcs_present = [storage.type == GCS_FUSE_TYPE for storage in storages]
+  gcs_present = any(storage.type == GCS_FUSE_TYPE for storage in storages)
   if gcs_present:
-    annotations.update(GCS_FUSE_ANNOTATION)
+    annotations.update(GCS_FUSE_ANNOTATIONS)
 
 
 def add_volumes(job_manifest, storage_volumes):


### PR DESCRIPTION
## Fixes / Features
- remove GCS fuse sidecar limits
- fixes error when creating workloads: `ValueError: dictionary update sequence element #0 has length 1; 2 is required`