### PR TITLE
[slice] Enable cert manager readiness check

### DIFF
--- a/slice/internal/util/cert/cert.go
+++ b/slice/internal/util/cert/cert.go
@@ -44,13 +44,14 @@ var dnsName = fmt.Sprintf("%s.%s.svc", serviceName, secretNamespace)
 // CertsManager creates certs for webhooks.
 func CertsManager(mgr ctrl.Manager, setupFinish chan struct{}) error {
 	return cert.AddRotator(mgr, &cert.CertRotator{
-		SecretKey:      types.NamespacedName{Namespace: secretNamespace, Name: secretName},
-		CertDir:        certDir,
-		CAName:         caName,
-		CAOrganization: caOrg,
-		DNSName:        dnsName,
-		IsReady:        setupFinish,
-		Webhooks:       []cert.WebhookInfo{{Type: cert.Mutating, Name: mutatingWebhookConfName}},
+		SecretKey:            types.NamespacedName{Namespace: secretNamespace, Name: secretName},
+		CertDir:              certDir,
+		CAName:               caName,
+		CAOrganization:       caOrg,
+		DNSName:              dnsName,
+		IsReady:              setupFinish,
+		Webhooks:             []cert.WebhookInfo{{Type: cert.Mutating, Name: mutatingWebhookConfName}},
+		EnableReadinessCheck: true,
 	})
 }
 


### PR DESCRIPTION
# Description
Enable certs manager readiness check to avoid such logs during startup:

```
2026-01-13T08:36:29Z    ERROR   cert-rotation   could not refresh CA and server certs   {"error": "Operation cannot be fulfilled on secrets \"slice-controller-webhook-server-cert\": the object has been modified; please apply your changes to the latest version and try again"}
github.com/open-policy-agent/cert-controller/pkg/rotator.(*CertRotator).refreshCertIfNeeded.func1
        /go/pkg/mod/github.com/open-policy-agent/cert-controller@v0.14.0/pkg/rotator/rotator.go:336
k8s.io/apimachinery/pkg/util/wait.runConditionWithCrashProtection
        /go/pkg/mod/k8s.io/apimachinery@v0.34.1/pkg/util/wait/wait.go:150
k8s.io/apimachinery/pkg/util/wait.ExponentialBackoff
        /go/pkg/mod/k8s.io/apimachinery@v0.34.1/pkg/util/wait/backoff.go:477
github.com/open-policy-agent/cert-controller/pkg/rotator.(*CertRotator).refreshCertIfNeeded
        /go/pkg/mod/github.com/open-policy-agent/cert-controller@v0.14.0/pkg/rotator/rotator.go:364
github.com/open-policy-agent/cert-controller/pkg/rotator.(*CertRotator).Start
        /go/pkg/mod/github.com/open-policy-agent/cert-controller@v0.14.0/pkg/rotator/rotator.go:292
sigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).reconcile.func1
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.3/pkg/manager/runnable_group.go:260
```

# Issue
<!--
---
