### PR TITLE
Rename Remote Python to Colocated Python

### DIFF
--- a/src/xpk/core/pathways.py
+++ b/src/xpk/core/pathways.py
@@ -74,7 +74,7 @@ def get_pathways_proxy_args(args) -> str:
 
 
 def get_pathways_sidecar_container(args) -> str:
-  """This is a sidecar container that runs the remote python server.
+  """This is a sidecar container that runs the colocated python server.
 
       It is a special case of the initContainer (designated by restartPolicy:
       Always)
@@ -87,8 +87,8 @@ def get_pathways_sidecar_container(args) -> str:
     str: yaml containing arguments for the Pathways sidecar container.
   """
   yaml = """initContainers:
-              - name: remote-python-sidecar
-                image: {args.remote_python_sidecar_image}
+              - name: colocated-python-sidecar
+                image: {args.colocated_python_sidecar_image}
                 imagePullPolicy: Always
                 securityContext:
                   privileged: true
@@ -101,7 +101,7 @@ def get_pathways_sidecar_container(args) -> str:
                 env:
                 - name: GRPC_SERVER_ADDRESS
                   value: '0.0.0.0:50051'"""
-  if args.use_pathways and args.remote_python_sidecar_image is not None:
+  if args.use_pathways and args.colocated_python_sidecar_image is not None:
     return yaml.format(args=args)
   else:
     return ''

--- a/src/xpk/parser/workload.py
+++ b/src/xpk/parser/workload.py
@@ -583,10 +583,10 @@ def add_shared_workload_create_optional_arguments(args_parsers):
         ),
     )
     custom_parser.add_argument(
-        '--remote-python-sidecar-image',
+        '--colocated-python-sidecar-image',
         type=str,
         default=None,
-        help='Remote Python sidecar server image.',
+        help='Colocated Python sidecar server image.',
     )
     custom_parser.add_argument(
         '--enable-debug-logs',


### PR DESCRIPTION
## Fixes / Features
- To be more in line with the JAX Colocated Python feature, rename "Remote Python" to Colocated Python. Changes will also be needed in the appropriate MaxText locations.
- Relevant MaxText PR: https://github.com/AI-Hypercomputer/maxtext/pull/1532

## Testing / Documentation
TODO: Verify with above MaxText PR.

- [ y ] Tests pass
- [ y ] Appropriate changes to documentation are included in the PR
