### PR TITLE
feat: Make workloads link navigate to aiml jobsets list

### DIFF
--- a/src/xpk/commands/workload.py
+++ b/src/xpk/commands/workload.py
@@ -84,8 +84,8 @@ from ..core.system_characteristics import (
 from ..core.vertex import create_vertex_experiment
 from ..core.workload import (
     check_if_workload_exists,
+    get_jobsets_list_gcp_link,
     get_workload_list,
-    get_workload_list_gcp_link,
     wait_for_job_completion,
     zone_to_region,
 )
@@ -763,12 +763,7 @@ def workload_list(args) -> None:
     xpk_exit(return_code)
   xpk_print(f'Workload List Output:\n{return_value}')
 
-  workload_list_gcp_link = get_workload_list_gcp_link(
-      project=args.project,
-      cluster=args.cluster,
-      zone=args.zone,
-      job_name_filter=args.filter_by_job,
-  )
+  workload_list_gcp_link = get_jobsets_list_gcp_link(project=args.project)
   xpk_print(f'See your workloads in Cloud Console: {workload_list_gcp_link}')
 
   xpk_exit(0)

--- a/src/xpk/core/tests/unit/test_workload.py
+++ b/src/xpk/core/tests/unit/test_workload.py
@@ -14,43 +14,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from xpk.core.workload import get_workload_list_gcp_link
-
-TEST_PROJECT = 'test-project'
-TEST_CLUSTER = 'test-cluster'
-TEST_ZONE = 'us-central1-c'
-LINK_WITHOUT_NAME_FILTER = 'https://console.cloud.google.com/kubernetes/workload/overview?project=test-project&pageState=(%22workload_list_table%22:(%22f%22:%22%255B%257B_22k_22_3A_22Cluster_22_2C_22t_22_3A10_2C_22v_22_3A_22_5C_22test-cluster_5C_22_22_2C_22i_22_3A_22metadata%252FclusterReference%252Fname_22%257D_2C%257B_22k_22_3A_22Location_22_2C_22t_22_3A10_2C_22v_22_3A_22_5C_22us-central1_5C_22_22_2C_22i_22_3A_22metadata%252FclusterReference%252FgcpLocation_22%257D_2C%257B_22k_22_3A_22Type_22_2C_22t_22_3A10_2C_22v_22_3A_22_5C_22Job_5C_22_22_2C_22i_22_3A_22type_meta%252FkindName_22%257D%255D%22))'
-LINK_WITH_NAME_FILTER = 'https://console.cloud.google.com/kubernetes/workload/overview?project=test-project&pageState=(%22workload_list_table%22:(%22f%22:%22%255B%257B_22k_22_3A_22Cluster_22_2C_22t_22_3A10_2C_22v_22_3A_22_5C_22test-cluster_5C_22_22_2C_22i_22_3A_22metadata%252FclusterReference%252Fname_22%257D_2C%257B_22k_22_3A_22Location_22_2C_22t_22_3A10_2C_22v_22_3A_22_5C_22us-central1_5C_22_22_2C_22i_22_3A_22metadata%252FclusterReference%252FgcpLocation_22%257D_2C%257B_22k_22_3A_22Type_22_2C_22t_22_3A10_2C_22v_22_3A_22_5C_22Job_5C_22_22_2C_22i_22_3A_22type_meta%252FkindName_22%257D_2C%257B_22k_22_3A_22Name_22_2C_22t_22_3A10_2C_22v_22_3A_22_5C_22test-workload_5C_22_22_2C_22i_22_3A_22metadata%252Fname_22%257D%255D%22))'
+from xpk.core.workload import get_jobsets_list_gcp_link
 
 
-def test_get_workload_list_gcp_link_without_job_name_filter():
-  result = get_workload_list_gcp_link(
-      project=TEST_PROJECT,
-      cluster=TEST_CLUSTER,
-      zone=TEST_ZONE,
-      job_name_filter=None,
+def test_get_jobsets_list_gcp_link():
+  result = get_jobsets_list_gcp_link(
+      project='test-project',
   )
 
-  assert result == LINK_WITHOUT_NAME_FILTER
-
-
-def test_get_workload_list_gcp_link_with_job_name_filter():
-  result = get_workload_list_gcp_link(
-      project=TEST_PROJECT,
-      cluster=TEST_CLUSTER,
-      zone=TEST_ZONE,
-      job_name_filter='test-workload',
+  assert (
+      result
+      == 'https://console.cloud.google.com/kubernetes/aiml/deployments/jobs?project=test-project'
   )
-
-  assert result == LINK_WITH_NAME_FILTER
-
-
-def test_get_workload_list_gcp_link_with_invalid_job_name_filter():
-  result = get_workload_list_gcp_link(
-      project=TEST_PROJECT,
-      cluster=TEST_CLUSTER,
-      zone=TEST_ZONE,
-      job_name_filter='test-workload.*',
-  )
-
-  assert result == LINK_WITHOUT_NAME_FILTER

--- a/src/xpk/core/workload.py
+++ b/src/xpk/core/workload.py
@@ -247,23 +247,7 @@ GCP_NAME_FILTER_VALUE_REGEX = re.compile(r'[a-z0-9\-]+')
 """Defines correct name prefix value (contains only letters, numbers and dashes) that can be used in GCP filter chips."""
 
 
-def get_workload_list_gcp_link(
-    project: str,
-    cluster: str,
-    zone: str,
-    job_name_filter: str | None,
-) -> str:
-  """Returns a link to Cloud Console Workloads list"""
+def get_jobsets_list_gcp_link(project: str) -> str:
+  """Returns a link to Cloud Console JobSets list"""
 
-  filters_encoded = [
-      f'%257B_22k_22_3A_22Cluster_22_2C_22t_22_3A10_2C_22v_22_3A_22_5C_22{cluster}_5C_22_22_2C_22i_22_3A_22metadata%252FclusterReference%252Fname_22%257D',
-      f'%257B_22k_22_3A_22Location_22_2C_22t_22_3A10_2C_22v_22_3A_22_5C_22{zone_to_region(zone)}_5C_22_22_2C_22i_22_3A_22metadata%252FclusterReference%252FgcpLocation_22%257D',
-      '%257B_22k_22_3A_22Type_22_2C_22t_22_3A10_2C_22v_22_3A_22_5C_22Job_5C_22_22_2C_22i_22_3A_22type_meta%252FkindName_22%257D',
-  ]
-  if job_name_filter and GCP_NAME_FILTER_VALUE_REGEX.fullmatch(job_name_filter):
-    filters_encoded.append(
-        f'%257B_22k_22_3A_22Name_22_2C_22t_22_3A10_2C_22v_22_3A_22_5C_22{job_name_filter}_5C_22_22_2C_22i_22_3A_22metadata%252Fname_22%257D'
-    )
-  filters_state = '_2C'.join(filters_encoded)
-
-  return f'https://console.cloud.google.com/kubernetes/workload/overview?project={project}&pageState=(%22workload_list_table%22:(%22f%22:%22%255B{filters_state}%255D%22))'
+  return f'https://console.cloud.google.com/kubernetes/aiml/deployments/jobs?project={project}'


### PR DESCRIPTION
## Fixes / Features
- http://b/329491174: Add the workload cloud console link to the workload list table
- The previous link was added in https://github.com/AI-Hypercomputer/xpk/pull/621.
- Unfortunately the JobSets table doesn't store its state in the url, so we cannot specify any filters in the url like cluster, location, workload name. I'll create a FR for the page owners.

## Testing / Documentation
Tested manually.

- [ y ] Tests pass
- [ n/a ] Appropriate changes to documentation are included in the PR
