### PR TITLE
Check github labels for breaking changes

### DIFF
--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -17,9 +17,11 @@
 
 changelog:
   categories:
+  - title: Breaking Changes
+    labels: [release-breaking]
   - title: New Features
     labels: [release-features]
-  - title: Improvments
-    labels: [release-improvments]
+  - title: Improvements
+    labels: [release-improvements]
   - title: Bug fixes
     labels: [release-bugfix]

--- a/.github/workflows/periodic_release.yaml
+++ b/.github/workflows/periodic_release.yaml
@@ -24,18 +24,37 @@ permissions:
   actions: write
 
 jobs:
-  create-release-branch:
-    environment:
-      name: release
+  validate-ref:
     runs-on: ubuntu-latest
+    steps:
+      - name: Check ref
+        run: |
+          if [[ "${{ github.ref_type }}" != "branch" ]]; then
+            echo "::error::This workflow must be run on a Branch, not a Tag."
+            exit 1
+          fi
+
+          if [[ "${{ github.ref_name }}" != "main" ]]; then
+            echo "::error::This workflow must be run on a main branch."
+            exit 1
+          fi
+
+  compute-release-branch:
+    needs: [validate-ref]
+    runs-on: ubuntu-latest
+    outputs:
+      skip_push: ${{ steps.compute_branch_name.outputs.skip_push }}
+      new_branch_name: ${{ steps.compute_branch_name.outputs.new_branch_name }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           fetch-tags: true
-      - name: Compute Next Version and Push Branch
+      - name: Compute Next Version
         id: compute_branch_name
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           LATEST_BRANCH=$(git branch -r | grep -oE 'origin/release-[0-9]+\.[0-9]+' | sort -V | tail -n 1)
 
@@ -53,7 +72,7 @@ jobs:
           if [ "$COMMIT_COUNT" -eq 0 ]; then
             echo "No new changes detected compared to $LATEST_BRANCH."
             echo "Skipping release branch creation."
-            echo "skipped=true" >> $GITHUB_OUTPUT
+            echo "skip_push=true" >> $GITHUB_OUTPUT
             exit 0
           fi
 
@@ -61,9 +80,18 @@ jobs:
           CURRENT_MAJOR=$(echo "$VERSION_STR" | cut -d. -f1)
           CURRENT_MINOR=$(echo "$VERSION_STR" | cut -d. -f2)
 
-          echo "Scanning commits between $LATEST_BRANCH and HEAD for 'BREAKING' keyword..."
+          echo "Retrieving pull request labels between $LATEST_BRANCH and HEAD..."
+          LABELS=$(git log $LATEST_BRANCH..HEAD --pretty=format:"%s" \
+            | grep -oE "#[0-9]+" \
+            | tr -d "#" \
+            | xargs -I {} gh pr view {} --json labels --jq '.labels[].name' \
+            | sort \
+            | uniq)
 
-          if git log "$LATEST_BRANCH"..HEAD --pretty=format:"%s" | grep -q "BREAKING"; then
+          echo "Pull request labels:"
+          echo "$LABELS"
+
+          if echo "$LABELS" | grep -q "release-breaking"; then
             NEW_MAJOR=$((CURRENT_MAJOR + 1))
             NEW_MINOR=0
             echo "BREAKING detected. Bumping Major version."
@@ -76,14 +104,30 @@ jobs:
           NEW_BRANCH_NAME="release-$NEW_MAJOR.$NEW_MINOR"
           echo "New release branch calculated: $NEW_BRANCH_NAME"
           echo "new_branch_name=$NEW_BRANCH_NAME" >> $GITHUB_OUTPUT
-          echo "skipped=false" >> $GITHUB_OUTPUT
+          echo "skip_push=false" >> $GITHUB_OUTPUT
 
+  create-release-branch:
+    needs: [compute-release-branch]
+    environment:
+      name: release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        if: needs.compute-release-branch.outputs.skip_push != 'true'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+      - name: Push the branch
+        if: needs.compute-release-branch.outputs.skip_push != 'true'
+        run: |
+          NEW_BRANCH_NAME="${{needs.compute-release-branch.outputs.new_branch_name}}"
           git checkout -b "$NEW_BRANCH_NAME"
           git push origin "$NEW_BRANCH_NAME"
 
           echo "Successfully pushed $NEW_BRANCH_NAME"
       - name: Run release branch versioning
-        if: steps.compute_branch_name.outputs.skipped != 'true'
+        if: needs.compute-release-branch.outputs.skip_push != 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh workflow run release_branch_versioning.yaml --ref ${{ steps.compute_branch_name.outputs.new_branch_name }}
+        run: gh workflow run release_branch_versioning.yaml --ref ${{needs.compute-release-branch.outputs.new_branch_name}}


### PR DESCRIPTION
# Description
- Check github pull request labels for breaking changes.
- Moved approval step later, so first we print computed version and then we block for approval (this should allow to catch errors with branch name computation)
- Added validation for manual triggers - we allow launch on main branch only.

# Issue
b/465710241

# Testing
Tested on my fork: https://github.com/scaliby/xpk/actions/runs/19935478920

Breaking changes run: https://github.com/scaliby/xpk/actions/runs/19959468416
