### PR TITLE
Add a flag to enable cloud DNS when creating cluster

### DIFF
--- a/src/xpk/commands/cluster.py
+++ b/src/xpk/commands/cluster.py
@@ -1131,6 +1131,9 @@ def run_gke_cluster_create_command(
   if args.enable_workload_identity or args.enable_gcsfuse_csi_driver:
     command += f' --workload-pool={args.project}.svc.id.goog'
 
+  if args.cloud_dns:
+    command += f' --cluster-dns=clouddns'
+
   addons = []
   if args.enable_gcsfuse_csi_driver:
     addons.append('GcsFuseCsiDriver')

--- a/src/xpk/commands/cluster.py
+++ b/src/xpk/commands/cluster.py
@@ -1131,7 +1131,7 @@ def run_gke_cluster_create_command(
   if args.enable_workload_identity or args.enable_gcsfuse_csi_driver:
     command += f' --workload-pool={args.project}.svc.id.goog'
 
-  if args.cloud_dns:
+  if args.enable_cloud_dns:
     command += f' --cluster-dns=clouddns'
 
   addons = []

--- a/src/xpk/commands/cluster.py
+++ b/src/xpk/commands/cluster.py
@@ -953,7 +953,10 @@ def update_coredns_if_necessary(args) -> int:
     0 if successful (CoreDNS was already present or successfully deployed),
     and 1 otherwise.
   """
-  if coredns_deployment_exists(args, namespace='kube-system'):
+  if args.enable_cloud_dns:
+    xpk_print('Skipping CoreDNS deployment since Cloud DNS is enabled.')
+    return 0
+  elif coredns_deployment_exists(args, namespace='kube-system'):
     xpk_print('Skipping CoreDNS deployment since it already exists.')
     return 0
   else:

--- a/src/xpk/parser/cluster.py
+++ b/src/xpk/parser/cluster.py
@@ -715,6 +715,11 @@ def add_shared_cluster_create_optional_arguments(parser: ArgumentParser):
       action='store_true',
       help='Enable Workload Identity Federation on the cluster and node-pools.',
   )
+  parser.add_argument(
+      '--cloud-dns',
+      action='store_true',
+      help='Enable Cloud DNS on the cluster and node-pools.',
+  )
   add_driver_arguments(parser)
 
 

--- a/src/xpk/parser/cluster.py
+++ b/src/xpk/parser/cluster.py
@@ -716,7 +716,7 @@ def add_shared_cluster_create_optional_arguments(parser: ArgumentParser):
       help='Enable Workload Identity Federation on the cluster and node-pools.',
   )
   parser.add_argument(
-      '--cloud-dns',
+      '--enable-cloud-dns',
       action='store_true',
       help='Enable Cloud DNS on the cluster and node-pools.',
   )


### PR DESCRIPTION
## Features

This PR adds a flag to enable cloud DNS when creating cluster. Without this flag, it took another 10s of minutes to enable Cloud DNS after cluster construction is complete.

## Testing / Documentation

```
xpk cluster create-pathways \
--num-slices=${CLUSTER_NODEPOOL_COUNT} \
--tpu-type=${TPU_TYPE} \
--pathways-gce-machine-type=${PW_CPU_MACHINE_TYPE} \
--cluster-cpu-machine-type=${PW_CPU_MACHINE_TYPE} \
--project=${PROJECT} \
--zone=${ZONE} \
--default-pool-cpu-num-nodes=1 \
--reservation=cloudtpu-20250402070001-1543930707 \
--cluster=${CLUSTER} \
--custom-cluster-arguments="--network=${NETWORK} --subnetwork=${SUBNETWORK} --enable-ip-alias" --enable-cloud-dns
```

Output:

```
...
[XPK] GKE commands done! Resources are created.
[XPK] See your GKE Cluster here: https://console.cloud.google.com/...
[XPK] Exiting XPK cleanly
```


- [ y ] Tests pass
- [ y ] Appropriate changes to documentation are included in the PR
