### PR TITLE
[slice] Improve logging when slice creation fails

### DIFF
--- a/slice/internal/controller/workload_controller.go
+++ b/slice/internal/controller/workload_controller.go
@@ -687,8 +687,8 @@ func (r *WorkloadReconciler) validatePartitionConflicts(
 	for _, slice := range slicesToCreate {
 		for _, id := range slice.Spec.PartitionIds {
 			if oldSliceName, ok := usedPartitionIDs[id]; ok {
-				log.V(2).Info("Partition ID collision detected", "partitionID", id, "oldSlice", oldSliceName, "newSlice", slice.Name)
-				conflictingIDs = append(conflictingIDs, id)
+				log.V(3).Info("Partition ID collision detected", "partitionID", id, "oldSlice", oldSliceName, "newSlice", slice.Name)
+				conflictingIDs = append(conflictingIDs, fmt.Sprintf("%v (used by %v)", id, oldSliceName))
 			}
 		}
 	}

--- a/slice/internal/controller/workload_controller_test.go
+++ b/slice/internal/controller/workload_controller_test.go
@@ -949,7 +949,7 @@ func TestWorkloadReconciler(t *testing.T) {
 					ControllerReference(jobSetGVK, baseJobSetName, baseJobSetName).
 					Finalizers(SliceControllerName).
 					AdmissionCheck(buildAdmissionCheckStateWithRequeue(kueue.CheckStateRetry,
-						`partition IDs ["subblock1"] are already used by existing Slices`, ptr.To(int32(10)))).
+						`partition IDs ["subblock1 (used by default-workload-ps1-0)"] are already used by existing Slices`, ptr.To(int32(10)))).
 					Obj(),
 			},
 			wantSlices: []slice.Slice{


### PR DESCRIPTION
# Issue
- don't print stack trace when slice creation fails due to conflicts -> we don't return an error from `Reconcile`, we switch to static 5 seconds retry
- log colliding slice names on level 2 instead of 3
- include what slices are conflicting in the error message log

# Testing

