### PR TITLE
Add Multi-tier checkpointing support in XPK Cluster Creation

### DIFF
--- a/src/xpk/commands/cluster.py
+++ b/src/xpk/commands/cluster.py
@@ -58,6 +58,7 @@ from ..core.nodepool import (
     run_gke_node_pool_create_command,
 )
 from ..core.ray import install_ray_cluster
+from ..core.mtc import install_mtc_on_cluster
 from ..core.resources import create_cluster_configmaps
 from ..core.storage import install_storage_crd
 from ..core.system_characteristics import (
@@ -277,6 +278,12 @@ def cluster_create(args) -> None:
     return_code = install_ray_cluster(args, system)
     if return_code != 0:
       xpk_print('Installation of RayCluster failed.')
+      xpk_exit(return_code)
+
+  if hasattr(args, 'enable_mtc') and args.enable_mtc:
+    return_code = install_mtc_on_cluster(args, system)
+    if return_code != 0:
+      xpk_print('Installation of MTC failed.')
       xpk_exit(return_code)
 
   xpk_print('GKE commands done! Resources are created.')
@@ -815,6 +822,7 @@ def run_gke_cluster_create_command(
   addons = []
   if args.enable_gcsfuse_csi_driver:
     addons.append('GcsFuseCsiDriver')
+
   if args.enable_gcpfilestore_csi_driver:
     addons.append('GcpFilestoreCsiDriver')
 
@@ -823,6 +831,9 @@ def run_gke_cluster_create_command(
 
   if args.enable_pd_csi_driver:
     addons.append('GcePersistentDiskCsiDriver')
+
+  if hasattr(args, 'enable_mtc') and args.enable_mtc:
+    addons.append('HighScaleCheckpointing')
 
   if len(addons) > 0:
     addons_str = ','.join(addons)

--- a/src/xpk/core/mtc.py
+++ b/src/xpk/core/mtc.py
@@ -1,0 +1,77 @@
+"""
+Copyright 2024 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from ..utils.console import xpk_exit, xpk_print
+from ..utils import templates
+from ..utils.kubectl import apply_kubectl_manifest
+from ..core.cluster import setup_k8s_env
+
+MTC_CPC_PATH = "/../templates/mtc-cpc.yaml"
+
+
+def create_mtc_cpc(
+    mtc_gcs_bucket: str,
+    mtc_machine_type: str,
+    mtc_toleration_key: str,
+    mtc_ramdisk_size: str,
+) -> dict:
+  data = templates.load(MTC_CPC_PATH)
+
+  data["spec"]["cloudStorageBucketName"] = mtc_gcs_bucket
+  data["spec"]["nodeSelector"][
+      "node.kubernetes.io/instance-type"
+  ] = mtc_machine_type
+  data["spec"]["tolerations"][0]["key"] = mtc_toleration_key
+  data["spec"]["inMemoryVolumeSize"] = mtc_ramdisk_size
+
+  return data
+
+
+def install_mtc_on_cluster(args, system) -> int:
+  """Install MTC on the cluster
+
+  Args:
+    args: user provided arguments for running the command.
+
+  Returns:
+    return code of the command.
+  """
+  if args.mtc_gcs_bucket is None:
+    xpk_print("MTC GCS bucket is required.")
+    xpk_exit(1)
+  if args.mtc_gcs_bucket.startswith("gs://"):
+    args.mtc_gcs_bucket = args.mtc_gcs_bucket.replace("gs://", "")
+
+  if args.mtc_ramdisk_size is None:
+    xpk_print("MTC ramdisk size is required.")
+    xpk_exit(1)
+
+  if args.mtc_toleration_key is None:
+    args.mtc_toleration_key = "google.com/tpu"
+
+  mtc_checkpoint_configuration_crd_data = create_mtc_cpc(
+      args.mtc_gcs_bucket,
+      system.gce_machine_type,
+      args.mtc_toleration_key,
+      args.mtc_ramdisk_size,
+  )
+  xpk_print("Applying MTC Checkpoint Configuration")
+  k8s_api_client = setup_k8s_env(args)
+  return_code = apply_kubectl_manifest(
+      k8s_api_client, [mtc_checkpoint_configuration_crd_data]
+  )
+
+  return return_code

--- a/src/xpk/parser/cluster.py
+++ b/src/xpk/parser/cluster.py
@@ -189,6 +189,12 @@ def set_cluster_create_parser(cluster_create_parser: ArgumentParser):
       cluster_create_tensorboard_arguments
   )
 
+  ### MTC arguments specific to "cluster create"
+  cluster_create_mtc_arguments = cluster_create_parser.add_argument_group(
+      'Optional MTC Arguments',
+      'Arguments for configuring MTC in cluster create.',
+  )
+  add_shared_cluster_create_mtc_arguments(cluster_create_mtc_arguments)
   cluster_create_parser.set_defaults(func=cluster_create)
 
 
@@ -244,6 +250,14 @@ def set_cluster_create_pathways_parser(
       cluster_create_pathways_tensorboard_arguments
   )
 
+  ### MTC arguments specific to "cluster create"
+  cluster_create_mtc_arguments = (
+      cluster_create_pathways_parser.add_argument_group(
+          'Optional MTC Arguments',
+          'Arguments for configuring MTC in cluster create.',
+      )
+  )
+  add_shared_cluster_create_mtc_arguments(cluster_create_mtc_arguments)
   cluster_create_pathways_parser.set_defaults(func=cluster_create_pathways)
 
 
@@ -313,6 +327,12 @@ def set_cluster_create_ray_parser(cluster_create_ray_parser: ArgumentParser):
       cluster_create_ray_tensorboard_arguments
   )
 
+  ### MTC arguments specific to "cluster create"
+  cluster_create_mtc_arguments = cluster_create_ray_parser.add_argument_group(
+      'Optional MTC Arguments',
+      'Arguments for configuring MTC in cluster create.',
+  )
+  add_shared_cluster_create_mtc_arguments(cluster_create_mtc_arguments)
   cluster_create_ray_parser.set_defaults(func=cluster_create_ray_cluster)
 
 
@@ -704,5 +724,45 @@ def add_shared_cluster_create_capacity_arguments(parser: ArgumentParser):
       help=(
           'Sets node pool creation to use spot resources.'
           ' See `--reservation` or `--on-demand` for other capacity types.'
+      ),
+  )
+
+
+def add_shared_cluster_create_mtc_arguments(parser: ArgumentParser):
+  """Add shared Multi-tier Checkpointing arguments in cluster create and Pathways cluster create.
+
+  Args:
+      List of cluster create MTC arguments parsers
+  """
+  parser.add_argument(
+      '--enable-mtc',
+      action='store_true',
+      help='Enable MTC on the cluster.',
+  )
+  parser.add_argument(
+      '--mtc-ramdisk-size',
+      type=str,
+      default=None,
+      help=(
+          '(Required if --enable-mtc is true) The size of the RAM disk to be'
+          ' used for multi-tier checkpointing. e.g. "64Mi" '
+      ),
+  )
+  parser.add_argument(
+      '--mtc-gcs-bucket',
+      type=str,
+      default=None,
+      help=(
+          '(Required if --enable-mtc is true) The GCS bucket to be used for'
+          ' multi-tier checkpointing.'
+      ),
+  )
+  parser.add_argument(
+      '--mtc-toleration-key',
+      type=str,
+      default=None,
+      help=(
+          '(Optional) The tolerance key to be used for multi-tier'
+          ' checkpointing. By default, it is set to "google.com/tpu".'
       ),
   )

--- a/src/xpk/templates/mtc-cpc.yaml
+++ b/src/xpk/templates/mtc-cpc.yaml
@@ -1,0 +1,15 @@
+apiVersion: checkpointing.gke.io/v1
+kind: CheckpointConfiguration
+metadata:
+  name: my-checkpointconfiguration
+spec:
+  cloudStorageBucketName:
+  # This field is optional
+  nodeSelector:
+    node.kubernetes.io/instance-type:
+  # This field is optional
+  tolerations:
+  - key:
+    operator: Exists
+    effect: NoSchedule
+  inMemoryVolumeSize:

--- a/src/xpk/utils/kubectl.py
+++ b/src/xpk/utils/kubectl.py
@@ -20,10 +20,11 @@ from kubernetes.dynamic import DynamicClient
 from .console import xpk_print
 
 
-def apply_kubectl_manifest(client, manifest):
+def apply_kubectl_manifest(client, manifest) -> int:
   xpk_print('Applying manifest')
   dynamic_client = DynamicClient(client)
 
+  status_code = 0
   for obj in manifest:
     api_version = obj['apiVersion']
     kind = obj['kind']
@@ -55,3 +56,5 @@ def apply_kubectl_manifest(client, manifest):
         )
       else:
         xpk_print(f'Error applying {kind}: {e}')
+        status_code = 1
+  return status_code


### PR DESCRIPTION
## Fixes / Features

Add Multi-tier checkpointing support in XPK Cluster Creation #465

## Testing / Documentation
Testing details.
Cluster detail: https://console.cloud.google.com/kubernetes/clusters/details/us-central2/abhinavsing-in-mem/details?project=cloud-tpu-multipod-dev

XPK logs:
```
[XPK] Task: `Applying Kueue Custom Resources` is implemented by `kubectl apply -f /tmp/tmpihb3vcy7`, streaming output live.
resourceflavor.kueue.x-k8s.io/2xv4-8 createdources`, for 0 seconds...
clusterqueue.kueue.x-k8s.io/cluster-queue createds`, for 1 seconds...
localqueue.kueue.x-k8s.io/multislice-queue created
priorityclass.scheduling.k8s.io/very-low created
priorityclass.scheduling.k8s.io/low created
priorityclass.scheduling.k8s.io/medium created
priorityclass.scheduling.k8s.io/high created
priorityclass.scheduling.k8s.io/very-high created
[XPK] Task: `Applying Kueue Custom Resources` terminated with code `0`
[XPK] Try 1: Applying MTC Checkpoint Configuration
[XPK] Task: `Applying MTC Checkpoint Configuration` is implemented by `kubectl apply -f /tmp/tmp64abbd86`, streaming output live.
checkpointconfiguration.checkpointing.gke.io/my-checkpointconfiguration created
[XPK] Task: `Applying MTC Checkpoint Configuration` terminated with code `0`
[XPK] GKE commands done! Resources are created.
[XPK] See your GKE Cluster here: https://console.cloud.google.com/kubernetes/clusters/details/us-central2/abhinavsing-in-mem/details?project=cloud-tpu-multipod-dev
```
[XPK] Exiting XPK cleanly
- [y] Tests pass
- [y] Appropriate changes to documentation are included in the PR
