### PR TITLE
[slice] Fix logging

### DIFF
--- a/slice/cmd/main.go
+++ b/slice/cmd/main.go
@@ -102,9 +102,7 @@ func main() {
 	flag.StringVar(&sliceHealthNodeAffinityMode, "default-slice-health-node-affinity", "HEALTHY",
 		"Default slice health node affinity. Possible values are HEALTHY or HEALTHY_AND_DEGRADED.")
 	flag.StringVar(&featureGates, "feature-gates", "", "A set of key=value pairs that describe feature gates for alpha/experimental features.")
-	opts := zap.Options{
-		Development: true,
-	}
+	opts := zap.Options{}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
 


### PR DESCRIPTION
# Description
<!--
Describe your change. 
What does it introduce?
Why do we need it?
If you are releasing a feature, have you updated documentation?
-->
Currently, all the logs in logs explorer are displayed as "Error". The reason is that by default we set "Development: true" in the zap options. This means that the logs are output in the plaintext and since they are (by default) written to stderr, the log severity is inferred as Error. We should remove this default (since this is in production anyway), plus its going to output the logs in JSON which should enable the Logs explorer to figure out the correct severity.


# Issue
<!--
Is there any related issue this change is trying to fix?
-->

# Testing
<!--
Have you performed any manual testing on your change?
Have you verified use cases affected by goldens?
-->
