### PR TITLE
Build actions -> build scripts

### DIFF
--- a/.github/workflows/nightly_tests.yaml
+++ b/.github/workflows/nightly_tests.yaml
@@ -29,7 +29,7 @@ jobs:
   build_wheel:
     uses: ./.github/workflows/reusable_build_wheel.yaml
   build_actions:
-    uses: ./.github/workflows/reusable_build_actions.yaml
+    uses: ./.github/workflows/reusable_build_scripts.yaml
   cluster-create-and-delete:
     runs-on: [ubuntu-22.04]
     needs: [build_wheel, build_actions]
@@ -44,8 +44,7 @@ jobs:
     steps:
     - uses: actions/download-artifact@v4
       with:
-        name: custom-actions
-        path: .github/actions
+        name: custom-scripts
     - name: Setup environment
       uses: ./.github/actions/setup-test-env
       with:
@@ -172,8 +171,7 @@ jobs:
     steps:
     - uses: actions/download-artifact@v4
       with:
-        name: custom-actions
-        path: .github/actions
+        name: custom-scripts
     - name: Setup environment
       uses: ./.github/actions/setup-test-env
       with:
@@ -211,8 +209,7 @@ jobs:
     steps:
     - uses: actions/download-artifact@v4
       with:
-        name: custom-actions
-        path: .github/actions
+        name: custom-scripts
     - name: Setup environment
       uses: ./.github/actions/setup-test-env
       with:

--- a/.github/workflows/reusable_build_scripts.yaml
+++ b/.github/workflows/reusable_build_scripts.yaml
@@ -12,22 +12,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License
 
-name: Build Actions
+name: Build Scripts
 
 on:
-    workflow_call:
+  workflow_call:
 
 permissions:
   contents: read
 
 jobs:
-    build:
-        name: Build Actions
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v4
-            - name: Store the distribution packages
-              uses: actions/upload-artifact@v4
-              with:
-                  name: custom-actions
-                  path: .github/actions
+  build:
+    name: Build Scripts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Store repository scripts
+        uses: actions/upload-artifact@v4
+        with:
+          name: custom-scripts
+          path: |
+            .github/actions
+            backoff_retry.sh


### PR DESCRIPTION
# Description
This is needed as nightly tests are failing now due to missing backoff_retry.sh script. It is good and bad. The good is that it confirms no XPK source code is available in the pipeline. The bad is that it fails.

Run: https://github.com/AI-Hypercomputer/xpk/actions/runs/18935955146

# Issue
b/445869874

# Testing
N/A
