### PR TITLE
Move deployment dir computation to CommandRunner

### DIFF
--- a/src/xpk/core/cluster_toolkit/command_runner.py
+++ b/src/xpk/core/cluster_toolkit/command_runner.py
@@ -64,3 +64,15 @@ class CommandRunner(ABC):
         str: path to a target directory.
     """
     return ""
+
+  @abstractmethod
+  def get_deployment_dir(self, prefix: str = "") -> str:
+    """Returns the path to the deployment directory.
+
+    Args:
+        prefix (str): Prefix to use for the deployment directory.
+
+    Returns:
+        str: path to the deployment directory.
+    """
+    return ""

--- a/src/xpk/core/cluster_toolkit/docker_manager.py
+++ b/src/xpk/core/cluster_toolkit/docker_manager.py
@@ -199,6 +199,10 @@ class DockerManager(CommandRunner):
   def _get_upload_directory_mounted(self, prefix: str = "") -> str:
     return os.path.join(working_dir_mount_path, upload_dir_name, prefix)
 
+  def get_deployment_dir(self, prefix: str = "") -> str:
+    prefix = f"/{prefix}" if prefix != "" else ""
+    return f"deployments{prefix}"
+
   def _create_tmp_for_dockerfile(self) -> str:
     tmp_dir = os.path.join(tempfile.gettempdir(), "xpkutils")
     ensure_directory_exists(tmp_dir)

--- a/src/xpk/core/gcluster_manager.py
+++ b/src/xpk/core/gcluster_manager.py
@@ -130,8 +130,7 @@ class GclusterManager:
     self.gcluster_command_runner.run_command(destroy_cmd)
 
   def _get_deployment_path(self, prefix: str = '') -> str:
-    prefix = f'/{prefix}' if prefix != '' else ''
-    return f'deployments{prefix}'
+    return self.gcluster_command_runner.get_deployment_dir(prefix)
 
   def destroy_deployment(self, deployment_name: str, prefix: str = '') -> None:
     """Destroy deployment.


### PR DESCRIPTION
# Description
Move deployment dir computation to `CommandRunner`. We will need to parameterize this with `NativeCommandRunner`.

# Issue
b/493833231

# Testing
n/a
