### PR TITLE
Add a shared memory mount for rdma_decorator

### DIFF
--- a/src/xpk/commands/common.py
+++ b/src/xpk/commands/common.py
@@ -87,7 +87,7 @@ def is_GPU_TAS_possible(
       f' --location={zone}'
       f' --project={project}'
       ' --filter="placementPolicy.type=COMPACT"'
-      ' --format="value(name)'
+      ' --format="value(name)"'
   )
   return_code, compact_placement_nps = run_command_for_value(
       command=command,

--- a/src/xpk/core/workload_decorators/rdma_decorator.py
+++ b/src/xpk/core/workload_decorators/rdma_decorator.py
@@ -84,6 +84,12 @@ def add_volumes(job_manifest):
   volumes.append(
       {'name': 'gib', 'hostPath': {'path': '/home/kubernetes/bin/gib'}}
   )
+  volumes.append({
+      'name': 'dshm',
+      'emptyDir': {
+          'medium': 'Memory',
+      },
+  })
 
 
 def add_tolerations(job_manifest):
@@ -110,4 +116,7 @@ def update_gpu_containers(job_manifest):
       )
       container['volumeMounts'].append(
           {'name': 'gib', 'mountPath': '/usr/local/gib'}
+      )
+      container['volumeMounts'].append(
+          {'name': 'dshm', 'mountPath': '/dev/shm'}
       )


### PR DESCRIPTION
# Description
<!--
Describe your change. 
What does it introduce?
Why do we need it?
If you are releasing a feature, have you updated documentation?
-->
We are currently using XPK to benchmark our GPU cluster. During a TorchTitan run, we identified a missing volume requied by NCCL communication through shared memory (SHM) so submitted a PR to resolve the issue.

Changes:
1. Add "dshm" volume to "rdma_decorator"
2. Add back a missing end quote

# Issue
<!--
Is there any related issue this change is trying to fix?
-->
During a TorchTitan run, the 'No space left on device' error occured because of a missing shared memory mount
```
Root Cause (first observed failure):
[0]:
  time      : 2026-01-13_09:20:58
  host      : chengken-ubench-93mf-slice-job-0-0.chengken-ubench-93mf.default.svc.cluster.local
  rank      : 0 (local_rank: 0)
  exitcode  : 1 (pid: 1016)
  error_file: /tmp/torchelastic_ey36uo59/chengken-ubench-93mf_i188asz_/attempt_0/0/error.json
  traceback : Traceback (most recent call last):
    File "/opt/conda/lib/python3.11/site-packages/torch/distributed/elastic/multiprocessing/errors/__init__.py", line 362, in wrapper
      return f(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^
    File "/app/torchtitan/torchtitan/train.py", line 112, in __init__
      dist_utils.set_determinism(
    File "/app/torchtitan/torchtitan/distributed/utils.py", line 140, in set_determinism
      torch.distributed.broadcast(seed_tensor, src=0)
    File "/opt/conda/lib/python3.11/site-packages/torch/distributed/c10d_logger.py", line 83, in wrapper
      return func(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^
    File "/opt/conda/lib/python3.11/site-packages/torch/distributed/distributed_c10d.py", line 2904, in broadcast
      work = group.broadcast([tensor], opts)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  torch.distributed.DistBackendError: NCCL error in: /pytorch/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp:3754, unhandled system error (run with NCCL_DEBUG=INFO for details), NCCL version 2.27.5
  ncclSystemError: System call (e.g. socket, malloc) or external library call failed or device error. 
  Last error:
  Error while creating shared memory segment /dev/shm/nccl-eZHGHz (size 33030528), error: No space left on device (28)
```

# Testing
<!--
Have you performed any manual testing on your change?
Have you verified use cases affected by goldens?
-->
Tested on GKE A3 Mega and A3 Ultra clusters