### PR TITLE
refactor: make install-dev to include lint tools

### DIFF
--- a/.github/workflows/build_tests.yaml
+++ b/.github/workflows/build_tests.yaml
@@ -112,7 +112,7 @@ jobs:
         lookup-only: true
     - name: install dependencies
       if : steps.check-cache.outputs.cache-hit != 'true'
-      run: make install-lint && make install-dev && cp ./bin/kubectl-kueue /usr/local/bin/kubectl-kueue && cp ./bin/kubectl-kjob /usr/local/bin/kubectl-kjob
+      run: make install-dev && cp ./bin/kubectl-kueue /usr/local/bin/kubectl-kueue && cp ./bin/kubectl-kjob /usr/local/bin/kubectl-kjob
     - name: Cache dependencies
       if : steps.check-cache.outputs.cache-hit != 'true'
       uses: actions/cache/save@v3

--- a/.github/workflows/reusable_unit_tests.yaml
+++ b/.github/workflows/reusable_unit_tests.yaml
@@ -39,7 +39,5 @@ jobs:
           ${{env.pythonLocation}}
         key: xpk-deps-3.10-${{github.run_id}}-${{github.run_attempt}}
         restore-keys: xpk-deps-3.10-
-    # - name: Install dependecies
-    #   run: make install-dev
     - name: Run unit tests
       run: make run-unittests

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ BIN_PATH=$(PROJECT_DIR)/bin
 install: check-python check-gcloud install-gcloud-auth-plugin install-kueuectl install-kjobctl pip-install
 
 .PHONY: install-dev
-install-dev: check-python check-gcloud mkdir-bin install-kueuectl install-kjobctl pip-install install-pytest
+install-dev: check-python check-gcloud mkdir-bin install-kueuectl install-kjobctl pip-install install-pytest install-lint
 
 .PHONY: pip-install
 pip-install:


### PR DESCRIPTION
## Fixes / Features
- `make install-dev` will contain lint libraries, including `mypy`

## Testing / Documentation

- [ y ] Tests pass
- [ n/a ] Appropriate changes to documentation are included in the PR
