### PR TITLE
Fix lint error

### DIFF
--- a/src/xpk/commands/cluster_gcluster.py
+++ b/src/xpk/commands/cluster_gcluster.py
@@ -328,7 +328,7 @@ def generate_blueprint(
       placement_policy = (
           {
               'type': 'COMPACT',
-              'name': placement_policy_name.split('/')[-1],
+              'name': placement_policy_name.rsplit('/', maxsplit=1)[-1],
           }
           if placement_policy_name is not None
           and len(placement_policy_name) > 0


### PR DESCRIPTION
# Description
<!--
Describe your change. 
What does it introduce?
Why do we need it?
If you are releasing a feature, have you updated documentation?
-->
Error: `src/xpk/commands/cluster_gcluster.py:336:22: C0207: Use placement_policy_name.rsplit('/', maxsplit=1)[-1] instead (use-maxsplit-arg)`

# Issue
<!--
Is there any related issue this change is trying to fix?
-->

# Testing
<!--
Have you performed any manual testing on your change?
Have you verified use cases affected by goldens?
-->
