### PR TITLE
Fix issue in control_plane_endpoints_config.dns_endpoint_config.allow…

### DIFF
--- a/src/xpk/core/cluster.py
+++ b/src/xpk/core/cluster.py
@@ -731,7 +731,6 @@ def get_cluster_credentials(args) -> None:
   command = (
       'gcloud container clusters get-credentials'
       f' {args.cluster} --region={zone_to_region(args.zone)}'
-      ' --dns-endpoint'
       f' --project={args.project} &&'
       ' kubectl config view && kubectl config set-context --current'
       ' --namespace=default'


### PR DESCRIPTION
## Fixes / Features
- It looks like some clusters ran into this issue due to dns endpoint in cluster credential get. This will be made default in GKE later. We should remove this.

![Screenshot 2025-06-12 at 3 05 33 PM](https://github.com/user-attachments/assets/b5a8f4a7-98d9-4940-823a-e470542a22db)

## Testing / Documentation
Tested on an old bodaborg cluster

- [ y ] Tests pass
- [ y ] Appropriate changes to documentation are included in the PR
