### PR TITLE
[slice] Skip TPU warden check for LWS

### DIFF
--- a/slice/internal/core/constants.go
+++ b/slice/internal/core/constants.go
@@ -28,6 +28,7 @@ const (
 	TPUAcceleratorLabel        = "cloud.google.com/gke-tpu-accelerator"
 	TPUBlockLabel              = "cloud.google.com/gce-topology-block"
 	TPUSubBlockLabel           = "cloud.google.com/gke-tpu-partition-4x4x4-id"
+	TPUSkipWardenAnnotation    = "cloud.google.com/skip-tpu-webhook-check"
 	TPUResourceName            = "google.com/tpu"
 	RetryOnFailureAnnotation   = "slice.gke.io/retry-on-failure"
 	TPUsPerCube                = 64

--- a/slice/internal/webhooks/leaderworkerset_webhook.go
+++ b/slice/internal/webhooks/leaderworkerset_webhook.go
@@ -78,15 +78,17 @@ func (r *LeaderWorkerSetWebhook) Default(ctx context.Context, lws *leaderworkers
 	if lws.Spec.LeaderWorkerTemplate.WorkerTemplate.Annotations == nil {
 		lws.Spec.LeaderWorkerTemplate.WorkerTemplate.Annotations = make(map[string]string)
 	}
+	lws.Spec.LeaderWorkerTemplate.WorkerTemplate.Annotations[core.TPUSkipWardenAnnotation] = "true"
 	if lws.Spec.LeaderWorkerTemplate.LeaderTemplate != nil {
-		// if the leader is defined, annotate both templates with the same group name
-		lws.Spec.LeaderWorkerTemplate.WorkerTemplate.Annotations[podsetGroupName] = podsetGroupValue
-		lws.Spec.LeaderWorkerTemplate.LeaderTemplate.Annotations[podsetGroupName] = podsetGroupValue
-
-		annotatePodTemplateSpecWithSliceHealth(lws.Spec.LeaderWorkerTemplate.LeaderTemplate, parsed, r.DefaultSliceHealthValues)
 		if lws.Spec.LeaderWorkerTemplate.LeaderTemplate.Annotations == nil {
 			lws.Spec.LeaderWorkerTemplate.LeaderTemplate.Annotations = make(map[string]string)
 		}
+		// if the leader is defined, annotate both templates with the same group name
+		lws.Spec.LeaderWorkerTemplate.WorkerTemplate.Annotations[podsetGroupName] = podsetGroupValue
+		lws.Spec.LeaderWorkerTemplate.LeaderTemplate.Annotations[podsetGroupName] = podsetGroupValue
+		lws.Spec.LeaderWorkerTemplate.LeaderTemplate.Annotations[core.TPUSkipWardenAnnotation] = "true"
+
+		annotatePodTemplateSpecWithSliceHealth(lws.Spec.LeaderWorkerTemplate.LeaderTemplate, parsed, r.DefaultSliceHealthValues)
 		lws.Spec.LeaderWorkerTemplate.LeaderTemplate.Annotations[kueue.PodSetRequiredTopologyAnnotation] = parsed.RequiredSliceLevel()
 	}
 

--- a/slice/internal/webhooks/leaderworkerset_webhook.go
+++ b/slice/internal/webhooks/leaderworkerset_webhook.go
@@ -19,6 +19,7 @@ package webhooks
 import (
 	"context"
 
+	corev1 "k8s.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
@@ -68,30 +69,36 @@ func (r *LeaderWorkerSetWebhook) Default(ctx context.Context, lws *leaderworkers
 		return nil
 	}
 
-	log.V(5).Info("Annotating WorkerTemplate")
 	tpuTopology := lws.Spec.LeaderWorkerTemplate.WorkerTemplate.Annotations[core.TPUSliceTopologyAnnotation]
 	parsed, err := topology.ParseTopologyV7(tpuTopology)
 	if err != nil {
 		return err
 	}
-	annotatePodTemplateSpecWithSliceHealth(&lws.Spec.LeaderWorkerTemplate.WorkerTemplate, parsed, r.DefaultSliceHealthValues)
-	if lws.Spec.LeaderWorkerTemplate.WorkerTemplate.Annotations == nil {
-		lws.Spec.LeaderWorkerTemplate.WorkerTemplate.Annotations = make(map[string]string)
+
+	log.V(5).Info("Annotating LeaderWorkerTemplate")
+	annotatePodTemplateSpec(&lws.Spec.LeaderWorkerTemplate.WorkerTemplate, parsed, r.DefaultSliceHealthValues)
+	annotatePodTemplateSpec(lws.Spec.LeaderWorkerTemplate.LeaderTemplate, parsed, r.DefaultSliceHealthValues)
+	setPodSetGroupName(lws)
+
+	return nil
+}
+
+func annotatePodTemplateSpec(template *corev1.PodTemplateSpec, parsed topology.ParsedTopology, defaultSliceHealthValues []string) {
+	if template == nil {
+		return
 	}
-	lws.Spec.LeaderWorkerTemplate.WorkerTemplate.Annotations[core.TPUSkipWardenAnnotation] = "true"
+	annotatePodTemplateSpecWithSliceHealth(template, parsed, defaultSliceHealthValues)
+	if template.Annotations == nil {
+		template.Annotations = make(map[string]string)
+	}
+	template.Annotations[core.TPUSkipWardenAnnotation] = "true"
+	template.Annotations[kueue.PodSetRequiredTopologyAnnotation] = parsed.RequiredSliceLevel()
+}
+
+func setPodSetGroupName(lws *leaderworkersetv1.LeaderWorkerSet) {
 	if lws.Spec.LeaderWorkerTemplate.LeaderTemplate != nil {
-		if lws.Spec.LeaderWorkerTemplate.LeaderTemplate.Annotations == nil {
-			lws.Spec.LeaderWorkerTemplate.LeaderTemplate.Annotations = make(map[string]string)
-		}
 		// if the leader is defined, annotate both templates with the same group name
 		lws.Spec.LeaderWorkerTemplate.WorkerTemplate.Annotations[podsetGroupName] = podsetGroupValue
 		lws.Spec.LeaderWorkerTemplate.LeaderTemplate.Annotations[podsetGroupName] = podsetGroupValue
-		lws.Spec.LeaderWorkerTemplate.LeaderTemplate.Annotations[core.TPUSkipWardenAnnotation] = "true"
-
-		annotatePodTemplateSpecWithSliceHealth(lws.Spec.LeaderWorkerTemplate.LeaderTemplate, parsed, r.DefaultSliceHealthValues)
-		lws.Spec.LeaderWorkerTemplate.LeaderTemplate.Annotations[kueue.PodSetRequiredTopologyAnnotation] = parsed.RequiredSliceLevel()
 	}
-
-	lws.Spec.LeaderWorkerTemplate.WorkerTemplate.Annotations[kueue.PodSetRequiredTopologyAnnotation] = parsed.RequiredSliceLevel()
-	return nil
 }

--- a/slice/internal/webhooks/leaderworkerset_webhook_test.go
+++ b/slice/internal/webhooks/leaderworkerset_webhook_test.go
@@ -92,6 +92,7 @@ func TestLeaderWorkerSetDefault(t *testing.T) {
 				Size(4).
 				WorkerAnnotation(core.TPUSliceTopologyAnnotation, "2x2x4").
 				WorkerAnnotation(kueue.PodSetRequiredTopologyAnnotation, "cloud.google.com/gke-tpu-partition-2x2x4-id").
+				WorkerAnnotation(core.TPUSkipWardenAnnotation, "true").
 				WorkerNodeSelector("cloud.google.com/gke-tpu-accelerator", string(slice.TypeTpu7x)).
 				WorkerNodeAffinity("cloud.google.com/gke-tpu-partition-2x2x4-state", []string{core.TPUSliceHealthNodeSelectorHealthy}).
 				WorkerLimit(core.TPUResourceName, "4").
@@ -114,11 +115,13 @@ func TestLeaderWorkerSetDefault(t *testing.T) {
 				WorkerAnnotation(core.TPUSliceTopologyAnnotation, "2x2x4").
 				WorkerAnnotation(podsetGroupName, podsetGroupValue).
 				WorkerAnnotation(kueue.PodSetRequiredTopologyAnnotation, "cloud.google.com/gke-tpu-partition-2x2x4-id").
+				WorkerAnnotation(core.TPUSkipWardenAnnotation, "true").
 				WorkerNodeSelector("cloud.google.com/gke-tpu-accelerator", string(slice.TypeTpu7x)).
 				WorkerNodeAffinity("cloud.google.com/gke-tpu-partition-2x2x4-state", []string{core.TPUSliceHealthNodeSelectorHealthy}).
 				WorkerLimit(core.TPUResourceName, "4").
 				LeaderAnnotation(core.TPUSliceTopologyAnnotation, "2x2x4").
 				LeaderAnnotation(podsetGroupName, podsetGroupValue).
+				LeaderAnnotation(core.TPUSkipWardenAnnotation, "true").
 				LeaderAnnotation(kueue.PodSetRequiredTopologyAnnotation, "cloud.google.com/gke-tpu-partition-2x2x4-id").
 				LeaderNodeSelector("cloud.google.com/gke-tpu-accelerator", string(slice.TypeTpu7x)).
 				LeaderNodeAffinity("cloud.google.com/gke-tpu-partition-2x2x4-state", []string{core.TPUSliceHealthNodeSelectorHealthy}).
@@ -139,6 +142,7 @@ func TestLeaderWorkerSetDefault(t *testing.T) {
 				Size(4).
 				WorkerAnnotation(core.TPUSliceTopologyAnnotation, "2x2x4").
 				WorkerAnnotation(kueue.PodSetRequiredTopologyAnnotation, "cloud.google.com/gke-tpu-partition-2x2x4-id").
+				WorkerAnnotation(core.TPUSkipWardenAnnotation, "true").
 				WorkerNodeSelector("cloud.google.com/gke-tpu-accelerator", string(slice.TypeTpu7x)).
 				WorkerNodeSelector("cloud.google.com/gke-tpu-partition-2x2x4-state", "HEALTHY").
 				WorkerLimit(core.TPUResourceName, "4").


### PR DESCRIPTION
# Description
<!--
Describe your change. 
What does it introduce?
Why do we need it?
If you are releasing a feature, have you updated documentation?
-->
In LWS there is no suspend so (gated) pods are created immediately, before Kueue admits the workload so before the slice is created. 

If these pods don’t have the cloud.google.com/gke-tpu-topology node selector, they get rejected by the GKE warden and if they do have, they cannot get scheduled (because since the slice is not there yet, the nodes don’t have the topology labels). 

This PR adds an Annotation to skip the GKE warden TPU webhook check to allow these pods to be created.

# Issue
<!--
Is there any related issue this change is trying to fix?
-->

# Testing
<!--
Have you performed any manual testing on your change?
Have you verified use cases affected by goldens?
-->
