### PR TITLE
Add support for merge queue trigger in build_tests

### DIFF
--- a/.github/workflows/build_tests.yaml
+++ b/.github/workflows/build_tests.yaml
@@ -16,6 +16,8 @@ name: Build Tests
 
 on:
   pull_request:
+  merge_group:
+    types: [checks_requested]
 
 permissions:
   contents: read


### PR DESCRIPTION
# Description
This is necessary before enabling merge queues.
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue

# Issue
b/457631192

# Testing
n/a
