### PR TITLE
feat: support --device-type for xpk cluster create-ray

### DIFF
--- a/src/xpk/parser/cluster.py
+++ b/src/xpk/parser/cluster.py
@@ -269,9 +269,13 @@ def set_cluster_create_ray_parser(cluster_create_ray_parser: ArgumentParser):
   add_shared_cluster_create_required_arguments(
       cluster_create_ray_required_arguments
   )
-  add_tpu_type_argument(cluster_create_ray_required_arguments, required=True)
+  cluster_device_group = (
+      cluster_create_ray_required_arguments.add_mutually_exclusive_group(
+          required=True
+      )
+  )
+  add_tpu_and_device_type_arguments(cluster_device_group)
 
-  # TODO(bzmarke): Add --device-type to support GPU/CPU
   cluster_create_ray_required_arguments.add_argument(
       '--ray-version',
       type=str,


### PR DESCRIPTION
# Description
<!--
Describe your change. 
What does it introduce?
Why do we need it?
If you are releasing a feature, have you updated documentation?
-->
Add `--device-type` to `create-ray` similarly to how we support it in other cluster create commands.

FWIW [`create_ray_cluster`](https://github.com/AI-Hypercomputer/xpk/blob/86dbe890da9eb5a6a6f0a217995784ed3735c6e5/src/xpk/commands/cluster.py#L903) just runs the regular cluster create under the hood, so I do not expect any problems with this addition.

# Issue
<!--
Is there any related issue this change is trying to fix?
-->
https://github.com/AI-Hypercomputer/xpk/issues/1163

# Testing
<!--
Have you performed any manual testing on your change?
Have you verified use cases affected by goldens?
-->
n/a
