### PR TITLE
Add a flag to support cloud DNS

### DIFF
--- a/src/xpk/commands/cluster.py
+++ b/src/xpk/commands/cluster.py
@@ -1131,6 +1131,9 @@ def run_gke_cluster_create_command(
   if args.enable_workload_identity or args.enable_gcsfuse_csi_driver:
     command += f' --workload-pool={args.project}.svc.id.goog'
 
+  if args.cloud_dns:
+    command += f' --cluster-dns=clouddns'
+
   addons = []
   if args.enable_gcsfuse_csi_driver:
     addons.append('GcsFuseCsiDriver')

--- a/src/xpk/parser/cluster.py
+++ b/src/xpk/parser/cluster.py
@@ -715,6 +715,11 @@ def add_shared_cluster_create_optional_arguments(parser: ArgumentParser):
       action='store_true',
       help='Enable Workload Identity Federation on the cluster and node-pools.',
   )
+  parser.add_argument(
+      '--cloud-dns',
+      action='store_true',
+      help='Enable Cloud DNS on the cluster and node-pools.',
+  )
   add_driver_arguments(parser)
 
 


### PR DESCRIPTION
## Fixes / Features

Add a flag to support CloudDNS as an option on creating a cluster. Without it, one has to run cluster update and node pool update command after cluster creation which is very time consuming.

## Testing / Documentation

xpk cluster create-pathways \
--num-slices=${CLUSTER_NODEPOOL_COUNT} \
--tpu-type=${TPU_TYPE} \
--pathways-gce-machine-type=${PW_CPU_MACHINE_TYPE} \
--cluster-cpu-machine-type=${PW_CPU_MACHINE_TYPE} \
--project=${PROJECT} \
--zone=${ZONE} \
--default-pool-cpu-num-nodes=1 \
--cluster=${CLUSTER} \
--custom-cluster-arguments="--network=${NETWORK} --subnetwork=${SUBNETWORK} --enable-ip-alias" --cloud-dns


- [ y ] Tests pass
- [ y ] Appropriate changes to documentation are included in the PR
