### PR TITLE
Revert "Simplify dependencies on build_test so it runs faster"

### DIFF
--- a/.github/workflows/build_tests.yaml
+++ b/.github/workflows/build_tests.yaml
@@ -28,9 +28,6 @@ on:
     branches: ["main","develop"]
   pull_request: # By default this runs for types assigned, opened and synchronize.
 
-permissions:
-  contents: read
-
 jobs:
   set-variables:
     runs-on: [ubuntu-22.04]
@@ -127,7 +124,7 @@ jobs:
           ${{env.pythonLocation}}
         key: xpk-deps-${{ matrix.python-version }}-${{github.run_id}}-${{github.run_attempt}}
   linter:
-    needs: [set-variables]
+    needs: [install-dependencies, set-variables]
     concurrency: # We support one build or nightly test to run at a time currently.
       group: linter-${{needs.set-variables.outputs.run-id}}
       cancel-in-progress: true
@@ -135,12 +132,12 @@ jobs:
     with:
       run-id: '${{needs.set-variables.outputs.run-id}}'
   verify-goldens:
-    needs: [set-variables]
+    needs: [install-dependencies, set-variables]
     uses: ./.github/workflows/reusable_goldens.yaml
     with:
       run-id: '${{needs.set-variables.outputs.run-id}}'
   run-unit-tests:
-    needs: [set-variables]
+    needs: [install-dependencies, set-variables]
     uses: ./.github/workflows/reusable_unit_tests.yaml
     with:
       run-id: ${{needs.set-variables.outputs.run-id}}


### PR DESCRIPTION
## Fixes / Features
Reverts AI-Hypercomputer/xpk#642. The `install-dependencies` step is installing python dependencies that are necessary for unit tests.

## Testing / Documentation
Tested here AI-Hypercomputer/xpk#643 with revert commit.

- [x] Tests pass
- [X] Appropriate changes to documentation are included in the PR