### PR TITLE
Add ability to disable telemetry through config

### DIFF
--- a/src/xpk/core/config.py
+++ b/src/xpk/core/config.py
@@ -31,6 +31,7 @@ CFG_BUCKET_KEY = 'cluster-state-gcs-bucket'
 CLUSTER_NAME_KEY = 'cluster-name'
 PROJECT_KEY = 'project-id'
 CLIENT_ID_KEY = 'client-id'
+SEND_TELEMETRY_KEY = 'send-telemetry'
 ZONE_KEY = 'zone'
 KJOB_BATCH_IMAGE = 'batch-image'
 KJOB_BATCH_WORKING_DIRECTORY = 'batch-working-directory'
@@ -47,6 +48,7 @@ DEFAULT_KEYS = [
     CLUSTER_NAME_KEY,
     PROJECT_KEY,
     CLIENT_ID_KEY,
+    SEND_TELEMETRY_KEY,
     ZONE_KEY,
     GKE_ENDPOINT_KEY,
     DEPENDENCIES_KEY,

--- a/src/xpk/core/telemetry.py
+++ b/src/xpk/core/telemetry.py
@@ -27,9 +27,17 @@ import requests
 from enum import Enum
 from typing import Any
 from dataclasses import dataclass
-from .config import xpk_config, CLIENT_ID_KEY, __version__ as xpk_version
+from .config import xpk_config, CLIENT_ID_KEY, SEND_TELEMETRY_KEY, __version__ as xpk_version
 from ..utils.execution_context import is_dry_run
 from ..utils.user_agent import get_user_agent
+from ..utils.feature_flags import FeatureFlags
+
+
+def should_send_telemetry():
+  return (
+      FeatureFlags.TELEMETRY_ENABLED
+      and xpk_config.get(SEND_TELEMETRY_KEY) != "false"
+  )
 
 
 def send_clearcut_payload(data: str, wait_to_complete: bool = False) -> None:

--- a/src/xpk/main.py
+++ b/src/xpk/main.py
@@ -37,8 +37,7 @@ import sys
 
 from .parser.core import set_parser
 from .core.updates import print_xpk_hello
-from .core.telemetry import MetricsCollector, send_clearcut_payload
-from .utils.feature_flags import FeatureFlags
+from .core.telemetry import MetricsCollector, send_clearcut_payload, should_send_telemetry
 from .utils.console import xpk_print, exit_code_to_int
 from .utils.execution_context import set_context
 ################### Compatibility Check ###################
@@ -89,7 +88,7 @@ def main() -> None:
     MetricsCollector.log_complete(-1)
     raise
   finally:
-    if FeatureFlags.TELEMETRY_ENABLED:
+    if should_send_telemetry():
       send_clearcut_payload(MetricsCollector.flush())
 
 


### PR DESCRIPTION
# Description
Added ability to opt-out of telemetry through the command:
```
xpk config set send-telemetry false
```

# Issue
b/452256566

# Testing
Unit testing + tested locally.
