### PR TITLE
Do not execute nightly after push (cron remains)

### DIFF
--- a/.github/workflows/nightly_tests.yaml
+++ b/.github/workflows/nightly_tests.yaml
@@ -15,8 +15,6 @@
 name: Nightly Tests
 
 on:
-  push:
-    branches: ["develop"]
   workflow_dispatch:
   schedule: # Schedule the job run at 12AM PST daily.
     - cron: '0 8 * * *'


### PR DESCRIPTION
## Fixes / Features
Nightly tests should be executed nightly, not after push to develop. Also looking at their [execution history](https://github.com/AI-Hypercomputer/xpk/actions?query=workflow%3A%22Nightly+Tests%22) they seem to succeed with high probability when they are triggered by cron and fail on pushes to develop. This is probably due to low demand for underlaying resources at night.

## Testing / Documentation
N/A

- [X] Tests pass
- [X] Appropriate changes to documentation are included in the PR
