### PR TITLE
[slice] Slice name restriction

### DIFF
--- a/slice/internal/core/slice.go
+++ b/slice/internal/core/slice.go
@@ -29,7 +29,7 @@ import (
 )
 
 const (
-	maxSliceNameLength = 63
+	maxSliceNameLength = 54
 )
 
 func SliceKeyFromWorkload(wl *kueue.Workload, podSetName kueue.PodSetReference, sliceIndex int32) client.ObjectKey {

--- a/slice/internal/core/slice_test.go
+++ b/slice/internal/core/slice_test.go
@@ -37,12 +37,12 @@ func TestSliceName(t *testing.T) {
 			sliceIndex:   0,
 			want:         "default-wl-main-0",
 		},
-		"exact limit (63 chars)": {
+		"exact limit (54 chars)": {
 			ns:           "ns",
-			workloadName: "1234567890123456789012345678901234567890123456789012345",
+			workloadName: "1234567890123456789012345678901234567890123456",
 			podSetName:   "ps",
 			sliceIndex:   0,
-			want:         "ns-1234567890123456789012345678901234567890123456789012345-ps-0",
+			want:         "ns-1234567890123456789012345678901234567890123456-ps-0",
 		},
 		"long name": {
 			ns:           "very-long-namespace-name",


### PR DESCRIPTION
# Description
<!--
Describe your change. 
What does it introduce?
Why do we need it?
If you are releasing a feature, have you updated documentation?
-->
The slice name can have at most 54 characters, so we would produce too long names. This PR fixes the issue and reduces the hash to 5 characters.

# Issue
<!--
Is there any related issue this change is trying to fix?
-->

# Testing
<!--
Have you performed any manual testing on your change?
Have you verified use cases affected by goldens?
-->
