### PR TITLE
feat: Pathways use single resource group

### DIFF
--- a/src/xpk/core/kueue.py
+++ b/src/xpk/core/kueue.py
@@ -508,6 +508,7 @@ def get_kueue_covered_resources_config(
   config_format = """
   - coveredResources: ["cpu", "memory", "{resource_type}"]
     flavors:
+{pathways_resources}
     - name: {cluster_hardware_name}
       resources:
       - name: "cpu"
@@ -516,7 +517,6 @@ def get_kueue_covered_resources_config(
         nominalQuota: "99999999999Gi"
       - name: "{resource_type}"
         nominalQuota: {total_chips}
-{pathways_resources}
   """
   config_string = config_format.format(
       cluster_hardware_name=cluster_hardware_name,

--- a/src/xpk/core/pathways.py
+++ b/src/xpk/core/pathways.py
@@ -37,19 +37,6 @@ spec:
   return ''
 
 
-def add_pw_resources_to_kueue(args):
-  """Add resource flavors required for Pathways, to the cluster queue."""
-  resources_yaml = """- coveredResources: ["cpu", "memory"]
-    flavors:
-    - name: cpu-user
-      resources:
-      - name: "cpu"
-        nominalQuota: 480
-      - name: "memory"
-        nominalQuota: 2000G"""
-  if args.enable_pathways:
-    return resources_yaml
-  return ''
 
 
 def ensure_pathways_workload_prerequisites(args, system) -> bool:


### PR DESCRIPTION
Jobs requesting TPU resources may also have requests for CPU and memory. However when pathways is enabled, Kueue will not be able to admit such jobs since there is no cpu and memory quota.

This fix adds a very high number of CPU and memory for TPU/GPU resources and merges the pathways resource group with the accelerator resource group.

This also allows us to run AXLearn jobs without having to make changes manually.


Follow up from: https://github.com/AI-Hypercomputer/xpk/pull/574
this time with a branch within xpk repo.




