### PR TITLE
[slice] Change default node affinity for workloads to HEALTHY or DEGRADED health status

### DIFF
--- a/slice/cmd/main.go
+++ b/slice/cmd/main.go
@@ -101,7 +101,7 @@ func main() {
 	flag.StringVar(&metricsCertKey, "metrics-cert-key", "tls.key", "The name of the metrics server key file.")
 	flag.BoolVar(&enableHTTP2, "enable-http2", false,
 		"If set, HTTP/2 will be enabled for the metrics and webhook servers")
-	flag.StringVar(&sliceHealthNodeAffinityMode, "default-slice-health-node-affinity", "HEALTHY",
+	flag.StringVar(&sliceHealthNodeAffinityMode, "default-slice-health-node-affinity", "HEALTHY_AND_DEGRADED",
 		"Default slice health node affinity. Possible values are HEALTHY or HEALTHY_AND_DEGRADED.")
 	flag.StringVar(&featureGates, "feature-gates", "", "A set of key=value pairs that describe feature gates for alpha/experimental features.")
 	opts := zap.Options{}

--- a/slice/config/manager/manager.yaml
+++ b/slice/config/manager/manager.yaml
@@ -64,6 +64,7 @@ spec:
           - --leader-elect
           - --health-probe-bind-address=:8081
           - --zap-log-level=3
+          - --default-slice-health-node-affinity=HEALTHY_AND_DEGRADED
         image: controller:latest
         name: manager
         ports: []

--- a/slice/test/e2e/subslice/job_test.go
+++ b/slice/test/e2e/subslice/job_test.go
@@ -141,7 +141,7 @@ var _ = ginkgo.Describe("Job Subslicing", func() {
 						if matchExpression.Key == fmt.Sprintf("cloud.google.com/gke-tpu-partition-%s-state", tc.topology) {
 							found = true
 							g.Expect(matchExpression.Operator).Should(gomega.Equal(corev1.NodeSelectorOpIn))
-							g.Expect(matchExpression.Values).Should(gomega.ConsistOf(core.TPUSliceHealthNodeSelectorHealthy))
+							g.Expect(matchExpression.Values).Should(gomega.ConsistOf(core.TPUSliceHealthNodeSelectorHealthy, core.TPUSliceHealthNodeSelectorDegraded))
 						}
 					}
 				}

--- a/slice/test/e2e/subslice/jobset_test.go
+++ b/slice/test/e2e/subslice/jobset_test.go
@@ -152,7 +152,7 @@ var _ = ginkgo.Describe("Subslicing", func() {
 							if matchExpression.Key == fmt.Sprintf("cloud.google.com/gke-tpu-partition-%s-state", tc.topology) {
 								found = true
 								g.Expect(matchExpression.Operator).Should(gomega.Equal(corev1.NodeSelectorOpIn))
-								g.Expect(matchExpression.Values).Should(gomega.ConsistOf(core.TPUSliceHealthNodeSelectorHealthy))
+								g.Expect(matchExpression.Values).Should(gomega.ConsistOf(core.TPUSliceHealthNodeSelectorHealthy, core.TPUSliceHealthNodeSelectorDegraded))
 							}
 						}
 					}

--- a/slice/test/e2e/subslice/lws_test.go
+++ b/slice/test/e2e/subslice/lws_test.go
@@ -175,7 +175,7 @@ var _ = ginkgo.Describe("LWS Subslicing", func() {
 							if matchExpression.Key == fmt.Sprintf("cloud.google.com/gke-tpu-partition-%s-state", tc.topology) {
 								found = true
 								g.Expect(matchExpression.Operator).Should(gomega.Equal(corev1.NodeSelectorOpIn))
-								g.Expect(matchExpression.Values).Should(gomega.ConsistOf(core.TPUSliceHealthNodeSelectorHealthy))
+								g.Expect(matchExpression.Values).Should(gomega.ConsistOf(core.TPUSliceHealthNodeSelectorHealthy, core.TPUSliceHealthNodeSelectorDegraded))
 							}
 						}
 					}

--- a/slice/test/e2e/superslice/job_test.go
+++ b/slice/test/e2e/superslice/job_test.go
@@ -129,7 +129,7 @@ var _ = ginkgo.Describe("Job", func() {
 							if matchExpression.Key == core.TPUSliceHealthNodeSelectorKey {
 								found = true
 								g.Expect(matchExpression.Operator).Should(gomega.Equal(corev1.NodeSelectorOpIn))
-								g.Expect(matchExpression.Values).Should(gomega.ConsistOf(core.TPUSliceHealthNodeSelectorHealthy))
+								g.Expect(matchExpression.Values).Should(gomega.ConsistOf(core.TPUSliceHealthNodeSelectorHealthy, core.TPUSliceHealthNodeSelectorDegraded))
 							}
 						}
 					}

--- a/slice/test/e2e/superslice/jobset_test.go
+++ b/slice/test/e2e/superslice/jobset_test.go
@@ -194,7 +194,7 @@ var _ = ginkgo.Describe("JobSet", func() {
 									if matchExpression.Key == core.TPUSliceHealthNodeSelectorKey {
 										found = true
 										g.Expect(matchExpression.Operator).Should(gomega.Equal(corev1.NodeSelectorOpIn))
-										g.Expect(matchExpression.Values).Should(gomega.ConsistOf(core.TPUSliceHealthNodeSelectorHealthy))
+										g.Expect(matchExpression.Values).Should(gomega.ConsistOf(core.TPUSliceHealthNodeSelectorHealthy, core.TPUSliceHealthNodeSelectorDegraded))
 									}
 								}
 							}


### PR DESCRIPTION
change default node affinity to HEALTHY or DEGRADED when node selectors or node affinity is not defined for a workload.