### PR TITLE
`make verify-goldens`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ goldens:
 
 .PHONY: verify-goldens
 verify-goldens:
-	XPK_TESTER=false XPK_VERSION_OVERRIDE=v0.0.0 python3 tools/recipes.py golden recipes/*.md
+	XPK_TESTER=false XPK_VERSION_OVERRIDE=v0.0.0 UPDATE_GOLDEN_COMMAND="make goldens" python3 tools/recipes.py golden recipes/*.md
 
 .PHONY: mkdir-bin
 mkdir-bin:

--- a/tools/recipes.py
+++ b/tools/recipes.py
@@ -30,6 +30,7 @@ Usage:
 
 import concurrent.futures
 import difflib
+import os
 import re
 import subprocess
 import sys
@@ -246,10 +247,13 @@ def main():
 
   if not all_passed:
     if mode == Mode.GOLDEN:
-      print(
-          f"{Color.RED}Goldens do not match. If the changes are expected, run"
-          f" 'make goldens' to update them.{Color.NC}"
-      )
+      print(f"{Color.RED}Goldens do not match.{Color.NC}")
+      update_command = os.environ.get("UPDATE_GOLDEN_COMMAND")
+      if update_command:
+        print(
+            f"{Color.RED}If the changes are expected, run '{update_command}' to"
+            f" update them.{Color.NC}"
+        )
     sys.exit(1)
 
 


### PR DESCRIPTION
# Description
<!--
Describe your change. 
What does it introduce?
Why do we need it?
If you are releasing a feature, have you updated documentation?
-->

Add `make verify-goldens` action.
I find it useful for gemini-cli, because standard `make goldens` always exits with 0.

# Issue
<!--
Is there any related issue this change is trying to fix?
-->

# Testing
<!--
Have you performed any manual testing on your change?
Have you verified use cases affected by goldens?
-->
verified manually