### PR TITLE
refactor: move project_id -> project_number translation to gcloud_context

### DIFF
--- a/src/xpk/core/gcloud_context.py
+++ b/src/xpk/core/gcloud_context.py
@@ -17,11 +17,15 @@ limitations under the License.
 import subprocess
 import sys
 from dataclasses import dataclass
+from functools import lru_cache
+
+from google.api_core.exceptions import PermissionDenied
+from google.cloud import resourcemanager_v3
 
 from ..utils.console import xpk_print, xpk_exit
 from ..utils.versions import ReleaseChannel
+from ..utils.execution_context import is_dry_run
 from .commands import run_command_for_value
-from functools import lru_cache
 
 
 def get_project():
@@ -224,3 +228,41 @@ def get_gke_control_plane_version(
     return 1, None
 
   return 0, master_gke_version
+
+
+@lru_cache()
+def project_id_to_project_number(project_id: str) -> str:
+  if is_dry_run():
+    # 12 digit hash
+    return str(abs(hash(project_id) % (10**12)))
+
+  client = resourcemanager_v3.ProjectsClient()
+  request = resourcemanager_v3.GetProjectRequest()
+  request.name = f'projects/{project_id}'
+  try:
+    response = client.get_project(request=request)
+  except PermissionDenied as e:
+    xpk_print(
+        f"Couldn't translate project id: {project_id} to project number."
+        f' Error: {e}'
+    )
+    xpk_exit(1)
+  parts = response.name.split('/', 1)
+  xpk_print(f'Project number for project: {project_id} is {parts[1]}')
+  return str(parts[1])
+
+
+def get_project_number(args) -> str:
+  """Get project number from args or fetch it.
+
+  Args:
+    args: user provided arguments.
+
+  Returns:
+    Project number as string.
+  """
+  if getattr(args, 'project_number', None):
+    xpk_print(f'Using provided project number: {args.project_number}')
+    return str(args.project_number)
+  else:
+    return project_id_to_project_number(args.project)


### PR DESCRIPTION
# Description
<!--
Describe your change. 
What does it introduce?
Why do we need it?
If you are releasing a feature, have you updated documentation?
-->
Basically no-op. I'll need the `project_id_to_project_number` in reservations/capacity in future PRs.

# Issue
<!--
Is there any related issue this change is trying to fix?
-->

# Testing
<!--
Have you performed any manual testing on your change?
Have you verified use cases affected by goldens?
-->
ut, goldens