### PR TITLE
Update kubernetes dependency to version 35.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
   "setuptools-scm>=8",
   "pyyaml==6.0.2",
   "docker==7.1.0",
-  "kubernetes==31.0.0",
+  "kubernetes==35.0.0",
   "google-cloud==0.34.0",
   "google-api-core==2.24.1",
   "packaging==24.2",


### PR DESCRIPTION
# Description
<!--
Describe your change. 
What does it introduce?
Why do we need it?
If you are releasing a feature, have you updated documentation?
-->
Update the client so it supports HTTPS_PROXY.

I haven't found any breaking changes in the CHANGELOG.

# Issue
<!--
Is there any related issue this change is trying to fix?
-->
There are users who have to use HTTPS_PROXY env var and the old kubernetes client did not support that.

# Testing
<!--
Have you performed any manual testing on your change?
Have you verified use cases affected by goldens?
-->
e2e: https://github.com/AI-Hypercomputer/xpk/actions/runs/24721472387.
