### PR TITLE
Remove args from run_command_with_full_controls

### DIFF
--- a/src/xpk/commands/run.py
+++ b/src/xpk/commands/run.py
@@ -126,7 +126,7 @@ def submit_job(args: Namespace) -> None:
   if args.time is not None:
     cmd += f' --time {args.time}'
 
-  return_code = run_command_with_full_controls(cmd, 'run task', args)
+  return_code = run_command_with_full_controls(cmd, 'run task')
 
   if return_code != 0:
     xpk_print(f'Running task returned ERROR {return_code}')

--- a/src/xpk/commands/shell.py
+++ b/src/xpk/commands/shell.py
@@ -38,9 +38,7 @@ def shell(args: Namespace):
   if exisitng_shell_pod_name is None:
     return_code = connect_to_new_interactive_shell(args)
   else:
-    return_code = connect_to_existing_interactive_shell(
-        exisitng_shell_pod_name, args
-    )
+    return_code = connect_to_existing_interactive_shell(exisitng_shell_pod_name)
 
   if return_code != 0:
     xpk_print(f'The command failed with code {return_code}.')
@@ -94,21 +92,17 @@ def connect_to_new_interactive_shell(args: Namespace) -> int:
   return run_command_with_full_controls(
       command=cmd,
       task='Creating new interactive shell and entering it',
-      global_args=args,
       instructions=exit_instructions,
   )
 
 
-def connect_to_existing_interactive_shell(
-    pod_name: str, args: Namespace
-) -> int:
+def connect_to_existing_interactive_shell(pod_name: str) -> int:
   return run_command_with_full_controls(
       command=(
           f'kubectl exec --stdin --tty {pod_name} --'
           f' {get_pod_template_interactive_command()}'
       ),
       task='Entering existing interactive shell',
-      global_args=args,
       instructions=exit_instructions,
   )
 

--- a/src/xpk/core/commands.py
+++ b/src/xpk/core/commands.py
@@ -18,7 +18,6 @@ import datetime
 import subprocess
 import sys
 import time
-from argparse import Namespace
 
 from ..utils.objects import chunks
 from ..utils.file import make_tmp_files, write_tmp_file
@@ -301,7 +300,6 @@ def run_command_for_value(
 def run_command_with_full_controls(
     command: str,
     task: str,
-    global_args: Namespace,
     instructions: str | None = None,
 ) -> int:
   """Run command in current shell with system out, in and error handles. Wait
@@ -310,13 +308,12 @@ def run_command_with_full_controls(
   Args:
     command: command to execute
     task: user-facing name of the task
-    global_args: user provided arguments for running the command.
     verbose: shows stdout and stderr if set to true. Set to True by default.
 
   Returns:
     0 if successful and 1 otherwise.
   """
-  if global_args.dry_run:
+  if is_dry_run():
     xpk_print(
         f'Task: `{task}` is implemented by the following command'
         ' not running since it is a dry run.'


### PR DESCRIPTION
## Fixes / Features
This is a cleanup so we don't have to carry `args` down the invocation tree. The new pattern is to understand if XPK is running in dry-run mode using `is_dry_run()` helper from `utils.execution_context`.

## Testing / Documentation
Tests are automatic.

- [X] Tests pass
- [X] Appropriate changes to documentation are included in the PR
