### PR TITLE
reafactor: Move accelerator and machine label creators to system_characteristics

### DIFF
--- a/src/xpk/commands/workload.py
+++ b/src/xpk/commands/workload.py
@@ -577,8 +577,8 @@ def workload_create(args) -> None:
     yml_string = PW_WORKLOAD_CREATE_YAML.format(
         args=args,
         system=system,
-        topology=create_tpu_topology(system.accelerator_type, system),
-        machine_type=create_tpu_machine_type(system.accelerator_type, system),
+        topology=create_tpu_topology(system),
+        machine_type=create_tpu_machine_type(system),
         custom_pathways_proxy_server=append_custom_pathways_proxy_server(args),
         custom_pathways_server=append_custom_pathways_server(args),
         custom_pathways_worker=append_custom_pathways_worker(args),
@@ -603,9 +603,7 @@ def workload_create(args) -> None:
             else system.vms_per_slice
         ),
         affinity=get_cpu_affinity(system.accelerator_type),
-        accelerator_label=create_accelerator_label(
-            system.accelerator_type, system
-        ),
+        accelerator_label=create_accelerator_label(system),
         sub_slicing_annotations=(
             ''
             if not FeatureFlags.SUB_SLICING_ENABLED
@@ -615,7 +613,7 @@ def workload_create(args) -> None:
             )
         ),
         placement_policy_label=placement_policy_label,
-        machine_label=create_machine_label(system.accelerator_type, system),
+        machine_label=create_machine_label(system),
         local_queue_name=LOCAL_QUEUE_NAME,
         autoprovisioning_args=autoprovisioning_args,
         volumes=get_volumes(args, system),

--- a/src/xpk/core/kueue_manager.py
+++ b/src/xpk/core/kueue_manager.py
@@ -319,15 +319,13 @@ class KueueManager:
     main_flavor_name = f"{num_slices}x{device_type_str}"
 
     node_labels_dict = {}
-    accelerator_label = create_accelerator_label(
-        system.accelerator_type, system
-    )
+    accelerator_label = create_accelerator_label(system)
     if accelerator_label:
       key, value = accelerator_label.split(":", 1)
       node_labels_dict[key] = value.strip()
 
     if not autoprovisioning:
-      machine_label = create_machine_label(system.accelerator_type, system)
+      machine_label = create_machine_label(system)
       if machine_label:
         key, value = machine_label.split(":", 1)
         node_labels_dict[key] = value.strip()

--- a/src/xpk/core/scheduling.py
+++ b/src/xpk/core/scheduling.py
@@ -197,10 +197,8 @@ def get_gpu_scheduler(
               """
     gpu_scheduler = gpu_scheduler_yaml.format(
         scheduler_name=args.scheduler,
-        accelerator_label=create_accelerator_label(
-            system.accelerator_type, system
-        ),
-        machine_label=create_machine_label(system.accelerator_type, system),
+        accelerator_label=create_accelerator_label(system),
+        machine_label=create_machine_label(system),
         node_pool_name=f'{args.cluster}-np-0',
         autoprovisioning_args=autoprovisioning_args,
     )
@@ -215,37 +213,14 @@ def get_gpu_scheduler(
   return gpu_scheduler, return_code
 
 
-def create_tpu_machine_type(
-    accelerator_type: AcceleratorType, system: SystemCharacteristics
-) -> str:
-  """Generates TPU machine type..
-
-  Args:
-    accelerator_type: type of accelerator.
-    system: system characteristics.
-
-  Returns:
-    The accelerator label.
-  """
-  if accelerator_type == AcceleratorType.TPU:
+def create_tpu_machine_type(system: SystemCharacteristics) -> str:
+  if system.accelerator_type == AcceleratorType.TPU:
     return f'{system.gce_machine_type}'
   return ''
 
 
-def create_tpu_topology(
-    accelerator_type: AcceleratorType, system: SystemCharacteristics
-) -> str:
-  """Generates TPU topology.
-
-  Args:
-    accelerator_type: type of accelerator.
-    system: system characteristics.
-    autoprovisioning_enabled: describes autoprovisioning enablement.
-
-  Returns:
-    The machine label.
-  """
-  if accelerator_type == AcceleratorType.TPU:
+def create_tpu_topology(system: SystemCharacteristics) -> str:
+  if system.accelerator_type == AcceleratorType.TPU:
     return f'{system.topology}'
   return ''
 

--- a/src/xpk/core/system_characteristics.py
+++ b/src/xpk/core/system_characteristics.py
@@ -810,23 +810,19 @@ def get_system_characteristics_keys_by_accelerator_type(
   ]
 
 
-def create_accelerator_label(
-    accelerator_type: AcceleratorType, system: SystemCharacteristics
-) -> str:
-  if accelerator_type == AcceleratorType.CPU:
+def create_accelerator_label(system: SystemCharacteristics) -> str:
+  if system.accelerator_type == AcceleratorType.CPU:
     return ''
   return (
-      f'{AcceleratorTypeToAcceleratorCharacteristics[accelerator_type].accelerator_label}:'
+      f'{AcceleratorTypeToAcceleratorCharacteristics[system.accelerator_type].accelerator_label}:'
       f' {system.gke_accelerator}'
   )
 
 
-def create_machine_label(
-    accelerator_type: AcceleratorType, system: SystemCharacteristics
-) -> str:
-  if accelerator_type == AcceleratorType.TPU:
+def create_machine_label(system: SystemCharacteristics) -> str:
+  if system.accelerator_type == AcceleratorType.TPU:
     return (
-        f'{AcceleratorTypeToAcceleratorCharacteristics[accelerator_type].machine_label}:'
+        f'{AcceleratorTypeToAcceleratorCharacteristics[system.accelerator_type].machine_label}:'
         f' {system.topology}'
     )
   return ''


### PR DESCRIPTION
# Description
<!--
Describe your change. 
What does it introduce?
Why do we need it?
If you are releasing a feature, have you updated documentation?
-->
- I need to move these creator functions outside of `scheduling`, because in my next PR `scheduling.py` will depend on `kueue_manager.py`.
- Added missing argument types in the other `scheduling.py` functions.
- Removed redundant PyDocs, that were not providing any value.
- Removed `autoprovisioning_enabled` boolean arguments that were used only in one place (kueue_manager).
- Removed redundant `accelerator_type`, because `system` was already provided.

# Issue
<!--
Is there any related issue this change is trying to fix?
-->

# Testing
<!--
Have you performed any manual testing on your change?
Have you verified use cases affected by goldens?
-->
