### PR TITLE
Simplify dependencies on build_test so it runs faster

### DIFF
--- a/.github/workflows/build_tests.yaml
+++ b/.github/workflows/build_tests.yaml
@@ -28,6 +28,9 @@ on:
     branches: ["main","develop"]
   pull_request: # By default this runs for types assigned, opened and synchronize.
 
+permissions:
+  contents: read
+
 jobs:
   set-variables:
     runs-on: [ubuntu-22.04]
@@ -124,7 +127,7 @@ jobs:
           ${{env.pythonLocation}}
         key: xpk-deps-${{ matrix.python-version }}-${{github.run_id}}-${{github.run_attempt}}
   linter:
-    needs: [install-dependencies, set-variables]
+    needs: [set-variables]
     concurrency: # We support one build or nightly test to run at a time currently.
       group: linter-${{needs.set-variables.outputs.run-id}}
       cancel-in-progress: true
@@ -132,12 +135,12 @@ jobs:
     with:
       run-id: '${{needs.set-variables.outputs.run-id}}'
   verify-goldens:
-    needs: [install-dependencies, set-variables]
+    needs: [set-variables]
     uses: ./.github/workflows/reusable_goldens.yaml
     with:
       run-id: '${{needs.set-variables.outputs.run-id}}'
   run-unit-tests:
-    needs: [install-dependencies, set-variables]
+    needs: [set-variables]
     uses: ./.github/workflows/reusable_unit_tests.yaml
     with:
       run-id: ${{needs.set-variables.outputs.run-id}}


### PR DESCRIPTION
## Fixes / Features
We don't need to wait for `install-dependencies` on `linter`, `verify-goldens`, and `run-unit-tests`. This would allow these tasks to execute faster and provide feedback to developer faster.

## Testing / Documentation
No testing.

- [X] Tests pass
- [X] Appropriate changes to documentation are included in the PR
