### PR TITLE
Feat: add skip validation flag

### DIFF
--- a/goldens/Basic_cluster_create.txt
+++ b/goldens/Basic_cluster_create.txt
@@ -1,5 +1,6 @@
 $ python3 xpk.py cluster create --project=golden-project --zone=us-central1-a --cluster=golden-cluster --tpu-type=tpu7x-8 --spot --dry-run
 [XPK] Starting xpk
+[XPK] Skipping dependency validation.
 [XPK] Starting cluster create for cluster golden-cluster:
 [XPK] Working on golden-project and us-central1-a
 [XPK] Task: `Determine server supported GKE versions for default rapid gke version` is implemented by the following command not running since it is a dry run. 

--- a/goldens/Batch.txt
+++ b/goldens/Batch.txt
@@ -1,5 +1,6 @@
 $ python3 xpk.py batch --project=golden-project --zone=us-central1-a --cluster=golden-cluster --dry-run batch-read.sh
 [XPK] Starting xpk
+[XPK] Skipping dependency validation.
 [XPK] Working on golden-project and us-central1-a
 [XPK] Try 1: get-credentials to cluster golden-cluster
 [XPK] Task: `get-credentials to cluster golden-cluster` is implemented by the following command not running since it is a dry run. 

--- a/goldens/Cluster_create_private.txt
+++ b/goldens/Cluster_create_private.txt
@@ -1,5 +1,6 @@
 $ python3 xpk.py cluster create-pathways --project=golden-project --zone=us-central1-a --cluster=golden-cluster-private --private --tpu-type=v5p-8  --num-slices=1 --default-pool-cpu-machine-type=n1-standard-16 --default-pool-cpu-num-nodes=4 --reservation=golden-reservation --dry-run
 [XPK] Starting xpk
+[XPK] Skipping dependency validation.
 [XPK] Starting cluster create for cluster golden-cluster-private:
 [XPK] Working on golden-project and us-central1-a
 [XPK] Task: `Determine server supported GKE versions for default rapid gke version` is implemented by the following command not running since it is a dry run. 

--- a/goldens/Cluster_delete.txt
+++ b/goldens/Cluster_delete.txt
@@ -1,5 +1,6 @@
 $ python3 xpk.py cluster delete --project=golden-project --zone=us-central1-a --cluster=golden-cluster --dry-run
 [XPK] Starting xpk
+[XPK] Skipping dependency validation.
 [XPK] Starting cluster delete for cluster: golden-cluster
 [XPK] Working on golden-project and us-central1-a
 [XPK] Try 1: get-credentials to cluster golden-cluster

--- a/goldens/Cluster_delete_force.txt
+++ b/goldens/Cluster_delete_force.txt
@@ -1,5 +1,6 @@
 $ python3 xpk.py cluster delete --project=golden-project --zone=us-central1-a --cluster=golden-cluster --force --dry-run
 [XPK] Starting xpk
+[XPK] Skipping dependency validation.
 [XPK] Starting cluster delete for cluster: golden-cluster
 [XPK] Working on golden-project and us-central1-a
 [XPK] Try 1: get-credentials to cluster golden-cluster

--- a/goldens/Job_cancel.txt
+++ b/goldens/Job_cancel.txt
@@ -1,5 +1,6 @@
 $ python3 xpk.py job cancel golden-job --project=golden-project --zone=us-central1-a --cluster=golden-cluster --dry-run
 [XPK] Starting xpk
+[XPK] Skipping dependency validation.
 [XPK] Starting job cancel for job: ['golden-job']
 [XPK] Working on golden-project and us-central1-a
 [XPK] Try 1: get-credentials to cluster golden-cluster

--- a/goldens/Job_info.txt
+++ b/goldens/Job_info.txt
@@ -1,5 +1,6 @@
 $ python3 xpk.py job info golden-job --project=golden-project --zone=us-central1-a --cluster=golden-cluster --dry-run
 [XPK] Starting xpk
+[XPK] Skipping dependency validation.
 [XPK] Task: `Getting job data` is implemented by the following command not running since it is a dry run. 
 kubectl-kjob describe slurm golden-job
 [XPK] Task: `Getting job info` is implemented by the following command not running since it is a dry run. 

--- a/goldens/Job_list.txt
+++ b/goldens/Job_list.txt
@@ -1,5 +1,6 @@
 $ python3 xpk.py job ls --project=golden-project --zone=us-central1-a --cluster=golden-cluster --dry-run
 [XPK] Starting xpk
+[XPK] Skipping dependency validation.
 [XPK] Working on golden-project and us-central1-a
 [XPK] Try 1: get-credentials to cluster golden-cluster
 [XPK] Task: `get-credentials to cluster golden-cluster` is implemented by the following command not running since it is a dry run. 

--- a/goldens/NAP_cluster-create.txt
+++ b/goldens/NAP_cluster-create.txt
@@ -1,5 +1,6 @@
 $ python3 xpk.py cluster create --project=golden-project --zone=us-central1-a --enable-autoprovisioning --cluster=golden-cluster --tpu-type=tpu7x-8 --on-demand --dry-run
 [XPK] Starting xpk
+[XPK] Skipping dependency validation.
 [XPK] Starting cluster create for cluster golden-cluster:
 [XPK] Working on golden-project and us-central1-a
 [XPK] Task: `Determine server supported GKE versions for default rapid gke version` is implemented by the following command not running since it is a dry run. 

--- a/goldens/NAP_cluster-create_with_pathways.txt
+++ b/goldens/NAP_cluster-create_with_pathways.txt
@@ -1,5 +1,6 @@
 $ python3 xpk.py cluster create-pathways --project=golden-project --zone=us-central1-a --enable-autoprovisioning --cluster=golden-cluster --tpu-type=tpu7x-8 --on-demand --dry-run
 [XPK] Starting xpk
+[XPK] Skipping dependency validation.
 [XPK] Starting cluster create for cluster golden-cluster:
 [XPK] Working on golden-project and us-central1-a
 [XPK] Task: `Determine server supported GKE versions for default rapid gke version` is implemented by the following command not running since it is a dry run. 

--- a/goldens/Storage_list.txt
+++ b/goldens/Storage_list.txt
@@ -1,5 +1,6 @@
 $ python3 xpk.py storage list --project=golden-project --zone=us-central1-a --cluster=golden-cluster --dry-run
 [XPK] Starting xpk
+[XPK] Skipping dependency validation.
 NAME    TYPE    AUTO MOUNT    MOUNT POINT    READONLY    MANIFEST
 ------  ------  ------------  -------------  ----------  ----------
 [XPK] XPK Done.

--- a/goldens/Workload_create.txt
+++ b/goldens/Workload_create.txt
@@ -1,5 +1,6 @@
 $ python3 xpk.py workload create --project=golden-project --zone=us-central1-a --cluster=golden-cluster --workload=golden-workload --command "bash hello" --tpu-type=v5p-8 --num-slices=1 --script-dir=/tmp --dry-run
 [XPK] Starting xpk
+[XPK] Skipping dependency validation.
 [XPK] Task: `Check if Workload Already Exists` is implemented by the following command not running since it is a dry run. 
 kubectl get workloads -o=custom-columns='Jobset:.metadata.ownerReferences[0].name'
 [XPK] Starting workload create

--- a/goldens/Workload_create_pathways.txt
+++ b/goldens/Workload_create_pathways.txt
@@ -1,5 +1,6 @@
 $ python3 xpk.py workload create-pathways --project=golden-project --zone=us-central1-a --cluster=golden-cluster --workload=golden-workload --command "bash hello" --tpu-type=v5p-8 --num-slices=1 --script-dir=/tmp --dry-run
 [XPK] Starting xpk
+[XPK] Skipping dependency validation.
 [XPK] Task: `Check if Workload Already Exists` is implemented by the following command not running since it is a dry run. 
 kubectl get workloads -o=custom-columns='Jobset:.metadata.ownerReferences[0].name'
 [XPK] Starting workload create

--- a/goldens/Workload_delete.txt
+++ b/goldens/Workload_delete.txt
@@ -1,5 +1,6 @@
 $ python3 xpk.py workload delete --project=golden-project --zone=us-central1-a --cluster=golden-cluster --workload=golden-workload --dry-run
 [XPK] Starting xpk
+[XPK] Skipping dependency validation.
 [XPK] Starting Workload delete
 [XPK] Working on golden-project and us-central1-a
 [XPK] Try 1: get-credentials to cluster golden-cluster

--- a/goldens/Workload_list.txt
+++ b/goldens/Workload_list.txt
@@ -1,5 +1,6 @@
 $ python3 xpk.py workload list --project=golden-project --zone=us-central1-a --cluster=golden-cluster --dry-run
 [XPK] Starting xpk
+[XPK] Skipping dependency validation.
 [XPK] Starting workload list
 [XPK] Working on golden-project and us-central1-a
 [XPK] Try 1: get-credentials to cluster golden-cluster

--- a/src/xpk/main.py
+++ b/src/xpk/main.py
@@ -67,8 +67,11 @@ def main() -> None:
   main_args = parser.parse_args()
   main_args.enable_ray_cluster = False
   set_dry_run('dry_run' in main_args and main_args.dry_run)
-  if not main_args.dry_run:
+  if not main_args.dry_run and not main_args.skip_validation:
+    xpk_print('Validating dependencies...', flush=True)
     validate_dependencies()
+  else:
+    xpk_print('Skipping dependency validation.', flush=True)
   main_args.func(main_args)
   xpk_print('XPK Done.', flush=True)
 

--- a/src/xpk/parser/common.py
+++ b/src/xpk/parser/common.py
@@ -62,6 +62,17 @@ def add_shared_arguments(
       ),
       required=required,
   )
+  custom_parser_or_group.add_argument(
+      '--skip-validation',
+      type=bool,
+      action=argparse.BooleanOptionalAction,
+      default=False,
+      help=(
+          'Skip dependency validation checks (kubectl, gcloud, docker, etc). '
+          'Independent of --dry-run.'
+      ),
+      required=required,
+  )
 
 
 def add_cluster_arguments(


### PR DESCRIPTION
## Background
Our Airflow integration tests only use `workload create` and `create-pathway` commands. We do not require system dependencies like `docker` or `kubectl-kjob` to launch these workloads.

Installing these non-essential tools in the Airflow/Composer environment introduces significant complexity and workarounds (refer to b/411426745)

## Fixes / Features
- Modified the main execution flow in `src/xpk/main.py` to check for the `skip_validation` flag; validation is skipped with a corresponding message if the flag is set.

## Testing / Documentation
- The changes were tested by running workload creation commands that use a custom Docker image in Airflow. The tests confirm that validation is now successfully skipped in this scenario, allowing the commands to run without error.

- [ y/n ] Tests pass
- [ y/n ] Appropriate changes to documentation are included in the PR
