### PR TITLE
Fix inspector slice logs

### DIFF
--- a/src/xpk/commands/inspector.py
+++ b/src/xpk/commands/inspector.py
@@ -116,8 +116,8 @@ def inspector_run_slice_controller_helper(args, file: str):
   inspector_run_command_helper(args, command, command_description, file)
 
   command = (
-      'kubectl logs deployment slice-controller-controller-manager -n'
-      ' slice-controller-system --tail=100 --prefix=True'
+      'kubectl logs deployment/slice-controller-controller-manager -n'
+      ' slice-controller-system -c manager --tail=100 --prefix=True'
   )
   command_description = 'Slice Controller Logs'
   inspector_run_command_helper(args, command, command_description, file)

--- a/src/xpk/commands/inspector_test.py
+++ b/src/xpk/commands/inspector_test.py
@@ -57,7 +57,7 @@ def test_inspector_run_slice_controller_helper_no_super_slicing(
 
   inspector.inspector_run_slice_controller_helper(args, "test_file")
   commands_tester.assert_command_not_run(
-      "kubectl logs deployment slice-controller-controller-manager"
+      "kubectl logs deployment/slice-controller-controller-manager"
   )
   commands_tester.assert_command_not_run(
       "kubectl describe deployment slice-controller-controller-manager"
@@ -75,7 +75,7 @@ def test_inspector_run_slice_controller_helper_with_super_slicing_success(
       (0, "some logs"),
       "kubectl",
       "logs",
-      "deployment slice-controller-controller-manager",
+      "deployment/slice-controller-controller-manager",
   )
   commands_tester.set_result_for_command(
       (0, "some details"),
@@ -88,7 +88,7 @@ def test_inspector_run_slice_controller_helper_with_super_slicing_success(
   inspector.inspector_run_slice_controller_helper(args, "test_file")
 
   commands_tester.assert_command_run(
-      "kubectl logs deployment slice-controller-controller-manager"
+      "kubectl logs deployment/slice-controller-controller-manager"
   )
   commands_tester.assert_command_run(
       "kubectl describe deployment slice-controller-controller-manager"
@@ -123,7 +123,7 @@ def test_inspector_run_slice_controller_helper_with_slice_controller_not_found(
       "kubectl describe deployment slice-controller-controller-manager"
   )
   commands_tester.assert_command_run(
-      "kubectl logs deployment slice-controller-controller-manager"
+      "kubectl logs deployment/slice-controller-controller-manager"
   )
 
   mock_append_tmp_file.assert_called()


### PR DESCRIPTION
# Description
The existing command is broken, so fixing it.

```
$ kubectl logs deployment myapp
error: error from server (NotFound): pods "deployment" not found in namespace "default"
$ kubectl logs deployment/myapp # we need a slash after deployment, not a space
Defaulted container "myapp" out of: myapp, logshipper (init)
CONTAINER LOGS
$ kubectl logs deployment/myapp -c myapp # explicitly specify which container we want logs for
CONTAINER LOGS
```

# Issue
b/477957805

# Testing
Unit testing.
