### PR TITLE
respect .dockerignore exclusions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 # editor and IDE paraphernalia
 .idea/
+.vscode
 
 *__pycache__*
 tmp/
@@ -139,4 +140,13 @@ dmypy.json
 **/.DS_Store
 
 # XPK/Cluster Toolkit working directory
-xpkclusters/*
+xpkclusters
+
+# XPK documentation
+docs
+examples
+recipes
+
+# git
+.git
+.github

--- a/recipes/Workload_create_Crane.md
+++ b/recipes/Workload_create_Crane.md
@@ -28,7 +28,7 @@ kubectl get configmap golden-cluster-resources-configmap -o=custom-columns="Conf
 
 [XPK] Adding /tmp to container image archive e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 [XPK] Task: `Upload Container Image` is implemented by the following command not running since it is a dry run. 
-crane mutate python:3.10 --append e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 --platform linux/amd64   --tag gcr.io/golden-project/dry-run-runner:prefix-current --workdir /app
+crane mutate python:3.10 --append e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 --platform linux/amd64 --tag gcr.io/golden-project/dry-run-runner:prefix-current --workdir /app
 [XPK] Deleting container image archive e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 [XPK] Temp file (39eda1549f4c0d68a4f11e6cbd89ba655d49d2faeef6898a140f476e6e70ae0e) content: 
 apiVersion: jobset.x-k8s.io/v1alpha2


### PR DESCRIPTION
# Description
Respect .dockerignore ignore patterns while building the container archive.
Filtering done via `exclude_paths` from [docker-py build utils](https://github.com/docker/docker-py/blob/main/docker/utils/build.py).
It's not feasible to use `tar` function directly because it doesn't support setting custom WORKDIR (arcname relative path).

Differences between .gitignore and .dockerignore [here](https://dockerignore.com/dockerignore-vs-gitignore).

Also, adding git and vscode patterns to XPK's .dockerignore.

# Issue
b/481653975

# Testing
Manual testing.
Before change: http://screen/6jefyNtPBA5Qh63
After: http://screen/5SMMoyBJDoXi9CH
