### PR TITLE
Add crane workload integration test

### DIFF
--- a/.github/actions/install-crane/action.yml
+++ b/.github/actions/install-crane/action.yml
@@ -1,0 +1,34 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+name: "Install Crane"
+description: "Installs Crane"
+
+inputs:
+  version:
+    description: "The version to install"
+    required: false
+    default: "0.20.7"
+
+runs:
+  using: composite
+  steps:
+    - name: Install crane
+      shell: bash
+      run: |
+        curl -Lo ./go-containerregistry.tar.gz https://github.com/google/go-containerregistry/releases/download/v${{inputs.version}}/go-containerregistry_Linux_x86_64.tar.gz
+        tar -zxvf go-containerregistry.tar.gz -C ./ crane        
+        rm ./go-containerregistry.tar.gz
+        chmod +x ./crane
+        mv ./crane /usr/local/bin/crane

--- a/.github/workflows/integration_basic_cluster_create.yaml
+++ b/.github/workflows/integration_basic_cluster_create.yaml
@@ -92,6 +92,7 @@ jobs:
         env:
             TPU_CLUSTER_NAME: nightly-xpk-2-v5p-8
             WORKLOAD_NAME: xpktest-nightly-${{ github.run_attempt }}
+            CRANE_WORKLOAD_NAME: xpktest-nightly-crane-${{ github.run_attempt }}
         steps:
             - uses: actions/download-artifact@v4
               with:
@@ -120,6 +121,18 @@ jobs:
               run: xpk info --cluster $TPU_CLUSTER_NAME --zone=us-central2-b
             - name: Delete the workload on the cluster
               run: xpk workload delete --workload $WORKLOAD_NAME --cluster $TPU_CLUSTER_NAME --zone=us-central2-b
+
+            - name: Install Crane
+              uses: ./.github/actions/install-crane            
+            - name: Run a crane workload
+              run: CRANE_WORKLOADS_ENABLED=True xpk workload create --cluster $TPU_CLUSTER_NAME --workload $CRANE_WORKLOAD_NAME  --command "bash workload.sh"  --tpu-type=v4-8 --num-slices=2 --zone=us-central2-b
+            - name: Run xpk inspector with the workload created above
+              run: CRANE_WORKLOADS_ENABLED=True xpk inspector --cluster $TPU_CLUSTER_NAME --zone=us-central2-b  --workload $CRANE_WORKLOAD_NAME
+            - name: Wait for workload completion and confirm it succeeded
+              run: CRANE_WORKLOADS_ENABLED=True xpk workload list --cluster $TPU_CLUSTER_NAME --zone=us-central2-b --wait-for-job-completion $CRANE_WORKLOAD_NAME --timeout 600
+            - name: Delete the workload on the cluster
+              run: CRANE_WORKLOADS_ENABLED=True xpk workload delete --workload $CRANE_WORKLOAD_NAME --cluster $TPU_CLUSTER_NAME --zone=us-central2-b
+
             - name: Delete the cluster created
               if: always()
               run: xpk cluster delete --cluster $TPU_CLUSTER_NAME --zone=us-central2-b --force


### PR DESCRIPTION
# Description
Add an integration test to create a workload via crane.
After the launch the installation of crane will be included into setup-test-env, but for now let's leave it as a separate step.

# Issue
b/483380872

# Testing
Successful run: https://github.com/AI-Hypercomputer/xpk/actions/runs/22105688925/job/63887649000
