### PR TITLE
stale action: Don't close Issues and increase number of operations-per-run

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -25,8 +25,8 @@ jobs:
       - uses: actions/stale@5f858e3efba33a5ca4407a664cc011ad407f2008 # v10.1.0
         with:
           stale-pr-message: 'This pull request is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 7 days.'
-          days-before-stale: 30
-          days-before-close: 7
+          days-before-pr-stale: 30
+          days-before-pr-close: 7
           operations-per-run: 100
 
 permissions:


### PR DESCRIPTION
# Description
<!--
Describe your change. 
What does it introduce?
Why do we need it?
If you are releasing a feature, have you updated documentation?
-->
Let's don't close "stale" Issues for now. We have no process of managing the Github issues. Some of them may be indeed stale and they require manual cleanup. But I think we also need a triage process for the Github issues. Once we have this process, we can re-add this bot. The problem is that we'd like to keep some of the issues open, as they are still actual, and they require action from our side.

# Issue
<!--
Is there any related issue this change is trying to fix?
-->

# Testing
<!--
Have you performed any manual testing on your change?
Have you verified use cases affected by goldens?
-->
