### PR TITLE
Don't set --enable-queued-provisioning for flex multislice

### DIFF
--- a/src/xpk/core/capacity.py
+++ b/src/xpk/core/capacity.py
@@ -195,10 +195,12 @@ def get_capacity_arguments_from_capacity_type(
       capacity_args = '--spot'
     case CapacityType.FLEX_START:
       capacity_args = (
-          ' --flex-start --enable-queued-provisioning --enable-autoscaling'
+          ' --flex-start --enable-autoscaling'
           ' --location-policy=ANY --reservation-affinity=none'
           f' --no-enable-autorepair --max-nodes={max_nodes}'
       )
+      if args.num_slices <= 1:
+        capacity_args += ' --enable-queued-provisioning'
     case CapacityType.RESERVATION:
       capacity_args = (
           f'--reservation-affinity=specific --reservation={args.reservation}'


### PR DESCRIPTION
## Fixes / Features
- Doesn't set --enable-queued-provisioning in case of flex capacity and multislice

Tested by creating a flex multislice cluster and verifying configuration.
