### PR TITLE
Update PathwaysJob Version to v0.1.1 To Fix RM OOM

### DIFF
--- a/src/xpk/core/cluster.py
+++ b/src/xpk/core/cluster.py
@@ -33,7 +33,7 @@ from .nodepool import upgrade_gke_nodepools_version
 from .system_characteristics import SystemCharacteristics
 
 JOBSET_VERSION = 'v0.8.0'
-PATHWAYS_JOB_VERSION = 'v0.1.0'
+PATHWAYS_JOB_VERSION = 'v0.1.1'
 INSTALLER_NCC_TCPX = 'https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/master/gpudirect-tcpx/nccl-tcpx-installer.yaml'
 INSTALLER_NCC_TCPXO = 'https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/master/gpudirect-tcpxo/nccl-tcpxo-installer.yaml'
 CONFIG_NCCL_TCPX = 'https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/master/gpudirect-tcpx/nccl-config.yaml'


### PR DESCRIPTION
## Fixes / Features
- Update Pathways Job version to prevent OOMKill. This version of PW Job increases RM resource limits (https://github.com/google/pathways-job/releases/tag/v0.1.1).

## Testing / Documentation
Applied to Testing Cluster

- [ y ] Tests pass
- [ y ] Appropriate changes to documentation are included in the PR
