### PR TITLE
Fix provisioning 1x1 and 1x1x1 topologies

### DIFF
--- a/src/xpk/core/nodepool.py
+++ b/src/xpk/core/nodepool.py
@@ -281,7 +281,9 @@ def run_gke_node_pool_create_command(
     )
     if system.accelerator_type == AcceleratorType['TPU']:
       command += f' --node-version={gke_node_pool_version}'
-      topology_product = reduce(mul, (int(x) for x in system.topology.split('x')), 1)
+      topology_product = reduce(
+          mul, (int(x) for x in system.topology.split('x')), 1
+      )
       if capacity_type == CapacityType.FLEX_START:
         command += ' --num-nodes=0'
       elif topology_product > 1:


### PR DESCRIPTION
## Fixes / Features
Currently TPU v6e-1x1 and TPU tpu7x-1x1x1 topologies cannot be provisioned due to `placement-type`, `num-nodes` and `tpu-type` parameters added when creating `node-pool`. This change removes that parameter when topology product is 1.

## Testing / Documentation
Tested provisioning with command:
```python3 xpk.py cluster create --cluster=xpk-test-v6e-1x1-2 --project=tpu-staging-env-one-vm --tpu-type=v6e-1x1 --zone=us-central1-b --num-nodes=1 --enable-autoprovisioning --on-demand```

- [y] Tests pass
- [y] Appropriate changes to documentation are included in the PR
