### PR TITLE
fix the incorrect number of chips per VM for v5litepod-8

### DIFF
--- a/src/xpk/core/system_characteristics.py
+++ b/src/xpk/core/system_characteristics.py
@@ -1156,7 +1156,7 @@ UserFacingNameToSystemCharacteristics = {
         2,
         'tpu-v5-lite-podslice',
         'ct5lp-hightpu-4t',
-        8,
+        4,
         AcceleratorType['TPU'],
         'v5litepod-8',
     ),


### PR DESCRIPTION
## Fixes / Features
- fix the incorrect number of chips per VM for v5litepod-8
