### PR TITLE
fix: stacktrace-explorer sidecar hangs after main container exits

### DIFF
--- a/src/xpk/core/docker_container.py
+++ b/src/xpk/core/docker_container.py
@@ -55,7 +55,23 @@ def get_main_and_sidecar_container(
   )
   yaml = """- name: stacktrace-explorer
                 image: busybox:1.28
-                args: [/bin/sh, -c, "while [ ! -d /tmp/debugging ] && [ ! -f /shared-volume/stacktrace_signal ]; do sleep 5; done; [ -f /shared-volume/stacktrace_signal ] && exit 0; while ! ls /tmp/debugging/* >/dev/null 2>&1 && [ ! -f /shared-volume/stacktrace_signal ]; do sleep 5; done; [ -f /shared-volume/stacktrace_signal ] && exit 0; tail -n+1 -f /tmp/debugging/* & TAIL_PID=$!; while [ ! -f /shared-volume/stacktrace_signal ]; do sleep 1; done; kill $TAIL_PID 2>/dev/null; exit 0;"]
+                args:
+                - /bin/sh
+                - -c
+                - |
+                  while [ ! -d /tmp/debugging ] && [ ! -f /shared-volume/stacktrace_signal ]; do sleep 5; done
+                  while ! ls /tmp/debugging/* >/dev/null 2>&1 && [ ! -f /shared-volume/stacktrace_signal ]; do sleep 5; done
+                  if ls /tmp/debugging/* >/dev/null 2>&1; then
+                    if [ -f /shared-volume/stacktrace_signal ]; then
+                      cat /tmp/debugging/*
+                    else
+                      tail -n+1 -f /tmp/debugging/* & TAIL_PID=$!
+                      while [ ! -f /shared-volume/stacktrace_signal ]; do sleep 1; done
+                      sleep 2
+                      kill $TAIL_PID 2>/dev/null
+                    fi
+                  fi
+                  exit 0
                 volumeMounts:
                 - name: tpu-stack-trace
                   readOnly: true


### PR DESCRIPTION
# Description

Fix stuck `stacktrace-explorer` sidecar in `--deploy-stacktrace-sidecar` for TPU workloads.

## Problem

I haven't investigated this issue very deeply. But as I understand, the sidecar uses busybox 1.28 ash which has broken `$$` expansion in subshells and `pidof` races. When the main container finishes before `tail` starts, the sidecar hangs forever.

<img width="1259" height="384" alt="image" src="https://github.com/user-attachments/assets/4e58ef0f-33fe-432e-b2ab-464c50274edb" />

## Fix

Replaced the script with simple polling - each loop checks the signal file directly, no `$$`/`trap`/`pidof`/subshells needed. Only `$!` (last background PID) is used to kill `tail` on exit.

## Testing

- Verified sidecar exits cleanly when main container completes
