### PR TITLE
Fix cluster create when `--enable-autoprovisioning` is supplied

### DIFF
--- a/src/xpk/core/nap.py
+++ b/src/xpk/core/nap.py
@@ -99,9 +99,20 @@ def enable_autoprovisioning_on_cluster(
       f' --region={zone_to_region(args.zone)} --enable-autoprovisioning'
       ' --autoprovisioning-config-file'
       f' {autoprovisioning_config.config_filename}'
-      ' --autoscaling-profile=optimize-utilization'
   )
   task = 'Update cluster with autoprovisioning enabled'
+  return_code = run_command_with_updates(command, task, args)
+  if return_code != 0:
+    xpk_print(f'{task} request returned ERROR {return_code}')
+    return autoprovisioning_config, return_code
+
+  command = (
+      'gcloud container clusters update'
+      f' {args.cluster} --project={args.project}'
+      f' --region={zone_to_region(args.zone)}'
+      ' --autoscaling-profile=optimize-utilization'
+  )
+  task = 'Update cluster with autoscaling-profile'
   return_code = run_command_with_updates(command, task, args)
   if return_code != 0:
     xpk_print(f'{task} request returned ERROR {return_code}')


### PR DESCRIPTION
## Fixes
Cluster create with `--enable-autoprovisioning` flag.

AR: Cluster create fails.
ER: Cluster create succeeds.

## Testing / Documentation
Testing can be performed by executing following command:
```
python3 xpk.py cluster create \
  --cluster $CLUSTER_NAME \
  --num-slices=$NUM_SLICES \
  --device-type=$DEVICE_TYPE \
  --zone=$ZONE \
  --project=$PROJECT \
  --reservation=$RESERVATION \
  --enable-autoprovisioning \
  --autoprovisioning-max-chips=$MAX_CHIPS
```

- [y] Tests pass
- [y] Appropriate changes to documentation are included in the PR
