### PR TITLE
Fix xpk workload list displaying <none> for superslicing clusters

### DIFF
--- a/recipes/Cluster_delete.md
+++ b/recipes/Cluster_delete.md
@@ -17,8 +17,7 @@ gcloud container clusters list --project=golden-project --filter=name=golden-clu
 gcloud container clusters get-credentials golden-cluster --location=us-central1 --dns-endpoint --project=golden-project && kubectl config view && kubectl config set-context --current --namespace=default
 [XPK] Get the name of the workloads in the cluster.
 [XPK] Task: `List Jobs with filter-by-status=EVERYTHING` is implemented by the following command not running since it is a dry run. 
-kubectl get workloads --ignore-not-found -o=jsonpath='{range .items[*]}JOBSET_NAME={.metadata.ownerReferences[0].name}~CREATED_TIME={.metadata.creationTimestamp}~PRIORITY={.spec.podSets[0].template.spec.priorityClassName}~TPU_VMS_NEEDED={.spec.podSets[*].count}~TPU_VMS_RUNNING_RAN={.status.admission.podSetAssignments[*].count}~TPU_VMS_DONE={.status.reclaimablePods[*].count}~STATUS={.status.conditions[-1].type}~STATUS_MESSAGE={.status.conditions[-1].message}~STATUS_TIME={.status.conditions[-1].lastTransitionTime}{"
-"}{end}'
+kubectl get workloads --ignore-not-found -o=jsonpath='{range .items[*]}JOBSET_NAME={.metadata.ownerReferences[0].name}CREATED_TIME={.metadata.creationTimestamp}PRIORITY={.spec.podSets[0].template.spec.priorityClassName}TPU_VMS_NEEDED={.spec.podSets[*].count}TPU_VMS_RUNNING_RAN={.status.admission.podSetAssignments[*].count}TPU_VMS_DONE={.status.reclaimablePods[*].count}STATUS={.status.conditions[-1].type}STATUS_MESSAGE={.status.conditions[-1].message}STATUS_TIME={.status.conditions[-1].lastTransitionTime}{"\n"}{end}'
 [XPK] Task: `Cluster Delete` is implemented by the following command not running since it is a dry run. 
 gcloud beta container clusters delete golden-cluster --project=golden-project --location=us-central1 --quiet
 [XPK] Task: `Get All Subnets` is implemented by the following command not running since it is a dry run. 

--- a/recipes/Workload_list.md
+++ b/recipes/Workload_list.md
@@ -18,8 +18,7 @@ gcloud container clusters get-credentials golden-cluster --location=us-central1 
 kubectl get pods
 [XPK] Finished get-credentials and kubectl setup.
 [XPK] Task: `List Jobs with filter-by-status=EVERYTHING` is implemented by the following command not running since it is a dry run. 
-kubectl get workloads --ignore-not-found -o=jsonpath='{range .items[*]}JOBSET_NAME={.metadata.ownerReferences[0].name}~CREATED_TIME={.metadata.creationTimestamp}~PRIORITY={.spec.podSets[0].template.spec.priorityClassName}~TPU_VMS_NEEDED={.spec.podSets[*].count}~TPU_VMS_RUNNING_RAN={.status.admission.podSetAssignments[*].count}~TPU_VMS_DONE={.status.reclaimablePods[*].count}~STATUS={.status.conditions[-1].type}~STATUS_MESSAGE={.status.conditions[-1].message}~STATUS_TIME={.status.conditions[-1].lastTransitionTime}{"
-"}{end}'
+kubectl get workloads --ignore-not-found -o=jsonpath='{range .items[*]}JOBSET_NAME={.metadata.ownerReferences[0].name}CREATED_TIME={.metadata.creationTimestamp}PRIORITY={.spec.podSets[0].template.spec.priorityClassName}TPU_VMS_NEEDED={.spec.podSets[*].count}TPU_VMS_RUNNING_RAN={.status.admission.podSetAssignments[*].count}TPU_VMS_DONE={.status.reclaimablePods[*].count}STATUS={.status.conditions[-1].type}STATUS_MESSAGE={.status.conditions[-1].message}STATUS_TIME={.status.conditions[-1].lastTransitionTime}{"\n"}{end}'
 [XPK] Workload List Output:
 
 [XPK] See your workloads in Cloud Console: https://console.cloud.google.com/kubernetes/aiml/deployments/jobs?project=golden-project

--- a/recipes/comprehensive-demo.md
+++ b/recipes/comprehensive-demo.md
@@ -54,8 +54,7 @@ gcloud container clusters get-credentials foo --location=us-central1 --dns-endpo
 kubectl get pods
 [XPK] Finished get-credentials and kubectl setup.
 [XPK] Task: `List Jobs with filter-by-status=EVERYTHING` is implemented by the following command not running since it is a dry run. 
-kubectl get workloads --ignore-not-found -o=jsonpath='{range .items[*]}JOBSET_NAME={.metadata.ownerReferences[0].name}~CREATED_TIME={.metadata.creationTimestamp}~PRIORITY={.spec.podSets[0].template.spec.priorityClassName}~TPU_VMS_NEEDED={.spec.podSets[*].count}~TPU_VMS_RUNNING_RAN={.status.admission.podSetAssignments[*].count}~TPU_VMS_DONE={.status.reclaimablePods[*].count}~STATUS={.status.conditions[-1].type}~STATUS_MESSAGE={.status.conditions[-1].message}~STATUS_TIME={.status.conditions[-1].lastTransitionTime}{"
-"}{end}'
+kubectl get workloads --ignore-not-found -o=jsonpath='{range .items[*]}JOBSET_NAME={.metadata.ownerReferences[0].name}CREATED_TIME={.metadata.creationTimestamp}PRIORITY={.spec.podSets[0].template.spec.priorityClassName}TPU_VMS_NEEDED={.spec.podSets[*].count}TPU_VMS_RUNNING_RAN={.status.admission.podSetAssignments[*].count}TPU_VMS_DONE={.status.reclaimablePods[*].count}STATUS={.status.conditions[-1].type}STATUS_MESSAGE={.status.conditions[-1].message}STATUS_TIME={.status.conditions[-1].lastTransitionTime}{"\n"}{end}'
 [XPK] Workload List Output:
 
 [XPK] See your workloads in Cloud Console: https://console.cloud.google.com/kubernetes/aiml/deployments/jobs?project=bar

--- a/src/xpk/core/workload.py
+++ b/src/xpk/core/workload.py
@@ -23,7 +23,7 @@ from ..utils.console import xpk_exit, xpk_print
 from .commands import run_command_for_value
 from .gcloud_context import get_cluster_location
 
-_WORKLOAD_LIST_DELIMITER = '~'
+_WORKLOAD_LIST_DELIMITER = '\x1f'
 
 
 def _safe_int(s: str) -> int:
@@ -33,11 +33,15 @@ def _safe_int(s: str) -> int:
     return 0
 
 
+def _default_format(val: str) -> str:
+  return val if val else '<none>'
+
+
 @dataclass
 class _WorkloadListColumn:
   header: str
   jsonpath: str
-  formatter: Callable[[str], str] = lambda x: x
+  formatter: Callable[[str], str] = _default_format
 
 
 def _sum_counts(value: str) -> str:

--- a/src/xpk/core/workload_test.py
+++ b/src/xpk/core/workload_test.py
@@ -56,8 +56,8 @@ def test_get_jobsets_list_gcp_link():
 def test_get_workload_list(commands_tester: CommandsTester):
   mock_output = '\n'.join([
       (
-          'JOBSET_NAME=job-test~CREATED_TIME=2024-01-01T00:00:00Z~PRIORITY=high~TPU_VMS_NEEDED=32~TPU_VMS_RUNNING_RAN=32~TPU_VMS_DONE=0~STATUS=Running~STATUS_MESSAGE=All'
-          ' good~STATUS_TIME=2024-01-01T00:01:00Z'
+          'JOBSET_NAME=job-test\x1fCREATED_TIME=2024-01-01T00:00:00Z\x1fPRIORITY=high\x1fTPU_VMS_NEEDED=32\x1fTPU_VMS_RUNNING_RAN=32\x1fTPU_VMS_DONE=0\x1fSTATUS=Running\x1fSTATUS_MESSAGE=All'
+          ' good\x1fSTATUS_TIME=2024-01-01T00:01:00Z'
       ),
   ])
   commands_tester.set_result_for_command(
@@ -86,16 +86,16 @@ def test_get_workload_list(commands_tester: CommandsTester):
 def test_get_workload_list_super_slicing(commands_tester: CommandsTester):
   mock_output = '\n'.join([
       (
-          'JOBSET_NAME=job-super~CREATED_TIME=2024-01-01T00:00:00Z~PRIORITY=high~TPU_VMS_NEEDED=32'
-          ' 32~TPU_VMS_RUNNING_RAN=32 32~TPU_VMS_DONE=0'
-          ' 0~STATUS=Running~STATUS_MESSAGE=All'
-          ' good~STATUS_TIME=2024-01-01T00:01:00Z'
+          'JOBSET_NAME=job-super\x1fCREATED_TIME=2024-01-01T00:00:00Z\x1fPRIORITY=high\x1fTPU_VMS_NEEDED=32'
+          ' 32\x1fTPU_VMS_RUNNING_RAN=32 32\x1fTPU_VMS_DONE=0'
+          ' 0\x1fSTATUS=Running\x1fSTATUS_MESSAGE=All'
+          ' good\x1fSTATUS_TIME=2024-01-01T00:01:00Z'
       ),
       (
-          'JOBSET_NAME=job-normal~CREATED_TIME=2024-01-02T00:00:00Z~PRIORITY=low~TPU_VMS_NEEDED=4~TPU_VMS_RUNNING_RAN=4~TPU_VMS_DONE=0~STATUS=Running~STATUS_MESSAGE=All'
-          ' good~STATUS_TIME=2024-01-02T00:01:00Z'
+          'JOBSET_NAME=job-normal\x1fCREATED_TIME=2024-01-02T00:00:00Z\x1fPRIORITY=low\x1fTPU_VMS_NEEDED=4\x1fTPU_VMS_RUNNING_RAN=4\x1fTPU_VMS_DONE=0\x1fSTATUS=Running\x1fSTATUS_MESSAGE=All'
+          ' good\x1fSTATUS_TIME=2024-01-02T00:01:00Z'
       ),
-      'JOBSET_NAME=job-pending~CREATED_TIME=2024-01-03T00:00:00Z~PRIORITY=high~TPU_VMS_NEEDED=16~TPU_VMS_RUNNING_RAN=~TPU_VMS_DONE=0~STATUS=Admitted~STATUS_MESSAGE=Waiting~STATUS_TIME=2024-01-03T00:01:00Z',
+      'JOBSET_NAME=job-pending\x1fCREATED_TIME=2024-01-03T00:00:00Z\x1fPRIORITY=high\x1fTPU_VMS_NEEDED=16\x1fTPU_VMS_RUNNING_RAN=\x1fTPU_VMS_DONE=0\x1fSTATUS=Admitted\x1fSTATUS_MESSAGE=Waiting\x1fSTATUS_TIME=2024-01-03T00:01:00Z',
   ])
   commands_tester.set_result_for_command(
       (0, mock_output), 'kubectl', 'get', 'workloads'
@@ -132,14 +132,14 @@ def test_get_workload_list_super_slicing(commands_tester: CommandsTester):
 def test_get_workload_list_filter_by_job(commands_tester: CommandsTester):
   mock_output = '\n'.join([
       (
-          'JOBSET_NAME=job-test-1~CREATED_TIME=2024-01-01T00:00:00Z~PRIORITY=high~TPU_VMS_NEEDED=32~TPU_VMS_RUNNING_RAN=32~TPU_VMS_DONE=0~STATUS=Running~STATUS_MESSAGE=All'
-          ' good~STATUS_TIME=2024-01-01T00:01:00Z'
+          'JOBSET_NAME=job-test-1\x1fCREATED_TIME=2024-01-01T00:00:00Z\x1fPRIORITY=high\x1fTPU_VMS_NEEDED=32\x1fTPU_VMS_RUNNING_RAN=32\x1fTPU_VMS_DONE=0\x1fSTATUS=Running\x1fSTATUS_MESSAGE=All'
+          ' good\x1fSTATUS_TIME=2024-01-01T00:01:00Z'
       ),
       (
-          'JOBSET_NAME=job-test-2~CREATED_TIME=2024-01-02T00:00:00Z~PRIORITY=low~TPU_VMS_NEEDED=4~TPU_VMS_RUNNING_RAN=4~TPU_VMS_DONE=0~STATUS=Running~STATUS_MESSAGE=All'
-          ' good~STATUS_TIME=2024-01-02T00:01:00Z'
+          'JOBSET_NAME=job-test-2\x1fCREATED_TIME=2024-01-02T00:00:00Z\x1fPRIORITY=low\x1fTPU_VMS_NEEDED=4\x1fTPU_VMS_RUNNING_RAN=4\x1fTPU_VMS_DONE=0\x1fSTATUS=Running\x1fSTATUS_MESSAGE=All'
+          ' good\x1fSTATUS_TIME=2024-01-02T00:01:00Z'
       ),
-      'JOBSET_NAME=other-job~CREATED_TIME=2024-01-03T00:00:00Z~PRIORITY=high~TPU_VMS_NEEDED=16~TPU_VMS_RUNNING_RAN=~TPU_VMS_DONE=0~STATUS=Admitted~STATUS_MESSAGE=Waiting~STATUS_TIME=2024-01-03T00:01:00Z',
+      'JOBSET_NAME=other-job\x1fCREATED_TIME=2024-01-03T00:00:00Z\x1fPRIORITY=high\x1fTPU_VMS_NEEDED=16\x1fTPU_VMS_RUNNING_RAN=\x1fTPU_VMS_DONE=0\x1fSTATUS=Admitted\x1fSTATUS_MESSAGE=Waiting\x1fSTATUS_TIME=2024-01-03T00:01:00Z',
   ])
   commands_tester.set_result_for_command(
       (0, mock_output), 'kubectl', 'get', 'workloads'
@@ -183,19 +183,19 @@ def test_get_workload_list_filters(
     expected_job_names: list[str],
 ):
   mock_output = '\n'.join([
-      'JOBSET_NAME=queued-job~CREATED_TIME=2024-01-01T00:00:00Z~PRIORITY=high~TPU_VMS_NEEDED=4~TPU_VMS_RUNNING_RAN=<none>~TPU_VMS_DONE=0~STATUS=Admitted~STATUS_MESSAGE=Waiting~STATUS_TIME=2024-01-01T00:01:00Z',
-      'JOBSET_NAME=running-job~CREATED_TIME=2024-01-01T00:00:00Z~PRIORITY=high~TPU_VMS_NEEDED=4~TPU_VMS_RUNNING_RAN=4~TPU_VMS_DONE=0~STATUS=Admitted~STATUS_MESSAGE=Running~STATUS_TIME=2024-01-01T00:01:00Z',
+      'JOBSET_NAME=queued-job\x1fCREATED_TIME=2024-01-01T00:00:00Z\x1fPRIORITY=high\x1fTPU_VMS_NEEDED=4\x1fTPU_VMS_RUNNING_RAN=<none>\x1fTPU_VMS_DONE=0\x1fSTATUS=Admitted\x1fSTATUS_MESSAGE=Waiting\x1fSTATUS_TIME=2024-01-01T00:01:00Z',
+      'JOBSET_NAME=running-job\x1fCREATED_TIME=2024-01-01T00:00:00Z\x1fPRIORITY=high\x1fTPU_VMS_NEEDED=4\x1fTPU_VMS_RUNNING_RAN=4\x1fTPU_VMS_DONE=0\x1fSTATUS=Admitted\x1fSTATUS_MESSAGE=Running\x1fSTATUS_TIME=2024-01-01T00:01:00Z',
       (
-          'JOBSET_NAME=success-job~CREATED_TIME=2024-01-01T00:00:00Z~PRIORITY=high~TPU_VMS_NEEDED=4~TPU_VMS_RUNNING_RAN=4~TPU_VMS_DONE=4~STATUS=Finished~STATUS_MESSAGE=Job'
-          ' finishedsuccessfully~STATUS_TIME=2024-01-01T00:01:00Z'
+          'JOBSET_NAME=success-job\x1fCREATED_TIME=2024-01-01T00:00:00Z\x1fPRIORITY=high\x1fTPU_VMS_NEEDED=4\x1fTPU_VMS_RUNNING_RAN=4\x1fTPU_VMS_DONE=4\x1fSTATUS=Finished\x1fSTATUS_MESSAGE=Job'
+          ' finishedsuccessfully\x1fSTATUS_TIME=2024-01-01T00:01:00Z'
       ),
       (
-          'JOBSET_NAME=failed-job~CREATED_TIME=2024-01-01T00:00:00Z~PRIORITY=high~TPU_VMS_NEEDED=4~TPU_VMS_RUNNING_RAN=4~TPU_VMS_DONE=0~STATUS=Finished~STATUS_MESSAGE=Job'
-          ' failed witherror~STATUS_TIME=2024-01-01T00:01:00Z'
+          'JOBSET_NAME=failed-job\x1fCREATED_TIME=2024-01-01T00:00:00Z\x1fPRIORITY=high\x1fTPU_VMS_NEEDED=4\x1fTPU_VMS_RUNNING_RAN=4\x1fTPU_VMS_DONE=0\x1fSTATUS=Finished\x1fSTATUS_MESSAGE=Job'
+          ' failed witherror\x1fSTATUS_TIME=2024-01-01T00:01:00Z'
       ),
       (
-          'JOBSET_NAME=test-queued-job~CREATED_TIME=2024-01-01T00:00:00Z~PRIORITY=high~TPU_VMS_NEEDED=4~TPU_VMS_RUNNING_RAN=0~TPU_VMS_DONE=0~STATUS=QuotaReserved~STATUS_MESSAGE=Waitingfor'
-          ' quota~STATUS_TIME=2024-01-01T00:01:00Z'
+          'JOBSET_NAME=test-queued-job\x1fCREATED_TIME=2024-01-01T00:00:00Z\x1fPRIORITY=high\x1fTPU_VMS_NEEDED=4\x1fTPU_VMS_RUNNING_RAN=0\x1fTPU_VMS_DONE=0\x1fSTATUS=QuotaReserved\x1fSTATUS_MESSAGE=Waitingfor'
+          ' quota\x1fSTATUS_TIME=2024-01-01T00:01:00Z'
       ),
   ])
   commands_tester.set_result_for_command(


### PR DESCRIPTION
# Description
<!--
Describe your change. 
What does it introduce?
Why do we need it?
If you are releasing a feature, have you updated documentation?
-->

## Problem
The `xpk workload list` command was incorrectly displaying `<none>` or inaccurate TPU VM counts (Needed, Running/Ran, Done) on certain clusters, particularly for complex workloads (like Pathways or super-slicing). This happened because the original `kubectl` query was hardcoded to only look at the first podSet (`podSets[0]`), completely missing the additional podSets that make up a heterogeneous workload (e.g., a CPU head node + TPU worker nodes). Additionally, the function's internal architecture relied on brittle shell parsing.

## Solution
*   **Query All PodSets:** Updated the query to use the `[*]` wildcard to fetch data across all `podSets` rather than just the first one (`podSets[0]`).
*   **Aggregate Counts:** Added Python-side logic (`_sum_counts`) to properly sum up the VM counts across all heterogeneous `podSets` within a single workload.
*   **Robust Parsing:** Migrated the data extraction from `kubectl -o=custom-columns` to `kubectl -o=jsonpath`, enabling precise key-value mapping (via Enums) and eliminating brittle `awk` shell filtering.
*   **Code Refactoring:** Refactored `get_workload_list` into a clean, easy-to-maintain pipeline with distinct stages: `fetch -> format -> filter -> render`.

---

## Appendix: Rationale for migrating from `custom-columns` to `jsonpath`

Previously, the code used `kubectl -o=custom-columns` paired with `awk` filtering. This approach had critical flaws:
1. **Variable Whitespace Padding:** `custom-columns` is designed for human readability and pads columns with variable spaces to align them visually. This fundamentally breaks programmatic parsing when the actual field values (such as `Status Message`) also contain spaces. 
2. **Order Dependency:** Parsing relied strictly on column order.
3. **Array Handling:** It makes aggregating array values (like multiple podSets) difficult to format consistently.

**Why `jsonpath` is better:**
Using `kubectl -o=jsonpath` allows us to define our own strict delimiters (e.g., `\x1f`) and structure the output as explicit key-value pairs (e.g., `JOBSET_NAME=job-1\x1fSTATUS=Finished`). This completely removes whitespace ambiguity, decouples the data parsing from the display order, and allows us to easily construct strictly-typed Python dictionaries to process the data robustly.

# Issue
<!--
Is there any related issue this change is trying to fix?
-->
http://b/482104524

# Testing
<!--
Have you performed any manual testing on your change?
Have you verified use cases affected by goldens?
-->
Tested manually on a standard cluster and on a super-slicing cluster.