### PR TITLE
[slice] Add validation for shorter slice names

### DIFF
--- a/slice/internal/controller/workload_controller_test.go
+++ b/slice/internal/controller/workload_controller_test.go
@@ -179,16 +179,17 @@ func TestWorkloadReconciler(t *testing.T) {
 	worker4Node := utiltesting.MakeNode("worker4").Label(core.TPUSubBlockLabel, "subblock4")
 
 	testCases := map[string]struct {
-		interceptorFuncsCreate func(ctx context.Context, client client.WithWatch, obj client.Object, opts ...client.CreateOption) error
-		request                types.NamespacedName
-		objs                   []client.Object
-		wantWorkloads          []kueue.Workload
-		wantSlices             []slice.Slice
-		wantJobSets            []jobset.JobSet
-		wantErr                error
-		wantEvents             []utiltesting.EventRecord
-		wantResult             controllerruntime.Result
-		enableRetryMechanism   bool
+		interceptorFuncsCreate       func(ctx context.Context, client client.WithWatch, obj client.Object, opts ...client.CreateOption) error
+		request                      types.NamespacedName
+		objs                         []client.Object
+		wantWorkloads                []kueue.Workload
+		wantSlices                   []slice.Slice
+		wantJobSets                  []jobset.JobSet
+		wantErr                      error
+		wantEvents                   []utiltesting.EventRecord
+		wantResult                   controllerruntime.Result
+		enableRetryMechanism         bool
+		enableShorterSliceNameLength bool
 	}{
 		"should skip reconciliation because the Workload was not found": {
 			request:       types.NamespacedName{Name: "other-workload", Namespace: corev1.NamespaceDefault},
@@ -2232,11 +2233,64 @@ func TestWorkloadReconciler(t *testing.T) {
 					Obj(),
 			},
 		},
+		"should create Slices with shorter name when feature gate enabled": {
+			enableShorterSliceNameLength: true,
+			request:                      types.NamespacedName{Name: "very-long-workload-name-exceeding-limit-for-testing", Namespace: corev1.NamespaceDefault}, // 51 characters
+			objs: []client.Object{
+				worker1Node.DeepCopy(),
+				worker2Node.DeepCopy(),
+				baseAdmissionCheckWrapper.DeepCopy(),
+				utiltesting.MakeWorkload("very-long-workload-name-exceeding-limit-for-testing", corev1.NamespaceDefault).
+					UID("very-long-workload-name-exceeding-limit-for-testing").
+					PodSets(basePodSets...).
+					ReserveQuota(baseAdmission, now).
+					ControllerReference(jobSetGVK, baseJobSetName, baseJobSetName).
+					Finalizers(SliceControllerName).
+					AdmissionCheck(buildAdmissionCheckState(kueue.CheckStatePending, "")).
+					Obj(),
+			},
+			wantWorkloads: []kueue.Workload{
+				*utiltesting.MakeWorkload("very-long-workload-name-exceeding-limit-for-testing", corev1.NamespaceDefault).
+					UID("very-long-workload-name-exceeding-limit-for-testing").
+					PodSets(basePodSets...).
+					ReserveQuota(baseAdmission, now).
+					ControllerReference(jobSetGVK, baseJobSetName, baseJobSetName).
+					Finalizers(SliceControllerName).
+					AdmissionCheck(buildAdmissionCheckState(kueue.CheckStatePending, `Slices are in states: 2 CREATED`)).
+					Obj(),
+			},
+			wantSlices: []slice.Slice{
+				*utiltesting.MakeSliceWrapper("default-very-long-workload-name-exceeding-l-035c3").
+					Type(slice.TypeTpu7x).
+					Topology("4x4x4").
+					OwnerWorkloadAnnotations(corev1.NamespaceDefault, "very-long-workload-name-exceeding-limit-for-testing").
+					PartitionIDs("subblock2").
+					Obj(),
+				*utiltesting.MakeSliceWrapper("default-very-long-workload-name-exceeding-l-24890").
+					Type(slice.TypeTpu7x).
+					Topology("4x4x4").
+					OwnerWorkloadAnnotations(corev1.NamespaceDefault, "very-long-workload-name-exceeding-limit-for-testing").
+					PartitionIDs("subblock1").
+					Obj(),
+			},
+			wantEvents: []utiltesting.EventRecord{
+				{
+					Key:       client.ObjectKey{Namespace: corev1.NamespaceDefault, Name: "very-long-workload-name-exceeding-limit-for-testing"},
+					EventType: corev1.EventTypeNormal,
+					Reason:    SlicesCreatedEventType,
+					Message:   `The Slices "default-very-long-workload-name-exceeding-l-035c3", "default-very-long-workload-name-exceeding-l-24890" have been created`,
+				},
+			},
+			wantResult: reconcile.Result{RequeueAfter: initializationRetryAfter},
+		},
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			if tc.enableRetryMechanism {
 				features.SetFeatureGateDuringTest(t, features.UseRetryMechanismForSliceCreation, true)
+			}
+			if tc.enableShorterSliceNameLength {
+				features.SetFeatureGateDuringTest(t, features.ShorterSliceNameLength, true)
 			}
 			scheme := runtime.NewScheme()
 			utilruntime.Must(corev1.AddToScheme(scheme))

--- a/slice/internal/core/slice.go
+++ b/slice/internal/core/slice.go
@@ -32,7 +32,9 @@ import (
 )
 
 const (
-	maxSliceNameLength = 54
+	maxSliceNameLength        = 54
+	maxShorterSliceNameLength = 49
+	hashLength                = 5
 )
 
 func SliceKeyFromWorkload(wl *kueue.Workload, podSetName kueue.PodSetReference, sliceIndex int32) client.ObjectKey {
@@ -54,11 +56,16 @@ func SliceWithMetadata(wl *kueue.Workload, podSetName kueue.PodSetReference, sli
 
 func SliceName(ns string, workloadName string, podSetName kueue.PodSetReference, sliceIndex int32) string {
 	name := fmt.Sprintf("%s-%s-%s-%d", ns, workloadName, podSetName, sliceIndex)
-	if len(name) <= maxSliceNameLength {
+	maxLen := maxSliceNameLength
+	if features.Enabled(features.ShorterSliceNameLength) {
+		maxLen = maxShorterSliceNameLength
+	}
+
+	if len(name) <= maxLen {
 		return name
 	}
 	hash := sha256.Sum256([]byte(name))
-	return fmt.Sprintf("%s-%s", name[:48], hex.EncodeToString(hash[:])[:5])
+	return fmt.Sprintf("%s-%s", name[:maxLen-(hashLength+1)], hex.EncodeToString(hash[:])[:hashLength])
 }
 
 func isStale(slice *v1beta1.Slice, timeout time.Duration) bool {

--- a/slice/internal/core/slice_test.go
+++ b/slice/internal/core/slice_test.go
@@ -20,6 +20,8 @@ import (
 	"testing"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+
+	"tpu-slice-controller/internal/features"
 )
 
 func TestSliceName(t *testing.T) {
@@ -29,6 +31,7 @@ func TestSliceName(t *testing.T) {
 		podSetName   kueue.PodSetReference
 		sliceIndex   int32
 		want         string
+		wantShorter  string
 	}{
 		"short name": {
 			ns:           "default",
@@ -43,6 +46,7 @@ func TestSliceName(t *testing.T) {
 			podSetName:   "ps",
 			sliceIndex:   0,
 			want:         "ns-1234567890123456789012345678901234567890123456-ps-0",
+			wantShorter:  "ns-1234567890123456789012345678901234567890-ef47a",
 		},
 		"long name": {
 			ns:           "very-long-namespace-name",
@@ -50,6 +54,7 @@ func TestSliceName(t *testing.T) {
 			podSetName:   "podset",
 			sliceIndex:   0,
 			want:         "very-long-namespace-name-very-long-workload-name-209e4",
+			wantShorter:  "very-long-namespace-name-very-long-workload-209e4",
 		},
 		"long name, different podset": {
 			ns:           "very-long-namespace-name",
@@ -57,6 +62,7 @@ func TestSliceName(t *testing.T) {
 			podSetName:   "another-podset",
 			sliceIndex:   0,
 			want:         "very-long-namespace-name-very-long-workload-name-a06b5",
+			wantShorter:  "very-long-namespace-name-very-long-workload-a06b5",
 		},
 		"long name, next index": {
 			ns:           "very-long-namespace-name",
@@ -64,14 +70,28 @@ func TestSliceName(t *testing.T) {
 			podSetName:   "podset",
 			sliceIndex:   1,
 			want:         "very-long-namespace-name-very-long-workload-name-36522",
+			wantShorter:  "very-long-namespace-name-very-long-workload-36522",
 		},
 	}
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
+			// Test with feature gate disabled (default)
+			features.SetFeatureGateDuringTest(t, features.ShorterSliceNameLength, false)
 			got := SliceName(tc.ns, tc.workloadName, tc.podSetName, tc.sliceIndex)
 			if got != tc.want {
-				t.Errorf("SliceName() = %q, want %q", got, tc.want)
+				t.Errorf("SliceName() [ShorterSliceNameLength disabled] = %q, want %q", got, tc.want)
+			}
+
+			// Test with feature gate enabled
+			features.SetFeatureGateDuringTest(t, features.ShorterSliceNameLength, true)
+			gotShorter := SliceName(tc.ns, tc.workloadName, tc.podSetName, tc.sliceIndex)
+			expectedShorter := tc.want
+			if tc.wantShorter != "" {
+				expectedShorter = tc.wantShorter
+			}
+			if gotShorter != expectedShorter {
+				t.Errorf("SliceName() [ShorterSliceNameLength enabled] = %q, want %q", gotShorter, expectedShorter)
 			}
 		})
 	}

--- a/slice/internal/features/features.go
+++ b/slice/internal/features/features.go
@@ -30,10 +30,16 @@ const (
 	// retries on creation failures (including upon partition ID conflicts).
 	// If a Slice fails to form within the timeout, we evict the Workload.
 	UseRetryMechanismForSliceCreation featuregate.Feature = "UseRetryMechanismForSliceCreation"
+
+	// ShorterSliceNameLength enables support for shorter Slice names (max 49 characters).
+	ShorterSliceNameLength featuregate.Feature = "ShorterSliceNameLength"
 )
 
 var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.VersionedSpecs{
 	UseRetryMechanismForSliceCreation: {
+		{Version: version.MustParse("0.1"), Default: false, PreRelease: featuregate.Alpha},
+	},
+	ShorterSliceNameLength: {
 		{Version: version.MustParse("0.1"), Default: false, PreRelease: featuregate.Alpha},
 	},
 }


### PR DESCRIPTION
# Description
Add validation for requiring slice name <= 49 characters.

The feature is hidden behind `ShorterSliceNameLength` feature gate.

# Issue
<!--
Is there any related issue this change is trying to fix?
-->

# Testing
<!--
Have you performed any manual testing on your change?
Have you verified use cases affected by goldens?
-->
