### PR TITLE
AutoscalingProfile was set to optimize_utilization

### DIFF
--- a/src/xpk/commands/cluster.py
+++ b/src/xpk/commands/cluster.py
@@ -842,6 +842,7 @@ def run_gke_cluster_create_command(
       f' {args.custom_cluster_arguments}'
       f' {rapid_release_cmd}'
       ' --enable-dns-access'
+      ' --autoscaling_profile=optimize-utilization'
   )
 
   enable_ip_alias = False

--- a/src/xpk/core/nap.py
+++ b/src/xpk/core/nap.py
@@ -99,6 +99,7 @@ def enable_autoprovisioning_on_cluster(
       f' --region={zone_to_region(args.zone)} --enable-autoprovisioning'
       ' --autoprovisioning-config-file'
       f' {autoprovisioning_config.config_filename}'
+      ' --autoscaling_profile=optimize-utilization'
   )
   task = 'Update cluster with autoprovisioning enabled'
   return_code = run_command_with_updates(command, task, args)


### PR DESCRIPTION
## Fixes / Features
AutoscalingProfile was set to optimize_utilization when:
- Creating a new cluster
- Enabling NAP

## Testing / Documentation
Testing details.

- [ y/n ] Tests pass
- [ y/n ] Appropriate changes to documentation are included in the PR
