### PR TITLE
fix: Super-slicing cluster documentation

### DIFF
--- a/docs/usage/clusters.md
+++ b/docs/usage/clusters.md
@@ -342,10 +342,10 @@ Currently, the below flags/arguments are supported for A3 Mega, A3 Ultra and A4 
   * `--flex`
 
 ## Provisioning Super-slicing clusters
-To create a cluster with Super-slicing support (e.g. for Trillium), use the `--super-slicing` flag. You also need to specify the number of cubes using `--num-cubes` (alias for `--num-slices`).
+To create a cluster with Super-slicing support, use the `--super-slicing` flag. You also need to specify the number of cubes using `--num-cubes` (alias for `--num-slices`).
 
 **Prerequisites:**
-*   Have valid Cluster Director reservations for the TPU resources.
+*   Have valid Cluster Director reservations for the TPU resources supporting Super-slicing.
 
 **Example Usage:**
 


### PR DESCRIPTION
# Description
<!--
Describe your change. 
What does it introduce?
Why do we need it?
If you are releasing a feature, have you updated documentation?
-->
Trillium is v6, and Super-slicing works for 7x+.

# Issue
<!--
Is there any related issue this change is trying to fix?
-->

# Testing
<!--
Have you performed any manual testing on your change?
Have you verified use cases affected by goldens?
-->
