### PR TITLE
Github: remove "-nodepools" suffix from e2e cluster names

### DIFF
--- a/.github/workflows/integration_basic_cluster_create.yaml
+++ b/.github/workflows/integration_basic_cluster_create.yaml
@@ -31,7 +31,7 @@ jobs:
           group: nightly-test-cluster-group-empty
           cancel-in-progress: false
       env:
-          EMPTY_CLUSTER_NAME: nightly-xpk-zero-nodepools
+          EMPTY_CLUSTER_NAME: nightly-xpk-zero
       steps:
           - uses: actions/download-artifact@v4
             with:
@@ -59,7 +59,7 @@ jobs:
           group: nightly-test-cluster-group-private
           cancel-in-progress: false
       env:
-          PRIVATE_CLUSTER_NAME: nightly-xpk-private-2-v4-8-nodepools
+          PRIVATE_CLUSTER_NAME: nightly-xpk-private-2-v4-8
       steps:
           - uses: actions/download-artifact@v4
             with:
@@ -90,7 +90,7 @@ jobs:
             group: nightly-test-cluster-group-tpu
             cancel-in-progress: false
         env:
-            TPU_CLUSTER_NAME: nightly-xpk-2-v5p-8-nodepools
+            TPU_CLUSTER_NAME: nightly-xpk-2-v5p-8
             WORKLOAD_NAME: xpktest-nightly-${{ github.run_attempt }}
         steps:
             - uses: actions/download-artifact@v4


### PR DESCRIPTION
# Description
<!--
Describe your change. 
What does it introduce?
Why do we need it?
If you are releasing a feature, have you updated documentation?
-->
The suffix is unnecessary and even causing problems for the private cluster e2e:
- generated np example: `nightly-xpk-private-2-v4-8-nodepools-np-0`
- error: `ERROR: (gcloud.beta.container.node-pools.create) ResponseError: code=400, message=Node_pool.name must be less than 40 characters.`.

# Issue
<!--
Is there any related issue this change is trying to fix?
-->

# Testing
<!--
Have you performed any manual testing on your change?
Have you verified use cases affected by goldens?
-->
