### PR TITLE
Silent credentials check

### DIFF
--- a/src/xpk/core/cluster.py
+++ b/src/xpk/core/cluster.py
@@ -751,6 +751,6 @@ def _get_credentials(
 def _are_credentials_valid() -> bool:
   kubectl_command = 'kubectl get pods'
   kubectl_return_code = run_command_with_updates(
-      kubectl_command, 'Test kubectl credentials'
+      kubectl_command, 'Test kubectl credentials', verbose=False
   )
   return kubectl_return_code == 0


### PR DESCRIPTION
# Description
Make kubectl credentials check silent, so workload list does not show unecessary workloads.

# Issue
b/472240401

# Testing
Tested manually in my terminal.