### PR TITLE
Fix kueuectl calls in xpk info

### DIFF
--- a/src/xpk/commands/info.py
+++ b/src/xpk/commands/info.py
@@ -219,7 +219,9 @@ def run_kueuectl_list_localqueue(args: Namespace) -> str:
   command = 'kubectl kueue list localqueue -o json'
   if args.namespace != '':
     command += f' --namespace {args.namespace}'
-  return_code, val = run_command_for_value(command, 'list localqueue')
+  return_code, val = run_command_for_value(
+      command, 'list localqueue', hide_error=True
+  )
 
   if return_code != 0:
     xpk_print(f'Cluster info request returned ERROR {return_code}')
@@ -235,7 +237,9 @@ def run_kueuectl_list_clusterqueue() -> str:
   """
   command = 'kubectl kueue list clusterqueue -o json'
 
-  return_code, val = run_command_for_value(command, 'list clusterqueue')
+  return_code, val = run_command_for_value(
+      command, 'list clusterqueue', hide_error=True
+  )
 
   if return_code != 0:
     xpk_print(f'Cluster info request returned ERROR {return_code}')


### PR DESCRIPTION
# Description
<!--
Describe your change. 
What does it introduce?
Why do we need it?
If you are releasing a feature, have you updated documentation?
-->
Since Kueue v0.15.0 `xpk info` got broken. The `kueuectl` response cannot be parsed, because `kueuectl` always prints `I0120 14:08:30.645240 4078291 warnings.go:110] "Warning: This version is deprecated. Use v1beta2 instead."` warning in stderr. Interestingly, upgrading all CRs to `v1beta2` doesn't remove this warning. I believe kueuectl just does two calls now (for both versions) and one call simply prints the deprecation warning.

`hide_error=True` should still display the error when the command fails.

# Issue
<!--
Is there any related issue this change is trying to fix?
-->

# Testing
<!--
Have you performed any manual testing on your change?
Have you verified use cases affected by goldens?
-->
Tested manually.