### PR TITLE
Server telemetry reporting

### DIFF
--- a/src/xpk/main.py
+++ b/src/xpk/main.py
@@ -37,7 +37,7 @@ import sys
 
 from .parser.core import set_parser
 from .core.updates import print_xpk_hello
-from .core.telemetry import MetricsCollector
+from .core.telemetry import MetricsCollector, send_clearcut_payload
 from .utils.feature_flags import FeatureFlags
 from .utils.console import xpk_print, exit_code_to_int
 from .utils.execution_context import set_context
@@ -90,8 +90,7 @@ def main() -> None:
     raise
   finally:
     if FeatureFlags.TELEMETRY_ENABLED:
-      # TODO(@scaliby): Flush to server instead of a console
-      xpk_print(MetricsCollector.flush())
+      send_clearcut_payload(MetricsCollector.flush())
 
 
 if __name__ == '__main__':

--- a/src/xpk/telemetry_uploader.py
+++ b/src/xpk/telemetry_uploader.py
@@ -1,0 +1,29 @@
+"""
+Copyright 2025 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import sys
+import os
+import requests
+import json
+
+file_path = sys.argv[1]
+if os.path.exists(file_path):
+  with open(file_path, mode="r", encoding="utf-8") as file:
+    kwargs = json.load(file)
+    response = requests.request(**kwargs)
+    print(f"Telemetry upload finished with {response.status_code} status code")
+
+  os.remove(file_path)

--- a/src/xpk/utils/user_agent.py
+++ b/src/xpk/utils/user_agent.py
@@ -1,0 +1,35 @@
+"""
+Copyright 2025 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import platform
+from ..core.config import __version__ as xpk_version
+
+
+def get_user_agent() -> str:
+  return f'XPK/{xpk_version} ({_get_user_agent_platform()})'
+
+
+def _get_user_agent_platform() -> str:
+  system = platform.system().lower()
+  if system == 'windows':
+    return f'Windows NT {platform.version()}'
+  elif system == 'linux':
+    return f'Linux; {platform.machine()}'
+  elif system == 'darwin':
+    version, _, arch = platform.mac_ver()
+    return f'Macintosh; {arch} Mac OS X {version}'
+  else:
+    return ''

--- a/src/xpk/utils/user_agent_test.py
+++ b/src/xpk/utils/user_agent_test.py
@@ -1,0 +1,44 @@
+"""
+Copyright 2025 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from .user_agent import get_user_agent
+
+
+def test_get_user_agent_returns_correct_value_for_windows(mocker):
+  mocker.patch('xpk.utils.user_agent.xpk_version', 'v1.0.0')
+  mocker.patch('platform.system', return_value='Windows')
+  mocker.patch('platform.version', return_value='10.0')
+  assert get_user_agent() == 'XPK/v1.0.0 (Windows NT 10.0)'
+
+
+def test_get_user_agent_returns_correct_value_for_linux(mocker):
+  mocker.patch('xpk.utils.user_agent.xpk_version', 'v1.0.0')
+  mocker.patch('platform.system', return_value='Linux')
+  mocker.patch('platform.machine', return_value='x86_64')
+  assert get_user_agent() == 'XPK/v1.0.0 (Linux; x86_64)'
+
+
+def test_get_user_agent_returns_correct_value_for_darwin(mocker):
+  mocker.patch('xpk.utils.user_agent.xpk_version', 'v1.0.0')
+  mocker.patch('platform.system', return_value='Darwin')
+  mocker.patch('platform.mac_ver', return_value=('10.15', '', 'x86_64'))
+  assert get_user_agent() == 'XPK/v1.0.0 (Macintosh; x86_64 Mac OS X 10.15)'
+
+
+def test_get_user_agent_returns_correct_value_for_unknown(mocker):
+  mocker.patch('xpk.utils.user_agent.xpk_version', 'v1.0.0')
+  mocker.patch('platform.system', return_value='Unknown')
+  assert get_user_agent() == 'XPK/v1.0.0 ()'


### PR DESCRIPTION
# Description
Sends telemetry data to server using a separate subprocess.


*Dear reviewers,*

*We should reflect on whether the additional complexity introduced by this proposal is justified by the ability to provide the best possible user experience. Specifically, this approach ensures immediate XPK exit upon request, regardless of potential network delays while flushing data.*

*For comparison, alternative approaches would involve:*

- *Sending telemetry data synchronously, which risks blocking the XPK process for seconds or even minutes on slow networks.*

- *Sending telemetry with a strict deadline (e.g., 1 second) and dropping the data if transmission cannot be completed within that window.*

*I look forward to your thoughts on these trade-offs.*

# Issue
b/452257096

# Testing
Unit testing, manual testing.
