### PR TITLE
Placement Policy removed from A3-Mega blueprints with --spot

### DIFF
--- a/src/xpk/blueprints/a3mega/kueue-xpk-configuration.yaml.tftpl
+++ b/src/xpk/blueprints/a3mega/kueue-xpk-configuration.yaml.tftpl
@@ -16,7 +16,7 @@ metadata:
 spec:
   nodeLabels:
     cloud.google.com/gke-accelerator: nvidia-h100-mega-80gb
-  topologyName: "gke-default"
+  ${tas_name}
 ---
 apiVersion: kueue.x-k8s.io/v1beta1
 kind: ClusterQueue

--- a/src/xpk/commands/batch.py
+++ b/src/xpk/commands/batch.py
@@ -26,14 +26,13 @@ from ..core.gcloud_context import add_zone_and_project
 from ..core.kjob import (
     AppProfileDefaults,
     JobTemplateDefaults,
-    Kueue_TAS_annotation,
     get_storage_annotations,
     prepare_kjob,
 )
 from ..core.kueue import LOCAL_QUEUE_NAME
 from ..utils.console import xpk_exit, xpk_print
 from .kind import set_local_cluster_command
-from .kjob_common import add_gpu_networking_annotations_to_command
+from .kjob_common import add_gpu_networking_annotations_to_command, add_TAS_annotations_to_command
 
 
 def batch(args: Namespace) -> None:
@@ -68,11 +67,11 @@ def submit_job(args: Namespace) -> None:
       'kubectl kjob create slurm'
       f' --profile {AppProfileDefaults.NAME.value}'
       f' --localqueue {LOCAL_QUEUE_NAME}'
-      f' --pod-template-annotation {Kueue_TAS_annotation}'
       f' --worker-container {JobTemplateDefaults.CONTAINER_NAME.value}'
       ' --first-node-ip'
   )
   cmd = add_gpu_networking_annotations_to_command(args, cmd)
+  cmd = add_TAS_annotations_to_command(args, cmd)
 
   for annotation in get_storage_annotations(args):
     cmd += f' --pod-template-annotation {annotation}'

--- a/src/xpk/commands/common.py
+++ b/src/xpk/commands/common.py
@@ -15,8 +15,10 @@ limitations under the License.
 """
 
 from ..core.commands import run_command_with_updates_retry
+from ..core.resources import get_cluster_capacity_type, get_cluster_system_characteristics
+from ..core.capacity import H100_MEGA_DEVICE_TYPE, CapacityType
 from ..core.gcloud_context import zone_to_region
-from ..utils.console import xpk_print
+from ..utils.console import xpk_print, xpk_exit
 
 
 def set_cluster_command(args) -> int:
@@ -42,3 +44,32 @@ def set_cluster_command(args) -> int:
   if return_code != 0:
     xpk_print(f'{task} returned ERROR {return_code}')
   return return_code
+
+
+def is_TAS_possible(args) -> bool:
+  """Check cluster's machine_type and capacity type to determine if Kueue TAS is possible
+
+  Args:
+    args: user provided arguments for running the command.
+
+  Returns:
+    True if possible and False otherwise.
+  """
+  system_characteristics = get_cluster_system_characteristics(args)
+  capacity_type = get_cluster_capacity_type(args)
+
+  if system_characteristics is None:
+    xpk_print('system_characteristics data was not found in configmaps.')
+    xpk_exit(1)
+
+  if capacity_type is None:
+    xpk_print('capacity_type data was not found in configmaps.')
+    xpk_exit(1)
+
+  if (
+      system_characteristics.device_type == H100_MEGA_DEVICE_TYPE
+      and capacity_type == CapacityType.SPOT
+  ):
+    return False
+
+  return True

--- a/src/xpk/commands/kjob_common.py
+++ b/src/xpk/commands/kjob_common.py
@@ -24,7 +24,9 @@ from ..core.kjob import (
     get_a3mega_pod_template_annotations,
     get_a3ultra_pod_template_annotations,
     get_a4_pod_template_annotations,
+    Kueue_TAS_annotation,
 )
+from .common import is_TAS_possible
 
 
 def add_gpu_networking_annotations_to_command(args, cmd: str) -> str:
@@ -43,5 +45,12 @@ def add_gpu_networking_annotations_to_command(args, cmd: str) -> str:
       f" --pod-template-annotation {annotation} " for annotation in annotations
   ]
   cmd += "\\\n".join(flags)
+
+  return cmd
+
+
+def add_TAS_annotations_to_command(args, cmd: str) -> str:
+  if is_TAS_possible(args):
+    cmd += f" --pod-template-annotation {Kueue_TAS_annotation}"
 
   return cmd

--- a/src/xpk/commands/run.py
+++ b/src/xpk/commands/run.py
@@ -25,14 +25,13 @@ from ..core.gcloud_context import add_zone_and_project
 from ..core.kjob import (
     AppProfileDefaults,
     JobTemplateDefaults,
-    Kueue_TAS_annotation,
     get_storage_annotations,
     prepare_kjob,
 )
 from ..core.kueue import LOCAL_QUEUE_NAME
 from ..utils.console import xpk_exit, xpk_print
 from .kind import set_local_cluster_command
-from .kjob_common import add_gpu_networking_annotations_to_command
+from .kjob_common import add_gpu_networking_annotations_to_command, add_TAS_annotations_to_command
 
 
 def run(args: Namespace) -> None:
@@ -64,12 +63,12 @@ def submit_job(args: Namespace) -> None:
       'kubectl kjob create slurm --profile'
       f' {AppProfileDefaults.NAME.value} '
       f' --localqueue {LOCAL_QUEUE_NAME} '
-      f" --pod-template-annotation '{Kueue_TAS_annotation}'"
       f' --stream-container {JobTemplateDefaults.CONTAINER_NAME.value}'
       f' --worker-container {JobTemplateDefaults.CONTAINER_NAME.value}'
       ' --wait --rm  --first-node-ip'
   )
   cmd = add_gpu_networking_annotations_to_command(args, cmd)
+  cmd = add_TAS_annotations_to_command(args, cmd)
 
   for annotation in get_storage_annotations(args):
     cmd += f' --pod-template-annotation {annotation}'

--- a/src/xpk/core/blueprint/blueprint_generator.py
+++ b/src/xpk/core/blueprint/blueprint_generator.py
@@ -180,7 +180,7 @@ class BlueprintGenerator:
     a3_megagpu_pool_0 = DeploymentModule(
         id="a3_megagpu_pool_0",
         source="modules/compute/gke-node-pool",
-        use=["gke_cluster", gpu_subnets_name, "group_placement_0"],
+        use=["gke_cluster", gpu_subnets_name],
         settings={
             "name": f"{cluster_name}-a3-megagpu-pool-0",
             "machine_type": system.gce_machine_type,
@@ -243,12 +243,17 @@ class BlueprintGenerator:
             primary_vpc,
             gpunets,
             gke_cluster,
-            group_placement_0,
             a3_megagpu_pool_0,
             workload,
             workload_configmap,
         ],
     )
+
+    set_placement_policy = capacity_type != CapacityType.SPOT
+    if set_placement_policy:
+      a3_megagpu_pool_0.use.append(group_placement_0.id)
+      primary_group.modules.append(group_placement_0)
+
     a3_mega_blueprint = Blueprint(
         terraform_backend_defaults=self._getblock_terraform_backend(
             gcs_bucket, cluster_name, prefix

--- a/src/xpk/core/blueprint/blueprint_generator.py
+++ b/src/xpk/core/blueprint/blueprint_generator.py
@@ -197,6 +197,9 @@ class BlueprintGenerator:
         },
         outputs=["instructions"],
     )
+
+    set_placement_policy = capacity_type != CapacityType.SPOT
+    tas_name = "topologyName: 'gke-default'" if set_placement_policy else ""
     num_chips = num_nodes * system.chips_per_vm
     workload = DeploymentModule(
         id="workload_component_install",
@@ -207,7 +210,10 @@ class BlueprintGenerator:
                 "install": True,
                 "version": "v0.10.0",  # TAS feature-gates is enabled in CT
                 "config_path": f'$(ghpc_stage("{blueprint_name}"))/kueue-xpk-configuration.yaml.tftpl',
-                "config_template_vars": {"num_chips": num_chips},
+                "config_template_vars": {
+                    "num_chips": num_chips,
+                    "tas_name": tas_name,
+                },
             },
             "jobset": {"install": True, "version": "v0.7.2"},
             "apply_manifests": [{
@@ -249,7 +255,6 @@ class BlueprintGenerator:
         ],
     )
 
-    set_placement_policy = capacity_type != CapacityType.SPOT
     if set_placement_policy:
       a3_megagpu_pool_0.use.append(group_placement_0.id)
       primary_group.modules.append(group_placement_0)

--- a/src/xpk/core/resources.py
+++ b/src/xpk/core/resources.py
@@ -254,6 +254,6 @@ def get_cluster_capacity_type(args) -> CapacityType | None:
 
   capacityValue = cluster_config_map.get('capacity_type')
   if capacityValue is not None:
-    return CapacityType[capacityValue]
+    return CapacityType[capacityValue.upper()]
 
   return None

--- a/src/xpk/core/resources.py
+++ b/src/xpk/core/resources.py
@@ -236,3 +236,24 @@ def get_cluster_system_characteristics(args) -> SystemCharacteristics | None:
       return system
 
   return None
+
+
+def get_cluster_capacity_type(args) -> CapacityType | None:
+  """Get systemCharcteristics based on the cluster resources configMap
+  Args:
+    args: user provided arguments for running the command.
+
+  Returns:
+    returns system characteristics
+  """
+  metadata_configmap_name = f'{args.cluster}-{CLUSTER_METADATA_CONFIGMAP}'
+  cluster_config_map = get_cluster_configmap(args, metadata_configmap_name)
+
+  if cluster_config_map is None:
+    return None
+
+  capacityValue = cluster_config_map.get('capacity_type')
+  if capacityValue is not None:
+    return CapacityType[capacityValue]
+
+  return None

--- a/src/xpk/core/tests/data/a3_mega.yaml
+++ b/src/xpk/core/tests/data/a3_mega.yaml
@@ -70,12 +70,6 @@ deployment_groups:
         gvnic_postfix: "-subnet"
         gvnic_start_index: 0
     outputs: [instructions]
-  - !DeploymentModule
-    id: group_placement_0
-    source: modules/compute/resource-policy
-    settings:
-      name: bar-gp-np-0
-      group_placement_max_distance: 2
 
   - !DeploymentModule
     id: a3_megagpu_pool_0
@@ -128,3 +122,10 @@ deployment_groups:
           capacity_type: "reservation",
           reservation: "test-reservation",
           }
+
+  - !DeploymentModule
+    id: group_placement_0
+    source: modules/compute/resource-policy
+    settings:
+      name: bar-gp-np-0
+      group_placement_max_distance: 2

--- a/src/xpk/core/tests/data/a3_mega.yaml
+++ b/src/xpk/core/tests/data/a3_mega.yaml
@@ -102,6 +102,7 @@ deployment_groups:
         config_path: $(ghpc_stage("xpk-gke-a3-megagpu"))/kueue-xpk-configuration.yaml.tftpl
         config_template_vars:
           num_chips: 16
+          tas_name: "topologyName: 'gke-default'"
       jobset:
         install: true
         version: v0.7.2

--- a/src/xpk/core/tests/data/a3_mega_spot.yaml
+++ b/src/xpk/core/tests/data/a3_mega_spot.yaml
@@ -1,0 +1,124 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+!Blueprint
+blueprint_name: xpk-gke-a3-megagpu
+toolkit_modules_url: github.com/GoogleCloudPlatform/cluster-toolkit
+toolkit_modules_version: v1.48.0
+
+vars:
+  project_id: "foo"
+  deployment_name: xpk-gke-a3-megagpu
+  region: us-central1
+  zone: us-central1-c
+
+deployment_groups:
+- !DeploymentGroup
+  group: primary
+  modules:
+  - !DeploymentModule
+    id: network1
+    source: modules/network/vpc
+    settings:
+      subnetwork_name: bar-xpk-gke-a3-megagpu-subnet
+      secondary_ranges:
+        bar-xpk-gke-a3-megagpu-subnet:
+        - range_name: pods
+          ip_cidr_range: 10.4.0.0/14
+        - range_name: services
+          ip_cidr_range: 10.0.32.0/20
+  - !DeploymentModule
+    id: gpunets
+    source: modules/network/multivpc
+    settings:
+      network_name_prefix: bar-gpunet
+      global_ip_address_range: 192.169.0.0/16
+      network_count: 8
+      subnetwork_cidr_suffix: 24
+  - !DeploymentModule
+    id: gke_cluster
+    source: modules/scheduler/gke-cluster
+    use: [network1, gpunets]
+    settings:
+      release_channel: RAPID
+      prefix_with_deployment_name: false
+      name_suffix: bar
+      enable_private_endpoint: false
+      enable_gcsfuse_csi: true
+      enable_filestore_csi: true
+      master_authorized_networks:
+      - cidr_block: 10.0.0.0/32  # Allows your machine run kubectl command. It's required for the multi-network setup.
+        display_name: "kubectl-access-network"
+      system_node_pool_machine_type: "e2-standard-32"
+      system_node_pool_node_count:
+        total_min_nodes: 5
+        total_max_nodes: 1000
+      k8s_network_names:
+        gvnic_prefix: "bar-gpunet-"
+        gvnic_postfix: "-subnet"
+        gvnic_start_index: 0
+    outputs: [instructions]
+
+  - !DeploymentModule
+    id: a3_megagpu_pool_0
+    source: modules/compute/gke-node-pool
+    use: [gke_cluster, gpunets]
+    settings:
+      name: bar-a3-megagpu-pool-0
+      machine_type: a3-megagpu-8g
+      static_node_count: 2
+      zones: [us-central1-c]
+      host_maintenance_interval: PERIODIC
+      reservation_affinity:
+        consume_reservation_type: NO_RESERVATION
+        specific_reservations: []
+      run_workload_script: false
+      spot: true
+      max_pods_per_node : 32
+      auto_upgrade: true
+    outputs: [instructions]
+
+  - !DeploymentModule
+    id: workload_component_install
+    source: modules/management/kubectl-apply
+    use: [gke_cluster]
+    settings:
+      kueue:
+        install: true
+        version: "v0.10.0"
+        config_path: $(ghpc_stage("xpk-gke-a3-megagpu"))/kueue-xpk-configuration.yaml.tftpl
+        config_template_vars:
+          num_chips: 16
+          tas_name: ""
+      jobset:
+        install: true
+        version: v0.7.2
+      apply_manifests: 
+      - source: $(ghpc_stage("xpk-gke-a3-megagpu"))/storage_crd.yaml
+
+  - !DeploymentModule
+    id: workload_configmap
+    source: modules/management/kubectl-apply
+    use: [gke_cluster]
+    settings:
+      apply_manifests:
+      - source: $(ghpc_stage("xpk-gke-a3-megagpu"))/config-map.yaml.tftpl
+        template_vars: {
+          resource_config_name: "bar-resources-configmap",
+          num_nodes: "2",
+          cluster_config_name: "bar-metadata-configmap",
+          capacity_type: "spot",
+          reservation: "None",
+          }

--- a/src/xpk/core/tests/unit/test_blueprint.py
+++ b/src/xpk/core/tests/unit/test_blueprint.py
@@ -28,6 +28,7 @@ yaml = ruamel.yaml.YAML()
 yaml.register_class(Blueprint)
 
 a3_yaml_test_path = "src/xpk/core/tests/data/a3_mega.yaml"
+a3_spot_yaml_test_path = "src/xpk/core/tests/data/a3_mega_spot.yaml"
 a3_ultra_yaml_test_path = "src/xpk/core/tests/data/a3_ultra.yaml"
 a4_yaml_test_path = "src/xpk/core/tests/data/a4.yaml"
 config_map_filename = "config-map.yaml.tftpl"
@@ -82,6 +83,40 @@ def test_generate_a3_mega_blueprint():
               tmp_test_dir, "prefix", blueprint_name, kueue_conf_filename
           )
       )
+
+  shutil.rmtree(tmp_test_dir)
+
+
+def test_generate_a3_mega_spot_blueprint():
+  prepare_test()
+  blueprint_name = "xpk-gke-a3-megagpu"
+  bp_generator = BlueprintGenerator(tmp_test_dir)
+  bp = bp_generator.generate_a3_mega_blueprint(
+      project_id="foo",
+      cluster_name="bar",
+      blueprint_name=blueprint_name,
+      prefix="prefix",
+      region="us-central1",
+      zone="us-central1-c",
+      auth_cidr="10.0.0.0/32",
+      capacity_type=CapacityType.SPOT,
+      system_node_pool_min_node_count=5,
+  )
+
+  assert bp.blueprint_file.endswith("/prefix/xpk-gke-a3-megagpu.yaml")
+
+  with open(a3_spot_yaml_test_path, encoding="utf-8") as stream:
+    ctk_yaml = yaml.load(stream)
+    with open(bp.blueprint_file, encoding="utf-8") as generated_blueprint:
+      ctk_test = yaml.load(generated_blueprint)
+      assert ctk_yaml.blueprint_name == ctk_test.blueprint_name
+      assert ctk_test.terraform_backend_defaults is None
+      assert ctk_yaml.toolkit_modules_url == ctk_test.toolkit_modules_url
+      assert (
+          ctk_yaml.toolkit_modules_version == ctk_test.toolkit_modules_version
+      )
+      assert ctk_yaml.vars == ctk_test.vars
+      assert ctk_test.deployment_groups == ctk_yaml.deployment_groups
 
   shutil.rmtree(tmp_test_dir)
 

--- a/src/xpk/core/workload_decorators/tcpx_decorator.py
+++ b/src/xpk/core/workload_decorators/tcpx_decorator.py
@@ -139,6 +139,7 @@ def add_tcpxo_daemon_container(job_manifest):
       'name': 'tcpx-daemon',
       'image': f'us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpx/tcpgpudmarxd-dev:{tcpx}',
       'imagePullPolicy': 'Always',
+      'restartPolicy': 'Always',
       'command': [
           '/tcpgpudmarxd/build/app/tcpgpudmarxd',
           '--gpu_nic_preset',
@@ -159,9 +160,9 @@ def add_tcpxo_daemon_container(job_manifest):
       ],
       'env': [{'name': 'LD_LIBRARY_PATH', 'value': '/usr/local/nvidia/lib64'}],
   }
-  job_manifest['spec']['template']['spec']['containers'].append(
-      tcpxo_daemon_container
-  )
+  spec = job_manifest['spec']['template']['spec']
+  spec.setdefault('initContainers', [])
+  spec['initContainers'].append(tcpxo_daemon_container)
 
 
 def update_gpu_containers(job_manifest):

--- a/src/xpk/core/workload_decorators/tcpxo_decorator.py
+++ b/src/xpk/core/workload_decorators/tcpxo_decorator.py
@@ -149,6 +149,7 @@ def add_tcpxo_daemon_container(job_manifest):
       'name': 'tcpxo-daemon',
       'image': f'us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:{rxdm}',
       'imagePullPolicy': 'Always',
+      'restartPolicy': 'Always',
       'command': ['/bin/sh', '-c'],
       'args': [
           'set -ex\nchmod 755'
@@ -165,9 +166,9 @@ def add_tcpxo_daemon_container(job_manifest):
       ],
       'env': [{'name': 'LD_LIBRARY_PATH', 'value': '/usr/local/nvidia/lib64'}],
   }
-  job_manifest['spec']['template']['spec']['containers'].append(
-      tcpxo_daemon_container
-  )
+  spec = job_manifest['spec']['template']['spec']
+  spec.setdefault('initContainers', [])
+  spec['initContainers'].append(tcpxo_daemon_container)
 
 
 def update_gpu_containers(job_manifest):

--- a/src/xpk/core/workload_decorators/tcpxo_decorator.py
+++ b/src/xpk/core/workload_decorators/tcpxo_decorator.py
@@ -103,7 +103,11 @@ def get_tcpxo_deamon_entry() -> tuple[str, str]:
 
 def add_annotations(job_manifest: dict, sub_networks: list[str]):
   """Adds or updates annotations in the Pod template."""
-  annotations = job_manifest['spec']['template']['metadata']['annotations']
+  metadata = job_manifest['spec']['template']['metadata']
+  annotations = metadata.get('annotations')
+  if annotations is None:
+    annotations = {}
+    metadata['annotations'] = annotations
   tcpxo_deamon_key, tcpxo_deamon_paths = get_tcpxo_deamon_entry()
   interfaces_key, interfaces_value = get_interfaces_entry(sub_networks)
   annotations.update({


### PR DESCRIPTION
## Fixes / Features
- Compact Placement avoided for A3-Mega when spot capacity used
- TAS annotations was removed from Workload and Slurm-like jobs for the above clusters 

## Testing / Documentation
Testing details.

- [ y/n ] Tests pass
- [ y/n ] Appropriate changes to documentation are included in the PR
