### PR TITLE
Use integration_tests environment for integration tests

### DIFF
--- a/.github/workflows/reusable_batch_tests.yaml
+++ b/.github/workflows/reusable_batch_tests.yaml
@@ -28,6 +28,8 @@ on:
 jobs:
   run-batch:
     runs-on: [ubuntu-22.04]
+    environment:
+      name: integration_tests
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5

--- a/.github/workflows/reusable_cluster_create.yaml
+++ b/.github/workflows/reusable_cluster_create.yaml
@@ -56,6 +56,8 @@ env:
 jobs:
   cluster-create:
     runs-on: [ubuntu-22.04]
+    environment:
+      name: integration_tests
     name: cluster-create
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/reusable_cluster_delete.yaml
+++ b/.github/workflows/reusable_cluster_delete.yaml
@@ -34,6 +34,8 @@ on:
 jobs:
   delete-cluster:
     runs-on: [ubuntu-22.04]
+    environment:
+      name: integration_tests
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5

--- a/.github/workflows/reusable_cluster_private.yaml
+++ b/.github/workflows/reusable_cluster_private.yaml
@@ -43,6 +43,8 @@ jobs:
   cluster-private:
     runs-on: [ubuntu-22.04]
     name: cluster-private
+    environment:
+      name: integration_tests
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5

--- a/.github/workflows/reusable_integration_tests.yaml
+++ b/.github/workflows/reusable_integration_tests.yaml
@@ -22,6 +22,8 @@ on:
 jobs:
   integration-tests:
     runs-on: [ubuntu-22.04]
+    environment:
+      name: integration_tests
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/reusable_storage_create.yaml
+++ b/.github/workflows/reusable_storage_create.yaml
@@ -36,15 +36,13 @@ on:
       storage-name:
         required: true
         type: string
-    secrets:
-      GCP_SA_KEY:
-        required: true
-      BUCKET_NAME:
-        required: true
+
 jobs:
   storage-create:
     name: "${{inputs.storage-type}}-${{inputs.storage-command}}"
     runs-on: [ubuntu-22.04]
+    environment:
+      name: integration_tests
     env:
       STORAGE_WRITE_WORKLOAD: "${{inputs.storage-type}}-${{inputs.storage-command}}-write-workload"
       STORAGE_READ_WORKLOAD: "${{inputs.storage-type}}-${{inputs.storage-command}}-read-workload"

--- a/.github/workflows/reusable_storage_delete.yaml
+++ b/.github/workflows/reusable_storage_delete.yaml
@@ -31,13 +31,13 @@ on:
       storage-name:
         required: true
         type: string
-    secrets:
-      GCP_SA_KEY:
-        required: true
+
 jobs:
   storage-delete:
     name: "${{inputs.storage-type}}-${{inputs.storage-command}}"
     runs-on: [ubuntu-22.04]
+    environment:
+      name: integration_tests
     steps:
     - name: Validate storage-command
       run: |

--- a/.github/workflows/reusable_workload_tests.yaml
+++ b/.github/workflows/reusable_workload_tests.yaml
@@ -51,6 +51,8 @@ env:
 jobs:
   run-workloads:
     runs-on: [ubuntu-22.04]
+    environment:
+      name: integration_tests
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5


### PR DESCRIPTION
## Fixes / Features
It changes all integration tests github actions to source secrets from `integration_tests` environment rather than using the global ones. This environment is guarded by approvals and would allow to contribute to the repository without having write access (external contributors through forks), as well as will allow us to better manage usage of GCP resources by requiring approvals before running expensive testing. Lightweight lint, unit tests etc are still running without approval (and access to GCP secrets).

## Testing / Documentation
N/A

- [y] Tests pass
- [y] Appropriate changes to documentation are included in the PR
