### PR TITLE
Move sub-slicing validation to kueue-manager

### DIFF
--- a/src/xpk/commands/workload.py
+++ b/src/xpk/commands/workload.py
@@ -27,7 +27,7 @@ from ..core.cluster import (
     setup_k8s_env,
 )
 from ..core.commands import run_command_with_updates, run_commands
-from ..core.kueue_manager import KueueManager
+from ..core.kueue_manager import KueueManager, has_sub_slicing_enabled
 from ..core.config import (VERTEX_TENSORBOARD_FEATURE_FLAG, XPK_CURRENT_VERSION)
 from ..core.docker_container import (
     get_main_container_docker_image,
@@ -683,9 +683,7 @@ def workload_create(args) -> None:
 
 
 def _validate_sub_slicing_availability():
-  kueue_manager = KueueManager()
-
-  return_code, sub_slicing_enabled = kueue_manager.has_sub_slicing_enabled()
+  return_code, sub_slicing_enabled = has_sub_slicing_enabled()
   if return_code != 0:
     xpk_print(
         'Error: Unable to validate sub-slicing support on a given cluster.'
@@ -699,6 +697,7 @@ def _validate_sub_slicing_availability():
     )
     xpk_exit(1)
 
+  kueue_manager = KueueManager()
   return_code, current_version = kueue_manager.get_installed_kueue_version()
   if return_code != 0:
     xpk_print(

--- a/src/xpk/commands/workload_test.py
+++ b/src/xpk/commands/workload_test.py
@@ -71,7 +71,7 @@ def test_validate_sub_slicing_availability_exits_when_getting_topologies_fails(
     xpk_print: MagicMock, mocker
 ):
   mocker.patch(
-      'xpk.commands.workload.KueueManager.has_sub_slicing_enabled',
+      'xpk.commands.workload.has_sub_slicing_enabled',
       return_value=(1, None),
   )
   with pytest.raises(SystemExit):
@@ -87,7 +87,7 @@ def test_validate_sub_slicing_availability_exits_when_subslicing_topology_is_not
     xpk_print: MagicMock, mocker
 ):
   mocker.patch(
-      'xpk.commands.workload.KueueManager.has_sub_slicing_enabled',
+      'xpk.commands.workload.has_sub_slicing_enabled',
       return_value=(0, False),
   )
   with pytest.raises(SystemExit):
@@ -103,7 +103,7 @@ def test_validate_sub_slicing_availability_exits_when_kueue_version_cannot_be_de
     xpk_print: MagicMock, mocker
 ):
   mocker.patch(
-      'xpk.commands.workload.KueueManager.has_sub_slicing_enabled',
+      'xpk.commands.workload.has_sub_slicing_enabled',
       return_value=(0, True),
   )
   mocker.patch(
@@ -120,7 +120,7 @@ def test_validate_sub_slicing_availability_exits_when_kueue_version_does_not_mee
     xpk_print: MagicMock, mocker
 ):
   mocker.patch(
-      'xpk.commands.workload.KueueManager.has_sub_slicing_enabled',
+      'xpk.commands.workload.has_sub_slicing_enabled',
       return_value=(0, True),
   )
   mocker.patch(
@@ -137,7 +137,7 @@ def test_validate_sub_slicing_availability_does_nothing_when_cluster_is_correctl
     mocker,
 ):
   mocker.patch(
-      'xpk.commands.workload.KueueManager.has_sub_slicing_enabled',
+      'xpk.commands.workload.has_sub_slicing_enabled',
       return_value=(0, True),
   )
   mocker.patch(

--- a/src/xpk/core/kueue_manager.py
+++ b/src/xpk/core/kueue_manager.py
@@ -140,16 +140,6 @@ class KueueManager:
       return 1, None
     return return_code, Version(version_tag[-1])
 
-  def has_sub_slicing_enabled(self) -> tuple[int, bool | None]:
-    return_code, value = run_command_for_value(
-        command="kubectl get topology", task="Get defined topologies"
-    )
-
-    if return_code != 0:
-      return return_code, None
-
-    return return_code, SUB_SLICE_TOPOLOGY_NAME in value
-
   def __install(
       self,
       tolerations: Optional[List[Dict[str, Any]]] = None,
@@ -431,3 +421,14 @@ class KueueManager:
     if return_code != 0:
       xpk_print(f"{task} returned ERROR {return_code}")
     return return_code
+
+
+def has_sub_slicing_enabled() -> tuple[int, bool | None]:
+  return_code, value = run_command_for_value(
+      command="kubectl get topology", task="Get defined topologies"
+  )
+
+  if return_code != 0:
+    return return_code, None
+
+  return return_code, SUB_SLICE_TOPOLOGY_NAME in value

--- a/src/xpk/core/kueue_manager_test.py
+++ b/src/xpk/core/kueue_manager_test.py
@@ -19,7 +19,7 @@ import unittest
 import yaml
 from unittest.mock import MagicMock, patch
 
-from xpk.core.kueue_manager import KueueConfig, KueueManager
+from xpk.core.kueue_manager import KueueConfig, KueueManager, has_sub_slicing_enabled
 from xpk.core.system_characteristics import AcceleratorType, SystemCharacteristics
 from packaging.version import Version
 
@@ -561,32 +561,35 @@ class KueueManagerTest(unittest.TestCase):
     assert isinstance(manifest, str)
     return manifest
 
-  @patch("xpk.core.kueue_manager.run_command_for_value")
-  def test_has_sub_slicing_enabled_returns_exit_code_when_command_fails(
-      self, mock_run_for_value
-  ):
-    mock_run_for_value.return_value = (1, None)
-    return_code, result = self.kueue_manager.has_sub_slicing_enabled()
-    assert return_code == 1
-    assert result is None
 
-  @patch("xpk.core.kueue_manager.run_command_for_value")
-  def test_has_sub_slicing_enabled_returns_false_when_sub_slicing_topology_is_not_present(
-      self, mock_run_for_value
-  ):
-    mock_run_for_value.return_value = (0, "")
-    return_code, result = self.kueue_manager.has_sub_slicing_enabled()
-    assert return_code == 0
-    assert result is False
+@patch("xpk.core.kueue_manager.run_command_for_value")
+def test_has_sub_slicing_enabled_returns_exit_code_when_command_fails(
+    mock_run_for_value,
+):
+  mock_run_for_value.return_value = (1, None)
+  return_code, result = has_sub_slicing_enabled()
+  assert return_code == 1
+  assert result is None
 
-  @patch("xpk.core.kueue_manager.run_command_for_value")
-  def test_has_sub_slicing_enabled_returns_true_when_sub_slicing_topology_is_not_present(
-      self, mock_run_for_value
-  ):
-    mock_run_for_value.return_value = (0, "sub-slice-topology")
-    return_code, result = self.kueue_manager.has_sub_slicing_enabled()
-    assert return_code == 0
-    assert result is True
+
+@patch("xpk.core.kueue_manager.run_command_for_value")
+def test_has_sub_slicing_enabled_returns_false_when_sub_slicing_topology_is_not_present(
+    mock_run_for_value,
+):
+  mock_run_for_value.return_value = (0, "")
+  return_code, result = has_sub_slicing_enabled()
+  assert return_code == 0
+  assert result is False
+
+
+@patch("xpk.core.kueue_manager.run_command_for_value")
+def test_has_sub_slicing_enabled_returns_true_when_sub_slicing_topology_is_not_present(
+    mock_run_for_value,
+):
+  mock_run_for_value.return_value = (0, "sub-slice-topology")
+  return_code, result = has_sub_slicing_enabled()
+  assert return_code == 0
+  assert result is True
 
 
 T = TypeVar("T")


### PR DESCRIPTION
# Description
It moves sub-slicing validation into `KueueManager` so it can be reused.

# Issue
b/452627273

# Testing
Unit tests
