### PR TITLE
Update Kueue to create Visibility folder

### DIFF
--- a/src/xpk/core/kueue.py
+++ b/src/xpk/core/kueue.py
@@ -252,6 +252,8 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
         volumeMounts:
+        - mountPath: /visibility
+          name: visibility
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert
           readOnly: true
@@ -263,6 +265,8 @@ spec:
       serviceAccountName: kueue-controller-manager
       terminationGracePeriodSeconds: 10
       volumes:
+      - name: visibility
+        emptyDir: {{}}
       - name: cert
         secret:
           defaultMode: 420


### PR DESCRIPTION
## Fixes / Features
- Resolves an issue where the /visibility folder is not created due to permission error, causing a crashloop for the `kueue-controller-manager`.

```
{"caller":"visibility/server.go:66", "error":"error creating self-signed certificates: mkdir /visibility: permission denied", "level":"error", "logger":"visibility-server", "msg":"Unable to apply VisibilityServerOptions", "stacktrace":"sigs.k8s.io/kueue/pkg/visibility.CreateAndStartVisibilityServer
	/workspace/pkg/visibility/server.go:66", "ts":"2025-07-23T06:32:54.41251975Z"}
```

- Fixes b/433633894

## Testing / Documentation

Patched into existing clusters and verified the fix works, see suggestion by GKE folks in b/433633894#comment28

- [ y ] Tests pass
- [ y ] Appropriate changes to documentation are included in the PR
