### PR TITLE
fix: xpk workload list Accelerator VMs counting

### DIFF
--- a/recipes/Workload_list.md
+++ b/recipes/Workload_list.md
@@ -20,7 +20,7 @@ kubectl get pods
 [XPK] Task: `List Jobs with filter-by-status=EVERYTHING` is implemented by the following command not running since it is a dry run. 
 kubectl get workloads --ignore-not-found -o=json
 [XPK] Workload List Output:
-Jobset Name   Created Time   Priority   TPU VMs Needed   TPU VMs Running/Ran   TPU VMs Done   Status   Status Message   Status Time
+Jobset Name   Created Time   Priority   TPU/GPU VMs Needed   TPU/GPU VMs Running/Ran   TPU/GPU VMs Done   Status   Status Message   Status Time
 [XPK] See your workloads in Cloud Console: https://console.cloud.google.com/kubernetes/aiml/deployments/jobs?project=golden-project
 [XPK] Exiting XPK cleanly
 -->

--- a/recipes/comprehensive-demo.md
+++ b/recipes/comprehensive-demo.md
@@ -56,7 +56,7 @@ kubectl get pods
 [XPK] Task: `List Jobs with filter-by-status=EVERYTHING` is implemented by the following command not running since it is a dry run. 
 kubectl get workloads --ignore-not-found -o=json
 [XPK] Workload List Output:
-Jobset Name   Created Time   Priority   TPU VMs Needed   TPU VMs Running/Ran   TPU VMs Done   Status   Status Message   Status Time
+Jobset Name   Created Time   Priority   TPU/GPU VMs Needed   TPU/GPU VMs Running/Ran   TPU/GPU VMs Done   Status   Status Message   Status Time
 [XPK] See your workloads in Cloud Console: https://console.cloud.google.com/kubernetes/aiml/deployments/jobs?project=bar
 [XPK] Exiting XPK cleanly
 -->

--- a/src/xpk/core/workload.py
+++ b/src/xpk/core/workload.py
@@ -64,9 +64,9 @@ class _WorkloadListRow:
   jobset_name: Optional[str]
   created_time: Optional[str]
   priority: Optional[str]
-  tpu_vms_needed: Optional[int]
-  tpu_vms_running_ran: Optional[int]
-  tpu_vms_done: Optional[int]
+  tpu_gpu_needed: Optional[int]
+  tpu_gpu_running_ran: Optional[int]
+  tpu_gpu_done: Optional[int]
   status: Optional[_WorkloadStatus]
   status_message: Optional[str]
   status_time: Optional[str]
@@ -84,11 +84,11 @@ _WORKLOAD_COLUMNS: list[_WorkloadListColumn] = [
     _WorkloadListColumn('Jobset Name', lambda row: row.jobset_name),
     _WorkloadListColumn('Created Time', lambda row: row.created_time),
     _WorkloadListColumn('Priority', lambda row: row.priority),
-    _WorkloadListColumn('TPU VMs Needed', lambda row: row.tpu_vms_needed),
+    _WorkloadListColumn('TPU/GPU VMs Needed', lambda row: row.tpu_gpu_needed),
     _WorkloadListColumn(
-        'TPU VMs Running/Ran', lambda row: row.tpu_vms_running_ran
+        'TPU/GPU VMs Running/Ran', lambda row: row.tpu_gpu_running_ran
     ),
-    _WorkloadListColumn('TPU VMs Done', lambda row: row.tpu_vms_done),
+    _WorkloadListColumn('TPU/GPU VMs Done', lambda row: row.tpu_gpu_done),
     _WorkloadListColumn('Status', lambda row: row.status),
     _WorkloadListColumn('Status Message', lambda row: row.status_message),
     _WorkloadListColumn('Status Time', lambda row: row.status_time),
@@ -121,10 +121,7 @@ def _is_accelerator_pod_set(ps: dict[str, Any]) -> bool:
       return True
 
   node_selector = spec.get('nodeSelector', {})
-  if not _ACCELERATOR_LABELS.isdisjoint(node_selector):
-    return True
-
-  return False
+  return not _ACCELERATOR_LABELS.isdisjoint(node_selector)
 
 
 def _parse_workload_item(item: dict[str, Any]) -> _WorkloadListRow:
@@ -149,7 +146,7 @@ def _parse_workload_item(item: dict[str, Any]) -> _WorkloadListRow:
       if _is_accelerator_pod_set(ps) and ps.get('name')
   }
 
-  tpu_vms_needed = (
+  tpu_gpu_needed = (
       sum(
           _safe_int(ps.get('count'))
           for ps in pod_sets
@@ -161,7 +158,7 @@ def _parse_workload_item(item: dict[str, Any]) -> _WorkloadListRow:
 
   admission_status = item.get('status', {}).get('admission', {})
   pod_set_assignments = admission_status.get('podSetAssignments', [])
-  tpu_vms_running_ran = (
+  tpu_gpu_running_ran = (
       sum(
           _safe_int(psa.get('count'))
           for psa in pod_set_assignments
@@ -172,7 +169,7 @@ def _parse_workload_item(item: dict[str, Any]) -> _WorkloadListRow:
   )
 
   reclaimable_pods = item.get('status', {}).get('reclaimablePods', [])
-  tpu_vms_done = (
+  tpu_gpu_done = (
       sum(
           _safe_int(rp.get('count'))
           for rp in reclaimable_pods
@@ -193,9 +190,9 @@ def _parse_workload_item(item: dict[str, Any]) -> _WorkloadListRow:
       jobset_name=jobset_name,
       created_time=created_time,
       priority=priority,
-      tpu_vms_needed=tpu_vms_needed,
-      tpu_vms_running_ran=tpu_vms_running_ran,
-      tpu_vms_done=tpu_vms_done,
+      tpu_gpu_needed=tpu_gpu_needed,
+      tpu_gpu_running_ran=tpu_gpu_running_ran,
+      tpu_gpu_done=tpu_gpu_done,
       status=status,
       status_message=status_message,
       status_time=status_time,
@@ -256,7 +253,7 @@ def _filter_workload(
 
   status = row_data.status
   message = row_data.status_message or ''
-  running_count = row_data.tpu_vms_running_ran or 0
+  running_count = row_data.tpu_gpu_running_ran or 0
 
   match filter_by_status:
     case _StatusFilter.EVERYTHING:

--- a/src/xpk/core/workload_test.py
+++ b/src/xpk/core/workload_test.py
@@ -145,9 +145,9 @@ def test_get_workload_list(commands_tester: CommandsTester):
   assert len(parsed_table) == 1
   assert parsed_table[0]['Jobset Name'] == 'job-test'
   assert parsed_table[0]['Status'] == 'Unknown'
-  assert parsed_table[0]['TPU VMs Needed'] == '32'
-  assert parsed_table[0]['TPU VMs Running/Ran'] == '32'
-  assert parsed_table[0]['TPU VMs Done'] == '0'
+  assert parsed_table[0]['TPU/GPU VMs Needed'] == '32'
+  assert parsed_table[0]['TPU/GPU VMs Running/Ran'] == '32'
+  assert parsed_table[0]['TPU/GPU VMs Done'] == '0'
   assert parsed_table[0]['Status Message'] == 'All good'
   assert parsed_table[0]['Created Time'] == '2024-01-01T00:00:00Z'
   assert parsed_table[0]['Status Time'] == '2024-01-01T00:01:00Z'
@@ -240,9 +240,9 @@ def test_get_workload_list_multiple_pod_sets(commands_tester: CommandsTester):
   parsed_table = _parse_workload_table(return_value)
   assert len(parsed_table) == 1
   assert parsed_table[0]['Jobset Name'] == 'multi-podset-job'
-  assert parsed_table[0]['TPU VMs Needed'] == '48'
-  assert parsed_table[0]['TPU VMs Running/Ran'] == '48'
-  assert parsed_table[0]['TPU VMs Done'] == '48'
+  assert parsed_table[0]['TPU/GPU VMs Needed'] == '48'
+  assert parsed_table[0]['TPU/GPU VMs Running/Ran'] == '48'
+  assert parsed_table[0]['TPU/GPU VMs Done'] == '48'
 
 
 @pytest.mark.parametrize(
@@ -410,6 +410,6 @@ def test_parse_workload_item_excludes_pathways_head():
       },
   }
   row = _parse_workload_item(item)
-  assert row.tpu_vms_needed == 32
-  assert row.tpu_vms_running_ran == 32
-  assert row.tpu_vms_done == 32
+  assert row.tpu_gpu_needed == 32
+  assert row.tpu_gpu_running_ran == 32
+  assert row.tpu_gpu_done == 32


### PR DESCRIPTION
# Description
<!--
Describe your change. 
What does it introduce?
Why do we need it?
If you are releasing a feature, have you updated documentation?
-->

When running a Pathways workload, the `xpk workload list` command overreports the number of "TPU VMs Needed" (as well as "TPU VMs Running/Ran" and "TPU VMs Done"). It incorrectly counts the CPU-bound `pathways-head` ReplicatedJob as a TPU VM, resulting in a display count of `actual_tpu_vms + 1`.

Currently, XPK calculates the total VMs for a JobSet by blindly summing `replicas * parallelism` across **all** `ReplicatedJobs` in the `JobSet` manifest. 
For a Pathways workload, the JobSet contains two `ReplicatedJobs`:
- `worker`: `1` replica * `32` parallelism = 32 VMs (TPU)
- `pathways-head`: `1` replica * `1` parallelism = 1 VM (CPU-only, scheduled on `cloud.google.com/gke-nodepool: cpu-np`)

Because the counting logic does not inspect the underlying container resource requests, it treats the `pathways-head` CPU pod as an additional TPU VM.

---

## Additional change:
- Renamed the column names from "TPU VMs*" to "TPU/GPU*".

# Issue
<!--
Is there any related issue this change is trying to fix?
-->
b/493553338

# Testing
<!--
Have you performed any manual testing on your change?
Have you verified use cases affected by goldens?
-->
- unit tests
- manual