### PR TITLE
feat: Added an update to CoreDNS

### DIFF
--- a/src/xpk/commands/cluster.py
+++ b/src/xpk/commands/cluster.py
@@ -869,15 +869,6 @@ def cleanup_coredns_repo(coredns_repo_full_path: str):
 def update_coredns(args):
   """Updates and deploys CoreDNS within a cluster.
 
-  This function performs the following steps:
-  1. Installs 'jq'.
-  2. Clones the CoreDNS deployment repository from GitHub if it doesn't already exist.
-  3. Deploys CoreDNS to the cluster.
-  4. Scales down the 'kube-dns-autoscaler' and 'kube-dns' deployments.
-  5. Scales up the 'coredns' deployment to 15 replicas.
-  6. Waits for kube-dns to scale down and coredns to be ready using kubectl wait.
-  7. Cleans up the cloned repository.
-
   Args:
     args: user provided arguments for running the command.
 

--- a/src/xpk/commands/cluster.py
+++ b/src/xpk/commands/cluster.py
@@ -698,7 +698,22 @@ def cluster_create_ray_cluster(args) -> None:
   cluster_create(args)
 
 def update_coredns(args):
+  """Updates and deploys CoreDNS within a cluster.
 
+  This function performs the following steps:
+  1. Installs 'jq'.
+  2. Clones the CoreDNS deployment repository from GitHub if it doesn't already exist.
+  3. Retrieves Google Kubernetes Engine (GKE) cluster credentials.
+  4. Deploys CoreDNS to the cluster.
+  5. Scales down the 'kube-dns-autoscaler' and 'kube-dns' deployments.
+  6. Scales up the 'coredns' deployment to 15 replicas.
+
+  Args:
+    args: user provided arguments for running the command.
+
+  Returns:
+    0 if successful and 1 otherwise.
+  """
   home_dir = os.path.expanduser("~")
   coredns_repo_dir_name = "deployment" 
   coredns_repo_full_path = os.path.join(home_dir, coredns_repo_dir_name)

--- a/src/xpk/commands/cluster.py
+++ b/src/xpk/commands/cluster.py
@@ -791,7 +791,8 @@ def _verify_coredns_readiness(args, timeout: int = 120, namespace: str = 'kube-s
   if return_code_kube_dns == 0:
     xpk_print("kube-dns did not scale down successfully within the timeout.")
     xpk_exit(1) # Exit if kube-dns cannot scale down
-
+  else:
+    xpk_print("kube-dns did not scale down successfully within the timeout.")
   # Wait for CoreDNS to be fully scaled up and available
   command_coredns_wait_available = (
     f"kubectl wait deployment/coredns --for=condition=Available=true "

--- a/src/xpk/commands/cluster.py
+++ b/src/xpk/commands/cluster.py
@@ -862,20 +862,20 @@ def update_coredns(args):
     os.chdir(coredns_k8s_path)
 
     command_deploy_coredns = (
-        f'./deploy.sh | kubectl apply -f -'
+      f'./deploy.sh | kubectl apply -f -'
     )
     xpk_print(f"Task: 'Deploy CoreDNS' in progress, Located at '{coredns_k8s_path}'")
     
     return_code = run_command_with_updates(
-        command_deploy_coredns, 'Deploy CoreDNS', args
+      command_deploy_coredns, 'Deploy CoreDNS', args
     )
     if return_code != 0:
       xpk_print(f'Deploy CoreDNS error {return_code}')
       pass
 
   finally:
-      # Whether it succeeds or fails, always restore to the original directory
-      os.chdir(original_cwd)
+    # Whether it succeeds or fails, always restore to the original directory
+    os.chdir(original_cwd)
   if return_code != 0:
     xpk_exit(return_code)
   
@@ -923,8 +923,8 @@ def update_coredns(args):
 
   # Call the check function here
   if not check_coredns_status(timeout=300):
-      xpk_print("CoreDNS verification failed, it might not have fully started.")
-      xpk_exit(1) 
+    xpk_print("CoreDNS verification failed, it might not have fully started.")
+    xpk_exit(1) 
   
   xpk_print("CoreDNS has successfully started and passed verification.")
 
@@ -1001,7 +1001,7 @@ def create_cluster_if_necessary(
     return 0
   else:
     return run_gke_cluster_create_command(
-        args, gke_control_plane_version, system
+      args, gke_control_plane_version, system
     )
 
 

--- a/src/xpk/commands/cluster.py
+++ b/src/xpk/commands/cluster.py
@@ -79,10 +79,6 @@ import shutil
 import os
 
 
-from kubernetes import client, config
-from kubernetes.client.rest import ApiException
-import time
-
 def cluster_adapt(args) -> None:
   """Function that performs cluster adaptation.
 
@@ -233,8 +229,6 @@ def cluster_create(args) -> None:
   )
   if create_cluster_command_code != 0:
     xpk_exit(create_cluster_command_code)
-
-
 
   authorize_private_cluster_access_command_code = (
       authorize_private_cluster_access_if_necessary(args)
@@ -747,7 +741,6 @@ def _deploy_coredns_manifests(args, coredns_k8s_path: str):
     return_code = run_command_with_updates(command_deploy_coredns, 'Deploy CoreDNS', args)
     if return_code != 0:
       xpk_print(f'Deploy CoreDNS error {return_code}')
-      pass
 
   finally:
     xpk_print(f"Restoring working directory to: {original_cwd}") 

--- a/src/xpk/commands/cluster.py
+++ b/src/xpk/commands/cluster.py
@@ -247,10 +247,9 @@ def cluster_create(args) -> None:
 
   get_cluster_credentials(args)
 
-  if args.enable_pathways == True:
-    update_coredns_command_code = update_coredns_if_necessary(args)
-    if update_coredns_command_code != 0:
-      xpk_exit(update_cluster_command_code)
+  update_coredns_command_code = update_coredns_if_necessary(args)
+  if update_coredns_command_code != 0:
+    xpk_exit(update_cluster_command_code)
 
   k8s_client = setup_k8s_env(args)
 

--- a/src/xpk/commands/cluster.py
+++ b/src/xpk/commands/cluster.py
@@ -75,6 +75,7 @@ from ..utils.console import get_user_input, xpk_exit, xpk_print
 from ..utils.file import write_tmp_file
 from . import cluster_gcluster
 from .common import set_cluster_command
+
 import os
 
 def cluster_adapt(args) -> None:


### PR DESCRIPTION
## Fixes / Features
Enhance DNS Scalability for Large-Scale Testing:
* Issue: During large-scale load testing, the existing Kube-DNS solution was found to be insufficient in supporting the demands of McJAX and Pathways TPU paths, leading to potential performance bottlenecks.
* Solution: Adjusted configurations to default to CoreDNS for McJAX and Pathways TPU paths.


## Testing / Documentation
When using the command ```python3 xpk.py cluster create-pathways``` to create a cluster, CoreDNS will be used by default. For the general command ```python3 xpk.py cluster create```, kube-dns is still the default.

- [ y/n ] Tests pass
- [ y/n ] Appropriate changes to documentation are included in the PR
