### PR TITLE
[slice] Trim AC message

### DIFF
--- a/slice/internal/controller/workload_controller.go
+++ b/slice/internal/controller/workload_controller.go
@@ -731,6 +731,7 @@ func (r *WorkloadReconciler) prepareAdmissionCheckStatus(ac *kueue.AdmissionChec
 		}
 		ac.Message += ". Errors: " + strings.Join(errMessages, "; ")
 	}
+	ac.Message = api.TruncateConditionMessage(ac.Message)
 }
 
 // SetupWithManager sets up the controller with the Manager.


### PR DESCRIPTION
# Description
<!--
Describe your change. 
What does it introduce?
Why do we need it?
If you are releasing a feature, have you updated documentation?
-->
I think we should trim the ac message since currently we directly append error message from slices. We may have multiple slice failures with long messages so this may exceed the 32kB limit.

# Issue
<!--
Is there any related issue this change is trying to fix?
-->

# Testing
<!--
Have you performed any manual testing on your change?
Have you verified use cases affected by goldens?
-->
