### PR TITLE
Remove dry_run arg from run_commands

### DIFF
--- a/src/xpk/commands/workload.py
+++ b/src/xpk/commands/workload.py
@@ -732,7 +732,6 @@ def workload_delete(args) -> None:
           'Delete Workload',
           task_names,
           batch=100,
-          dry_run=args.dry_run,
       )
 
     if return_code != 0:

--- a/src/xpk/core/commands.py
+++ b/src/xpk/core/commands.py
@@ -26,7 +26,7 @@ from ..utils.console import xpk_print
 from ..utils.execution_context import is_dry_run
 
 
-def run_commands(commands, jobname, per_command_name, batch=10, dry_run=False):
+def run_commands(commands, jobname, per_command_name, batch=10):
   """Run commands in groups of `batch`.
 
   Args:
@@ -34,7 +34,6 @@ def run_commands(commands, jobname, per_command_name, batch=10, dry_run=False):
     jobname: the name of the job.
     per_command_name: list of command names.
     batch: number of commands to run in parallel.
-    dry_run: enables dry_run if set to true.
 
   Returns:
     0 if successful and 1 otherwise.
@@ -47,7 +46,7 @@ def run_commands(commands, jobname, per_command_name, batch=10, dry_run=False):
       f'Breaking up a total of {len(commands)} commands into'
       f' {len(commands_batched)} batches'
   )
-  if dry_run:
+  if is_dry_run():
     xpk_print('Pretending all the jobs succeeded')
     return 0
 

--- a/src/xpk/core/nap.py
+++ b/src/xpk/core/nap.py
@@ -156,7 +156,6 @@ def enable_autoprovisioning_on_cluster(
       commands,
       'Update node pools with autoprovisioning support',
       task_names,
-      dry_run=args.dry_run,
   )
   if max_return_code != 0:
     xpk_print(

--- a/src/xpk/core/nodepool.py
+++ b/src/xpk/core/nodepool.py
@@ -212,7 +212,6 @@ def run_gke_node_pool_create_command(
         delete_commands,
         'Delete Nodepools',
         delete_task_names,
-        dry_run=args.dry_run,
     )
     if max_return_code != 0:
       xpk_print(f'Delete Nodepools returned ERROR {max_return_code}')
@@ -240,7 +239,6 @@ def run_gke_node_pool_create_command(
           update_WI_commands,
           'Enable Workload Identity on existing Nodepools',
           update_WI_task_names,
-          dry_run=args.dry_run,
       )
       if max_return_code != 0:
         xpk_print(
@@ -265,9 +263,7 @@ def run_gke_node_pool_create_command(
       )
       configmap_yml = {}
       configmap_yml[resources_configmap_name] = resources_yml
-      return_code = create_or_update_cluster_configmap(
-          configmap_yml, args.dry_run
-      )
+      return_code = create_or_update_cluster_configmap(configmap_yml)
       if return_code != 0:
         return 1
 
@@ -369,7 +365,6 @@ def run_gke_node_pool_create_command(
       create_commands,
       'Create Nodepools',
       create_task_names,
-      dry_run=args.dry_run,
   )
   if max_return_code != 0:
     xpk_print(f'Create Nodepools returned ERROR {max_return_code}')
@@ -582,7 +577,6 @@ def upgrade_gke_nodepools_version(args, default_rapid_gke_version) -> int:
       commands,
       'Update GKE node pools to default RAPID GKE version',
       task_names,
-      dry_run=args.dry_run,
   )
   if max_return_code != 0:
     xpk_print(

--- a/src/xpk/core/pathways.py
+++ b/src/xpk/core/pathways.py
@@ -326,7 +326,7 @@ def try_to_delete_pathwaysjob_first(args, workloads) -> bool:
     return_code = run_command_with_updates(commands[0], 'Delete Workload')
   else:
     return_code = run_commands(
-        commands, 'Delete Workload', task_names, batch=100, dry_run=args.dry_run
+        commands, 'Delete Workload', task_names, batch=100
     )
 
   if return_code != 0:

--- a/src/xpk/core/resources.py
+++ b/src/xpk/core/resources.py
@@ -153,12 +153,10 @@ def create_cluster_configmaps(
       args=args, name=metadata_configmap_name, data=metadata
   )
   configmap_yml[metadata_configmap_name] = metadata_yml
-  return create_or_update_cluster_configmap(configmap_yml, args.dry_run)
+  return create_or_update_cluster_configmap(configmap_yml)
 
 
-def create_or_update_cluster_configmap(
-    configmap_yml: dict, dry_run: bool
-) -> int:
+def create_or_update_cluster_configmap(configmap_yml: dict) -> int:
   """
   Args:
     configmap_yml: dict containing ConfigMap name and yml string.
@@ -179,7 +177,6 @@ def create_or_update_cluster_configmap(
       commands,
       'GKE Cluster CreateOrUpdate ConfigMap(s)',
       task_names,
-      dry_run=dry_run,
   )
   if return_code != 0:
     xpk_print(


### PR DESCRIPTION
## Fixes / Features
This is a cleanup so we don't have to carry `args` down the invocation tree. The new pattern is to understand if XPK is running in dry-run mode using `is_dry_run()` helper from `utils.execution_context`.

## Testing / Documentation
Tests are automatic.

- [X] Tests pass
- [X] Appropriate changes to documentation are included in the PR
