### PR TITLE
make verify: remove installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ install-pylint:
 	pip install pylint
 
 .PHONY: verify
-verify: install-lint pylint pyink mypy
+verify: pylint pyink mypy
 
 .PHONY: pylint
 pylint:


### PR DESCRIPTION
# Description
<!--
Describe your change. 
What does it introduce?
Why do we need it?
If you are releasing a feature, have you updated documentation?
-->
Remove `install-lint`, as it shouldn't be a part of `make verify`.

Currently `make verify` is not used anywhere, so I don't expect any breakages. However, my plan is to use inside GEMINI.md, like: 
```
- When implementation is finished:
  - run `make verify` to run linter checks -- fix the findings in the changed files,
  - ...
```

# Issue
<!--
Is there any related issue this change is trying to fix?
-->

# Testing
<!--
Have you performed any manual testing on your change?
Have you verified use cases affected by goldens?
-->
