### PR TITLE
feat: Add link to GCP Workloads list under xpk workload list

### DIFF
--- a/src/xpk/commands/workload.py
+++ b/src/xpk/commands/workload.py
@@ -85,6 +85,7 @@ from ..core.vertex import create_vertex_experiment
 from ..core.workload import (
     check_if_workload_exists,
     get_workload_list,
+    get_workload_list_gcp_link,
     wait_for_job_completion,
     zone_to_region,
 )
@@ -760,4 +761,15 @@ def workload_list(args) -> None:
     xpk_print(f'List Job request returned ERROR {return_code}')
     xpk_exit(return_code)
   xpk_print(f'Workload List Output:\n{return_value}')
+
+  workload_list_gcp_link = get_workload_list_gcp_link(
+      project=args.project,
+      cluster=args.cluster,
+      zone=args.zone,
+      job_filter=args.filter_by_job,
+  )
+  xpk_print(
+      f'See your workloads in Cloud Console: {workload_list_gcp_link}'
+  )
+
   xpk_exit(0)

--- a/src/xpk/core/tests/unit/test_workload.py
+++ b/src/xpk/core/tests/unit/test_workload.py
@@ -1,0 +1,56 @@
+"""
+Copyright 2025 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from xpk.core.workload import get_workload_list_gcp_link
+
+TEST_PROJECT = 'test-project'
+TEST_CLUSTER = 'test-cluster'
+TEST_ZONE = 'us-central1-c'
+LINK_WITHOUT_NAME_FILTER = f'https://console.cloud.google.com/kubernetes/workload/overview?project=test-project&pageState=(%22workload_list_table%22:(%22f%22:%22%255B%257B_22k_22_3A_22Cluster_22_2C_22t_22_3A10_2C_22v_22_3A_22_5C_22test-cluster_5C_22_22_2C_22i_22_3A_22metadata%252FclusterReference%252Fname_22%257D_2C%257B_22k_22_3A_22Location_22_2C_22t_22_3A10_2C_22v_22_3A_22_5C_22us-central1_5C_22_22_2C_22i_22_3A_22metadata%252FclusterReference%252FgcpLocation_22%257D_2C%257B_22k_22_3A_22Type_22_2C_22t_22_3A10_2C_22v_22_3A_22_5C_22Job_5C_22_22_2C_22i_22_3A_22type_meta%252FkindName_22%257D%255D%22))'
+LINK_WITH_NAME_FILTER = f'https://console.cloud.google.com/kubernetes/workload/overview?project=test-project&pageState=(%22workload_list_table%22:(%22f%22:%22%255B%257B_22k_22_3A_22Cluster_22_2C_22t_22_3A10_2C_22v_22_3A_22_5C_22test-cluster_5C_22_22_2C_22i_22_3A_22metadata%252FclusterReference%252Fname_22%257D_2C%257B_22k_22_3A_22Location_22_2C_22t_22_3A10_2C_22v_22_3A_22_5C_22us-central1_5C_22_22_2C_22i_22_3A_22metadata%252FclusterReference%252FgcpLocation_22%257D_2C%257B_22k_22_3A_22Type_22_2C_22t_22_3A10_2C_22v_22_3A_22_5C_22Job_5C_22_22_2C_22i_22_3A_22type_meta%252FkindName_22%257D_2C%257B_22k_22_3A_22Name_22_2C_22t_22_3A10_2C_22v_22_3A_22_5C_22test-workload_5C_22_22_2C_22i_22_3A_22metadata%252Fname_22%257D%255D%22))'
+
+
+def test_get_workload_list_gcp_link_without_job_filter():
+  result = get_workload_list_gcp_link(
+      project=TEST_PROJECT,
+      cluster=TEST_CLUSTER,
+      zone=TEST_ZONE,
+      job_filter=None,
+  )
+
+  assert result == LINK_WITHOUT_NAME_FILTER
+
+
+def test_get_workload_list_gcp_link_with_job_filter():
+  result = get_workload_list_gcp_link(
+      project=TEST_PROJECT,
+      cluster=TEST_CLUSTER,
+      zone=TEST_ZONE,
+      job_filter='test-workload',
+  )
+
+  assert result == LINK_WITH_NAME_FILTER
+
+
+def test_get_workload_list_gcp_link_with_invalid_job_filter():
+  result = get_workload_list_gcp_link(
+      project=TEST_PROJECT,
+      cluster=TEST_CLUSTER,
+      zone=TEST_ZONE,
+      job_filter='test-workload.*',
+  )
+
+  assert result == LINK_WITHOUT_NAME_FILTER

--- a/src/xpk/parser/workload.py
+++ b/src/xpk/parser/workload.py
@@ -452,7 +452,7 @@ def set_workload_parsers(workload_parser):
       type=str,
       help=(
           'Filters the arguments based on job name. Provide a regex'
-          ' expressionto parse jobs that match the pattern or provide a job'
+          ' expression to parse jobs that match the pattern or provide a job'
           ' name to delete a single job.'
       ),
   )
@@ -521,7 +521,7 @@ def set_workload_parsers(workload_parser):
       type=str,
       help=(
           'Filters the arguments based on job name. Provide a regex'
-          ' expressionto parse jobs that match the pattern or provide a job'
+          ' expression to parse jobs that match the pattern or provide a job'
           ' name to view a single job.'
       ),
       required=False,


### PR DESCRIPTION
## Fixes / Features
- b/329491174: Add the workload cloud console link to the workload list table
- Link navigates to Workloads table with the `Type: Job` filter, because it seems to be the most relevant type.

### Notes
- `xpk workload list` displays info read from `Workload` CR.
- `--filter-by-job` can be either a string or a RegExp, while GCP filter chips don't allow for RegExps. Name filter will be ignored in case of RegExp.
- Initially I wanted to take into account the status filter as well (`--filter-by-status`), but it's hard to map `Workload` status to `Job` status in the GCP workloads table. It's extra hard as filters in GCP are very limited and the resulting filter value would have to be super long.

## Testing / Documentation
Tested manually.

- [ y ] Tests pass
- [ n/a ] Appropriate changes to documentation are included in the PR
