### PR TITLE
Fix b/485965692: Support custom topologies in superslicing

### DIFF
--- a/src/xpk/core/scheduling.py
+++ b/src/xpk/core/scheduling.py
@@ -34,7 +34,7 @@ from packaging.version import Version
 
 _SUB_SLICING_MINIMUM_KUEUE_VERSION = Version('0.13.0')
 _SUPER_SLICING_MINIMUM_KUEUE_VERSION = Version('0.15.2')
-_SUPER_SLICING_MAX_TOPOLOGY = (16, 24, 24)
+_SUPER_SLICING_MAX_CUBES = 144
 ONE_TO_ONE_REPLICA_NODE_POOL_ASSIGNMENT_ANNOTATION = (
     'alpha.jobset.sigs.k8s.io/exclusive-topology: cloud.google.com/gke-nodepool'
 )
@@ -219,16 +219,17 @@ def _check_super_slicing_topology(
   topology = parse_topology(workload_system.topology)
   result = (
       all(size % 4 == 0 and size >= 4 for size in topology)
-      and len(topology) == len(_SUPER_SLICING_MAX_TOPOLOGY)
+      and len(topology) == 3
       and topology[0] <= topology[1] <= topology[2]
-      and all(a <= b for a, b in zip(topology, _SUPER_SLICING_MAX_TOPOLOGY))
+      and (topology[0] // 4) * (topology[1] // 4) * (topology[2] // 4)
+      <= _SUPER_SLICING_MAX_CUBES
   )
 
   if not result:
     xpk_print(
-        'Error: Invalid super-slicing topology. It must adhere to the format of'
-        ' 4i x 4j x 4k, where i <= j <= k, and i, j, k are integers, with a'
-        ' maximum of 16x24x24.'
+        'Error: Invalid super-slicing topology. It must adhere to the'
+        ' format of 4i x 4j x 4k, where i <= j <= k, and i, j, k are'
+        f' integers, and i * j * k <= {_SUPER_SLICING_MAX_CUBES}.'
     )
 
   return result

--- a/src/xpk/core/scheduling_test.py
+++ b/src/xpk/core/scheduling_test.py
@@ -377,11 +377,12 @@ SUPER_SLICING_CASE = SchedulingTestCase(
             'Super-slicing, but workload topology is too big for super-slice',
             dataclasses.replace(
                 SUPER_SLICING_CASE,
-                workload_system=_get_system_characteristics_or_die(
-                    'tpu7x-4x4x32'
+                workload_system=dataclasses.replace(
+                    _get_system_characteristics_or_die('tpu7x-4x4x16'),
+                    topology='16x16x40',
                 ),
-                # 10 cubes, to make sure vms fit:
-                resources_config_map={'tpu7x-128': str(64 // 4 * 10)},
+                # 160 cubes, to make sure vms fit:
+                resources_config_map={'tpu7x-128': str(64 // 4 * 160)},
             ),
             WorkloadScheduling.UNAVAILABLE,
         ),


### PR DESCRIPTION
# Description
<!--
Describe your change. 
What does it introduce?
Why do we need it?
If you are releasing a feature, have you updated documentation?
-->
The requirements changed and we need to lift the hardcoded maximum dimensions (16x24x24) for super-slicing topology validation and instead use a max cube count limit (144).

# Issue
<!--
Is there any related issue this change is trying to fix?
-->
http://b/485965692

# Testing
<!--
Have you performed any manual testing on your change?
Have you verified use cases affected by goldens?
-->
unit tests
