### PR TITLE
fix aggregate reservation accelerator type matching for DWS Calendar

### DIFF
--- a/src/xpk/core/capacity.py
+++ b/src/xpk/core/capacity.py
@@ -354,7 +354,7 @@ def _find_matching_accelerator_resource(
         f'acceleratorTypes/{reservation_accelerator_type}'
     )
     for r in reserved_resources:
-      if r.accelerator_type == target_type_id:
+      if r.accelerator_type.lstrip('/') == target_type_id:
         return r
 
     # Try with Project Number:
@@ -364,7 +364,7 @@ def _find_matching_accelerator_resource(
         f'acceleratorTypes/{reservation_accelerator_type}'
     )
     for r in reserved_resources:
-      if r.accelerator_type == target_type_number:
+      if r.accelerator_type.lstrip('/') == target_type_number:
         return r
   else:
     for r in reserved_resources:


### PR DESCRIPTION
# Description

Fix aggregate reservation accelerator type matching for DWS Calendar reservations.

The GCP Compute API returns `acceleratorType` in aggregate reservations with a leading `/` (e.g. `/projects/my-project/zones/us-east5-b/acceleratorTypes/ct6e`), but XPK builds the comparison string without a leading `/` (e.g. `projects/my-project/zones/us-east5-b/acceleratorTypes/ct6e`). This causes the string comparison to always fail, making it impossible to create clusters with aggregate/calendar reservations for TPU v6e (and likely other TPU types).

The fix strips the leading `/` from the API-returned accelerator type before comparison using `.lstrip('/')`.

# Issue

`xpk cluster create-pathways` (and likely `xpk cluster create`) fails with:
```
[XPK] ERROR: Aggregate Reservation 'my-test-reservation-XXXXXXXX-XXXXXX' does not have a matching accelerator for 'ct6e'.
```
when using a DWS Calendar reservation with TPU v6e-16, despite the reservation being valid and `READY`.

# Testing

- Tested locally with `xpk cluster create-pathways --reservation my-test-reservation-XXXXXXXX-XXXXXX` on a v6e-16 DWS Calendar reservation - the patched version successfully matches the accelerator type
