### PR TITLE
[slice] Fix e2e

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -21,6 +21,18 @@ jobs:
       - name: Verify kind installation
         run: kind version
 
+      - name: Disable containerd image store
+        run: |
+          sudo bash -c 'cat > /etc/docker/daemon.json << EOF
+          {
+            "features": {
+              "containerd-snapshotter": false
+            }
+          }
+          EOF'
+          sudo systemctl restart docker
+          docker info -f '{{ .DriverStatus }}'
+
       - name: Running Test e2e
         run: |
           cd ./slice


### PR DESCRIPTION
# Description
<!--
Describe your change. 
What does it introduce?
Why do we need it?
If you are releasing a feature, have you updated documentation?
-->

It looks like github workflows got updated and now contains a containerd bug (see eg https://github.com/kudobuilder/kuttl/pull/674). Following a similar solution as https://github.com/openperouter/openperouter/pull/236 to fix the error:

```
ERROR: failed to load image: command "docker exec --privileged -i kind-worker ctr --namespace=k8s.io images import --all-platforms --digests --snapshotter=overlayfs -" failed with error: exit status 1

Command Output: ctr: rpc error: code = NotFound desc = content digest sha256:42d55a9fad422334b4815f083faf916f8a85cadfad8febced3db00d8fd3487bc: not found
```

# Issue
<!--
Is there any related issue this change is trying to fix?
-->

# Testing
<!--
Have you performed any manual testing on your change?
Have you verified use cases affected by goldens?
-->
