### PR TITLE
Check if yq is installed in golden buddy

### DIFF
--- a/golden_buddy.sh
+++ b/golden_buddy.sh
@@ -83,6 +83,11 @@ GREEN='\033[0;32m'
 YELLOW='\033[0;33m'
 NC='\033[0m'
 
+if ! command -v yq &> /dev/null; then
+  echo -e "${RED}Error: 'yq' command not found. Please install yq to continue.${NC}" >&2
+  exit 1
+fi
+
 if [[ "$MODE" != "update" && "$MODE" != "verify" ]]; then
   echo "Error: Unsupported mode '$MODE'. Must be 'update' or 'verify'." >&2
   exit 1


### PR DESCRIPTION
## Fixes / Features
@SikaGrr correctly found out that when `yq` was not installed, script continued to run and printed "Goldens Updated" at the end of execution:

```
./golden_buddy.sh update goldens.yaml goldens
yq: command not found
Goldens updated!
```

## Testing / Documentation
Checked in environment where `yq` is not present and it works as expected.
Checked in environment where `yq` is present and it works as expected.

- [X] Tests pass
- [X] Appropriate changes to documentation are included in the PR
