### PR TITLE
Enable DNS Access to Prevent Connection Timeout Errors

### DIFF
--- a/src/xpk/commands/cluster.py
+++ b/src/xpk/commands/cluster.py
@@ -790,6 +790,7 @@ def run_gke_cluster_create_command(
       f' --num-nodes {args.default_pool_cpu_num_nodes}'
       f' {args.custom_cluster_arguments}'
       f' {rapid_release_cmd}'
+      ' --enable-dns-access'
   )
 
   enable_ip_alias = False

--- a/src/xpk/commands/common.py
+++ b/src/xpk/commands/common.py
@@ -33,6 +33,7 @@ def set_cluster_command(args) -> int:
   command = (
       'gcloud container clusters get-credentials'
       f' {args.cluster} --region={zone_to_region(args.zone)}'
+      ' --dns-endpoint'
       f' --project={args.project} &&'
       ' kubectl config view && kubectl config set-context --current'
       ' --namespace=default'

--- a/src/xpk/core/cluster.py
+++ b/src/xpk/core/cluster.py
@@ -661,6 +661,7 @@ def get_cluster_credentials(args) -> None:
   command = (
       'gcloud container clusters get-credentials'
       f' {args.cluster} --region={zone_to_region(args.zone)}'
+      ' --dns-endpoint'
       f' --project={args.project} &&'
       ' kubectl config view && kubectl config set-context --current'
       ' --namespace=default'


### PR DESCRIPTION
## Fixes / Features
- Fixes a `Unable to connect to the server: dial tcp [34.105.61.132:443](http://34.105.61.132:443/): connect: connection timed out` issue we've been encountering (b/421683213). Any newly created cluster will have DNS enabled and use that.

## Testing / Documentation
Tested on an internal cluster.

- [ y ] Tests pass
- [ y ] Appropriate changes to documentation are included in the PR
