### PR TITLE
fix: workload list priorityClassName for super-slicing workloads

### DIFF
--- a/src/xpk/core/workload.py
+++ b/src/xpk/core/workload.py
@@ -105,8 +105,8 @@ def _parse_workload_item(item: dict[str, Any]) -> _WorkloadListRow:
   created_time = item.get('metadata', {}).get('creationTimestamp', '') or None
 
   pod_sets = item.get('spec', {}).get('podSets') or []
-  priority = None
-  if pod_sets:
+  priority = item.get('spec', {}).get('priorityClassName', '') or None
+  if not priority and pod_sets:
     priority = (
         pod_sets[0]
         .get('template', {})

--- a/src/xpk/core/workload_test.py
+++ b/src/xpk/core/workload_test.py
@@ -20,7 +20,7 @@ import re
 import json
 from pytest_mock import MockerFixture
 from xpk.core.testing.commands_tester import CommandsTester
-from xpk.core.workload import get_jobsets_list_gcp_link, get_workload_list
+from xpk.core.workload import _parse_workload_item, get_jobsets_list_gcp_link, get_workload_list
 
 
 from dataclasses import dataclass
@@ -288,3 +288,40 @@ def test_get_workload_list_filters(
   parsed_table = _parse_workload_table(return_value)
   actual_job_names = [row['Jobset Name'] for row in parsed_table]
   assert actual_job_names == expected_job_names
+
+
+def test_parse_workload_item_priority_from_workload_spec():
+
+  item = {
+      'metadata': {'creationTimestamp': '2024-01-01T00:00:00Z'},
+      'spec': {
+          'priorityClassName': 'workload-high',
+          'podSets': [
+              {'template': {'spec': {'priorityClassName': 'pod-high'}}}
+          ],
+      },
+  }
+  row = _parse_workload_item(item)
+  assert row.priority == 'workload-high'
+
+
+def test_parse_workload_item_priority_from_pod_set_fallback():
+
+  item = {
+      'metadata': {'creationTimestamp': '2024-01-01T00:00:00Z'},
+      'spec': {
+          'podSets': [{'template': {'spec': {'priorityClassName': 'pod-low'}}}]
+      },
+  }
+  row = _parse_workload_item(item)
+  assert row.priority == 'pod-low'
+
+
+def test_parse_workload_item_priority_not_found():
+
+  item = {
+      'metadata': {'creationTimestamp': '2024-01-01T00:00:00Z'},
+      'spec': {'podSets': [{'template': {'spec': {}}}]},
+  }
+  row = _parse_workload_item(item)
+  assert row.priority is None


### PR DESCRIPTION
# Description
<!--
Describe your change. 
What does it introduce?
Why do we need it?
If you are releasing a feature, have you updated documentation?
-->
Fix `priorityClassName` so it's read from `podSets` template if the general `spec` does not specify the priority.

# Issue
<!--
Is there any related issue this change is trying to fix?
-->
b/482104524

# Testing
<!--
Have you performed any manual testing on your change?
Have you verified use cases affected by goldens?
-->
- UT
- manual
