### PR TITLE
[slice] Manual delete

### DIFF
--- a/slice/internal/controller/workload_controller.go
+++ b/slice/internal/controller/workload_controller.go
@@ -454,9 +454,12 @@ func (r *WorkloadReconciler) updateJobSetBeforeUnsuspend(ctx context.Context, wl
 		return err
 	}
 	patchJobSet := core.BaseSSAJobSet(jobSet)
-
 	for i := range jobSet.Spec.ReplicatedJobs {
 		rj := &jobSet.Spec.ReplicatedJobs[i]
+		if rj.Template.Spec.Template.Spec.NodeSelector[core.TPUTopologyAnnotation] != "" {
+			// the NodeSelector with topology annotation has already been copied, nothing to do
+			return nil
+		}
 		replicaJob := core.BaseSSAReplicatedJob(rj.Name)
 		if topology := rj.Template.Spec.Template.Annotations[core.TPUSliceTopologyAnnotation]; topology != "" {
 			log.V(5).Info("Copying topology annotation as nodeSelector", "topology", topology, "replicatedJobName", rj.Name)


### PR DESCRIPTION
# Description
<!--
Describe your change. 
What does it introduce?
Why do we need it?
If you are releasing a feature, have you updated documentation?
-->
When a slice is manually deleted while the workload is running, we recreate the slice, but we also try to update the jobset spec which is immutable at that point.

# Issue
<!--
Is there any related issue this change is trying to fix?
-->

# Testing
<!--
Have you performed any manual testing on your change?
Have you verified use cases affected by goldens?
-->
