### PR TITLE
refactor: Replace pytype with mypy

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,7 +3,7 @@
 
 *__pycache__*
 tmp/
-.pytype
+.mypy_cache
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/.github/workflows/reusable_lint_and_format.yml
+++ b/.github/workflows/reusable_lint_and_format.yml
@@ -49,5 +49,5 @@ jobs:
       run: make pylint
     - name: Check format with pyink
       run: make pyink
-    - name: Run pytype
-      run: make pytype
+    - name: Run mypy
+      run: make mypy

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 
 *__pycache__*
 tmp/
-.pytype
+.mypy_cache
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,9 +7,7 @@ repos:
         entry: pyink
         language_version: python3
         args: ["--check"]
-  - repo: https://github.com/google/pytype
-    rev: 2024.10.11
+  - repo: https://github.com/python/mypy
+    rev: 2025.07.31
     hooks:
-    - id: pytype
-      args: 
-        - --config=pytype-conf.cfg
+    - id: mypy

--- a/Makefile
+++ b/Makefile
@@ -71,11 +71,11 @@ check-python:
 	python3 --version || (echo "python3 not installed. Please install python in version required by xpk" && exit 1)
 
 .PHONY: install-lint
-install-lint: install-pytype install-pyink install-pylint pip-install
+install-lint: install-mypy install-pyink install-pylint pip-install
 
-.PHONY: install-pytype
-install-pytype:
-	pip install pytype
+.PHONY: install-mypy
+install-mypy:
+	pip install mypy
 
 .PHONY: install-pyink
 install-pyink:
@@ -86,7 +86,7 @@ install-pylint:
 	pip install pylint
 
 .PHONY: verify
-verify: install-lint pylint pyink pytype
+verify: install-lint pylint pyink mypy
 
 .PHONY: pylint
 pylint:
@@ -100,6 +100,6 @@ pyink:
 pyink-fix:
 	pyink .
 
-.PHONY: pytype
-pytype:
-	pytype --config=pytype-conf.cfg
+.PHONY: mypy
+mypy:
+	mypy

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,40 @@
+[mypy]
+
+warn_return_any = True
+warn_unused_configs = True
+follow_untyped_imports = True
+
+files = src/
+
+exclude = (?x)(
+  src/xpk/commands/cluster_gcluster.py
+  | src/xpk/commands/cluster.py
+  | src/xpk/commands/info.py
+  | src/xpk/commands/job.py
+  | src/xpk/commands/kjob_common.py
+  | src/xpk/commands/storage.py
+  | src/xpk/commands/workload.py
+  | src/xpk/core/blueprint/blueprint_generator.py
+  | src/xpk/core/cluster_private.py
+  | src/xpk/core/cluster.py
+  | src/xpk/core/commands.py
+  | src/xpk/core/config.py
+  | src/xpk/core/filestore.py
+  | src/xpk/core/gcloud_context.py
+  | src/xpk/core/gcluster_manager.py
+  | src/xpk/core/kjob.py
+  | src/xpk/core/kueue.py
+  | src/xpk/core/nap.py
+  | src/xpk/core/ray.py
+  | src/xpk/core/storage.py
+  | src/xpk/core/workload_decorators/rdma_decorator.py
+  | src/xpk/core/workload_decorators/storage_decorator.py
+  | src/xpk/core/workload_decorators/tcpx_decorator.py
+  | src/xpk/core/workload_decorators/tcpxo_decorator.py
+  | src/xpk/parser/cluster.py
+  | src/xpk/parser/info.py
+  | src/xpk/parser/job.py
+  | src/xpk/parser/shell.py
+  | src/xpk/parser/storage.py
+  | src/xpk/utils/yaml.py
+  )

--- a/src/xpk/core/cluster.py
+++ b/src/xpk/core/cluster.py
@@ -218,7 +218,7 @@ def get_cluster_nodes_info(args) -> list[dict]:
   if err_code != 0:
     xpk_exit(err_code)
   data = yaml.safe_load(val)
-  return data['items']  # pytype: disable=bad-return-type
+  return data['items']
 
 
 def count_nodes_on_cluster(args, system: SystemCharacteristics) -> int:
@@ -445,7 +445,7 @@ def setup_k8s_env(args) -> k8s_client.ApiClient:
     args.project_number = project_id_to_project_number(args.project)
 
   config.load_kube_config()
-  return k8s_client.ApiClient()  # pytype: disable=bad-return-type
+  return k8s_client.ApiClient()
 
 
 def get_gpu_type_from_cluster(args) -> str:
@@ -819,7 +819,7 @@ def update_cluster_with_clouddns_if_necessary(args) -> int:
       xpk_exit(server_config_return_code)
     upgrade_master_return_code = upgrade_gke_control_plane_version(
         args,
-        gke_server_config.default_rapid_gke_version,  # pytype: disable=attribute-error
+        gke_server_config.default_rapid_gke_version,
     )
     if upgrade_master_return_code > 0:
       xpk_print("Updating GKE cluster's control plane upgrade failed!")
@@ -828,7 +828,7 @@ def update_cluster_with_clouddns_if_necessary(args) -> int:
     # Upgrade nodepools version after the master upgrade.
     node_pool_update_code = upgrade_gke_nodepools_version(
         args,
-        gke_server_config.default_rapid_gke_version,  # pytype: disable=attribute-error
+        gke_server_config.default_rapid_gke_version,
     )
     if node_pool_update_code > 0:
       xpk_print('Upgrading nodepools version failed!')

--- a/src/xpk/core/docker_resources.py
+++ b/src/xpk/core/docker_resources.py
@@ -72,7 +72,7 @@ def get_env_container(args, system: SystemCharacteristics) -> str:
   if system.accelerator_type == AcceleratorType['CPU']:
     return get_cpu_env(args, system)
 
-  return format_env_dict(args.env, system)  # pytype: disable=bad-return-type
+  return format_env_dict(args.env, system)
 
 
 def get_gpu_env(args, system) -> str:

--- a/src/xpk/core/filestore.py
+++ b/src/xpk/core/filestore.py
@@ -93,11 +93,11 @@ class FilestoreClient:
 
     for instance in instancesZonal:
       if instance.name == fullname_zonal:
-        return instance  # pytype: disable=bad-return-type
+        return instance
 
     for instance in instancesRegional:
       if instance.name == fullname_regional:
-        return instance  # pytype: disable=bad-return-type
+        return instance
 
   def check_instance_exists(self) -> bool:
     """Check if Filestore instance exists"""

--- a/src/xpk/core/gcloud_context.py
+++ b/src/xpk/core/gcloud_context.py
@@ -85,7 +85,7 @@ def zone_to_region(zone) -> str:
      The region name.
   """
   zone_terms = zone.split('-')
-  return zone_terms[0] + '-' + zone_terms[1]  # pytype: disable=bad-return-type
+  return zone_terms[0] + '-' + zone_terms[1]
 
 
 @dataclass


### PR DESCRIPTION
## Fixes / Features
- pytype is no longer supported for Python > 3.12
- mypy seems to be the official choice and has the most github stars