### PR TITLE
Fix XPK freezing

### DIFF
--- a/src/xpk/core/updates.py
+++ b/src/xpk/core/updates.py
@@ -28,7 +28,7 @@ def get_latest_xpk_version() -> tuple[int, Version | None]:
     return 0, Version(__version__)
 
   return_code, result = run_command_for_value(
-      command="pip index versions xpk --json",
+      command="pip index versions xpk --json --no-input",
       task="Retrieve latest XPK version",
       quiet=True,
   )
@@ -46,3 +46,12 @@ def get_latest_xpk_version() -> tuple[int, Version | None]:
 def print_xpk_hello() -> None:
   current_version = Version(__version__)
   xpk_print(f"Starting xpk v{current_version}", flush=True)
+  return_code, latest_version = get_latest_xpk_version()
+  if return_code != 0 or latest_version is None:
+    return
+  if current_version < latest_version:
+    xpk_print(
+        f"XPK version v{current_version} is outdated. Please consider upgrading"
+        f" to v{latest_version}",
+        flush=True,
+    )

--- a/src/xpk/core/updates_test.py
+++ b/src/xpk/core/updates_test.py
@@ -68,3 +68,13 @@ def test_print_xpk_hello_does_not_print_update_when_xpk_is_up_to_date(
   get_latest_xpk_version.return_value = (0, Version(__version__))
   print_xpk_hello()
   xpk_print.assert_called_once()
+
+
+@patch('xpk.core.updates.xpk_print')
+@patch('xpk.core.updates.get_latest_xpk_version')
+def test_print_xpk_hello_prints_update_when_xpk_is_outdated(
+    get_latest_xpk_version: MagicMock, xpk_print: MagicMock
+):
+  get_latest_xpk_version.return_value = (0, Version('99.99.99'))
+  print_xpk_hello()
+  assert xpk_print.call_count == 2


### PR DESCRIPTION
# Description
Reported via chat, some users just see version printed out, then XPK hangs.
It will continue after pressing ENTER, but not everybody notices this.
Fixed by adding `--no-input`.

# Issue
b/466129455

# Testing
Manual testing.
