### PR TITLE
Ignore python venv better

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,7 @@ downloads/
 eggs/
 .eggs/
 lib/
-lib64/
+lib64
 parts/
 sdist/
 var/
@@ -117,6 +117,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+pyvenv.cfg
 
 # Spyder project settings
 .spyderproject


### PR DESCRIPTION
# Description
<!--
Describe your change. 
What does it introduce?
Why do we need it?
If you are releasing a feature, have you updated documentation?
-->
I have a local venv inside a repo dir and the `lib64` and `pyvenv.cfg` were not ignored.

# Issue
<!--
Is there any related issue this change is trying to fix?
-->
n/a

# Testing
<!--
Have you performed any manual testing on your change?
Have you verified use cases affected by goldens?
-->
n/a