### PR TITLE
[slice] Default log level

### DIFF
--- a/slice/config/manager/manager.yaml
+++ b/slice/config/manager/manager.yaml
@@ -63,6 +63,7 @@ spec:
         args:
           - --leader-elect
           - --health-probe-bind-address=:8081
+          - --zap-log-level=3
         image: controller:latest
         name: manager
         ports: []


### PR DESCRIPTION
# Description
<!--
Describe your change. 
What does it introduce?
Why do we need it?
If you are releasing a feature, have you updated documentation?
-->
We don't have any default log level. This means that without manual modification no logs are exported. In [Kueue we set this to 2](https://github.com/kubernetes-sigs/kueue/blob/66c2cf1a93ee3f19d8b29309d27832a4595d4106/config/components/manager/manager.yaml#L26) but here (I think) 3 would be a good default.

# Issue
<!--
Is there any related issue this change is trying to fix?
-->

# Testing
<!--
Have you performed any manual testing on your change?
Have you verified use cases affected by goldens?
-->
