### PR TITLE
[slice] Remove DEGRADED from default NodeAffinity

### DIFF
--- a/slice/internal/webhooks/jobset_webhook.go
+++ b/slice/internal/webhooks/jobset_webhook.go
@@ -116,7 +116,7 @@ func annotateReplicatedJobWithSliceHealth(rj *v1alpha2.ReplicatedJob) {
 	}
 
 	// 3. If neither of these, we add a NodeAffinity.
-	core.AddNodeAffinity(rj, core.TPUSliceHealthNodeSelectorKey, []string{core.TPUSliceHealthNodeSelectorHealthy, core.TPUSliceHealthNodeSelectorDegraded})
+	core.AddNodeAffinity(rj, core.TPUSliceHealthNodeSelectorKey, []string{core.TPUSliceHealthNodeSelectorHealthy})
 }
 
 func (r *JobSetWebhook) podSetSliceSize(tpuTopology string, parallelism int32) (string, error) {

--- a/slice/internal/webhooks/jobset_webhook_test.go
+++ b/slice/internal/webhooks/jobset_webhook_test.go
@@ -137,7 +137,7 @@ func TestDefault(t *testing.T) {
 					NodeSelector: map[string]string{
 						"cloud.google.com/gke-tpu-accelerator": string(slice.TypeTpu7x),
 					},
-				}).NodeAffinity("rj1", core.TPUSliceHealthNodeSelectorKey, []string{core.TPUSliceHealthNodeSelectorHealthy, core.TPUSliceHealthNodeSelectorDegraded}).
+				}).NodeAffinity("rj1", core.TPUSliceHealthNodeSelectorKey, []string{core.TPUSliceHealthNodeSelectorHealthy}).
 				Obj(),
 		},
 		"shouldn't set default values because invalid topology annotation": {

--- a/slice/test/e2e/jobset_test.go
+++ b/slice/test/e2e/jobset_test.go
@@ -194,7 +194,7 @@ var _ = ginkgo.Describe("JobSet", func() {
 									if matchExpression.Key == core.TPUSliceHealthNodeSelectorKey {
 										found = true
 										g.Expect(matchExpression.Operator).Should(gomega.Equal(corev1.NodeSelectorOpIn))
-										g.Expect(matchExpression.Values).Should(gomega.ConsistOf(core.TPUSliceHealthNodeSelectorHealthy, core.TPUSliceHealthNodeSelectorDegraded))
+										g.Expect(matchExpression.Values).Should(gomega.ConsistOf(core.TPUSliceHealthNodeSelectorHealthy))
 									}
 								}
 							}


### PR DESCRIPTION
# Description
<!--
Describe your change. 
What does it introduce?
Why do we need it?
If you are releasing a feature, have you updated documentation?
-->
We want to have only HEALTHY cubes in the default behavior. The users might opt-in to use the DEGRADED.

# Issue
<!--
Is there any related issue this change is trying to fix?
-->

# Testing
<!--
Have you performed any manual testing on your change?
Have you verified use cases affected by goldens?
-->
