### PR TITLE
Fix provisioning scopes for nap

### DIFF
--- a/src/xpk/core/nap.py
+++ b/src/xpk/core/nap.py
@@ -42,6 +42,8 @@ AUTOPROVISIONING_CONFIG_FILE = """
 management:
   autoRepair: true
   autoUpgrade: true
+scopes:
+  - "https://www.googleapis.com/auth/devstorage.read_write"
 autoprovisioningLocations:
   {zones}
 {resource_limits}


### PR DESCRIPTION
## Fixes / Features
NAP was provisioned with read only permissions to storage. This should be changed to read_write.

## Testing / Documentation
Tested with command:
```python3 xpk.py cluster create   --cluster mlperf-v5p   --num-slices=0   --device-type=v5p-8   --zone=europe-west4-b   --project=konradkaim-gke-dev   --on-demand   --enable-autoprovisioning   --autoprovisioning-max-chips=732```
It provisioned cluster that has read_write permissions for storage.

- [y] Tests pass
- [y] Appropriate changes to documentation are included in the PR
