### PR TITLE
Revert "[slice] Log at Level 5; AlwaysPullImage"

### DIFF
--- a/slice/config/manager/manager.yaml
+++ b/slice/config/manager/manager.yaml
@@ -63,9 +63,7 @@ spec:
         args:
           - --leader-elect
           - --health-probe-bind-address=:8081
-          - --zap-log-level=5
         image: controller:latest
-        imagePullPolicy: Always
         name: manager
         ports: []
         securityContext:


### PR DESCRIPTION
Reverts AI-Hypercomputer/xpk#590

This is causing E2e test to fail. Seems to be due to the imagePullPolicy