### PR TITLE
Update placement policy condition to include reservation

### DIFF
--- a/src/xpk/core/blueprint/blueprint_generator.py
+++ b/src/xpk/core/blueprint/blueprint_generator.py
@@ -303,7 +303,7 @@ class BlueprintGenerator:
             workload_configmap,
         ],
     )
-    if set_placement_policy and reservation_placement_policy is None:
+    if set_placement_policy and reservation_placement_policy is None and not reservation:
       a3_megagpu_pool_0.append_use(group_placement_0.id)
       primary_group.modules.append(group_placement_0)
     a3_mega_blueprint = Blueprint(


### PR DESCRIPTION
# Description

This change addresses a bug in XPK where NodePool creation for A3-Mega (H100) clusters fails when using a specific reservation.

Change:
* The fix modifies the conditional logic in blueprint_generator.py.

# Issue

[b/487148770](https://b.corp.google.com/issues/487148770): [BUG] A3-Mega NodePool creation fails on reservations due to redundant Placement Policy generation

# Testing
Tested on creating a3-mega cluster creation 
