### PR TITLE
SUPER_SLICING_ENABLED=True by default

### DIFF
--- a/src/xpk/utils/feature_flags.py
+++ b/src/xpk/utils/feature_flags.py
@@ -34,7 +34,7 @@ class _FeatureFlags:
   SUB_SLICING_ENABLED = _get_boolean_flag("SUB_SLICING_ENABLED", default=False)
   TELEMETRY_ENABLED = _get_boolean_flag("TELEMETRY_ENABLED", default=True)
   SUPER_SLICING_ENABLED = _get_boolean_flag(
-      "SUPER_SLICING_ENABLED", default=False
+      "SUPER_SLICING_ENABLED", default=True
   )
 
 


### PR DESCRIPTION
# Description
<!--
Describe your change. 
What does it introduce?
Why do we need it?
If you are releasing a feature, have you updated documentation?
-->
`SUPER_SLICING_ENABLED=True` by default.
We want it to by enabled by default in the Monday release.

I'll update the adequate docs next week.

# Issue
<!--
Is there any related issue this change is trying to fix?
-->

# Testing
<!--
Have you performed any manual testing on your change?
Have you verified use cases affected by goldens?
-->
Tested manually
