### PR TITLE
[slice] New workload condition with reason for eviction

### DIFF
--- a/slice/internal/controller/workload_controller.go
+++ b/slice/internal/controller/workload_controller.go
@@ -644,7 +644,7 @@ func (r *WorkloadReconciler) syncSlicesForAssignment(ctx context.Context, wl *ku
 			log.V(2).Info(fmt.Sprintf("Admission check %q updated state from %q to %q", ac.Name, ac.State, kueue.CheckStatePending), "reason", msg)
 			ac.State = kueue.CheckStatePending
 			ac.Message = api.TruncateConditionMessage(msg)
-			patchErr := r.updateWorkloadAdmissionCheckStatus(ctx, wl, ac, "")
+			patchErr := r.updateWorkloadStatus(ctx, wl, ac, "")
 			if patchErr != nil {
 				return nil, nil, errors.Join(err, patchErr)
 			}
@@ -724,10 +724,10 @@ func (r *WorkloadReconciler) evictWorkload(ctx context.Context, wl *kueue.Worklo
 	ac.State = kueue.CheckStateRetry
 	ac.RequeueAfterSeconds = ptr.To(int32(r.retryDelayOnSliceFailure.Round(time.Second).Seconds()))
 	ac.Message = api.TruncateConditionMessage(message)
-	return r.updateWorkloadAdmissionCheckStatus(ctx, wl, ac, reason)
+	return r.updateWorkloadStatus(ctx, wl, ac, reason)
 }
 
-func (r *WorkloadReconciler) updateWorkloadAdmissionCheckStatus(ctx context.Context, wl *kueue.Workload, ac *kueue.AdmissionCheckState, evictedReason string) error {
+func (r *WorkloadReconciler) updateWorkloadStatus(ctx context.Context, wl *kueue.Workload, ac *kueue.AdmissionCheckState, evictedReason string) error {
 	wlPatch := workload.BaseSSAWorkload(wl, true)
 	workload.SetAdmissionCheckState(&wlPatch.Status.AdmissionChecks, *ac, r.clock)
 
@@ -771,7 +771,7 @@ func (r *WorkloadReconciler) syncAdmissionCheckStatus(ctx context.Context, wl *k
 		return nil
 	}
 
-	if err := r.updateWorkloadAdmissionCheckStatus(ctx, wl, ac, evictedReason); err != nil {
+	if err := r.updateWorkloadStatus(ctx, wl, ac, evictedReason); err != nil {
 		return err
 	}
 

--- a/slice/internal/controller/workload_controller.go
+++ b/slice/internal/controller/workload_controller.go
@@ -741,7 +741,8 @@ func (r *WorkloadReconciler) updateWorkloadAdmissionCheckStatus(ctx context.Cont
 		}
 		apimeta.SetStatusCondition(&wlPatch.Status.Conditions, evictionCond)
 	} else if ac.State != kueue.CheckStateRetry {
-		if oldCond := apimeta.FindStatusCondition(wl.Status.Conditions, core.WorkloadSliceFailureConditionType); oldCond != nil {
+		oldCond := apimeta.FindStatusCondition(wl.Status.Conditions, core.WorkloadSliceFailureConditionType)
+		if oldCond != nil && oldCond.Status == metav1.ConditionTrue {
 			apimeta.SetStatusCondition(&wlPatch.Status.Conditions, metav1.Condition{
 				Type:    core.WorkloadSliceFailureConditionType,
 				Status:  metav1.ConditionFalse,

--- a/slice/internal/controller/workload_controller.go
+++ b/slice/internal/controller/workload_controller.go
@@ -891,12 +891,14 @@ func buildAdmissionCheckMessage(slicesByState map[core.SliceState][]v1beta1.Slic
 		message = fmt.Sprintf("Slices are in states: %s", strings.Join(stateMessages, ", "))
 	}
 
-	if effectiveFailedCount > 0 {
+	hasStaleSlicesAsErrors := features.Enabled(features.UseRetryMechanismForSliceCreation) && len(slicesByState[core.SliceStateStale]) > 0
+
+	if effectiveFailedCount > 0 || hasStaleSlicesAsErrors {
 		var errMessages []string
 		for _, slice := range slicesByState[core.SliceStateFailed] {
 			cond := meta.FindStatusCondition(slice.Status.Conditions, v1beta1.SliceStateConditionType)
 			if cond != nil {
-				errMessages = append(errMessages, cond.Message)
+				errMessages = append(errMessages, fmt.Sprintf("%s: %s", slice.Name, cond.Message))
 			}
 		}
 		if features.Enabled(features.FailOnUntoleratedDegradedSlice) {
@@ -906,11 +908,22 @@ func buildAdmissionCheckMessage(slicesByState map[core.SliceState][]v1beta1.Slic
 					continue
 				}
 				if cond := meta.FindStatusCondition(slice.Status.Conditions, v1beta1.SliceStateConditionType); cond != nil {
-					errMessages = append(errMessages, fmt.Sprintf("%s (degraded)", cond.Message))
+					errMessages = append(errMessages, fmt.Sprintf("%s: %s (degraded)", slice.Name, cond.Message))
 				}
 			}
 		}
-		message += ". Errors: " + strings.Join(errMessages, "; ")
+		if hasStaleSlicesAsErrors {
+			for _, slice := range slicesByState[core.SliceStateStale] {
+				if cond := meta.FindStatusCondition(slice.Status.Conditions, v1beta1.SliceStateConditionType); cond != nil && cond.Message != "" {
+					errMessages = append(errMessages, fmt.Sprintf("%s: %s (stale)", slice.Name, cond.Message))
+				} else {
+					errMessages = append(errMessages, fmt.Sprintf("%s: stale", slice.Name))
+				}
+			}
+		}
+		if len(errMessages) > 0 {
+			message += ". Errors: " + strings.Join(errMessages, "; ")
+		}
 	}
 	return api.TruncateConditionMessage(message)
 }

--- a/slice/internal/controller/workload_controller.go
+++ b/slice/internal/controller/workload_controller.go
@@ -29,6 +29,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
@@ -190,7 +191,7 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	desiredSlicesCount := totalDesiredSlices(wl, nodes)
 	if ac.State == kueue.CheckStateReady && (len(grouped.deleted) > 0 || len(slices) != desiredSlicesCount) {
 		log.V(3).Info("Slice has been deleted, evicting workload")
-		if err := r.evictWorkload(ctx, wl, ac, "Slice has been deleted"); err != nil {
+		if err := r.evictWorkload(ctx, wl, ac, core.WorkloadSliceDeletion, "Slice has been deleted"); err != nil {
 			return ctrl.Result{}, err
 		}
 		return ctrl.Result{}, r.deleteSlicesForEvictedWorkload(ctx, grouped)
@@ -627,7 +628,7 @@ func (r *WorkloadReconciler) syncSlicesForAssignment(ctx context.Context, wl *ku
 		log := ctrl.LoggerFrom(ctx)
 		log.V(2).Info("Slice validation failed, not creating Slices, evicting the workload", "error", err)
 		msg := err.Error()
-		if patchErr := r.evictWorkload(ctx, wl, ac, msg); patchErr != nil {
+		if patchErr := r.evictWorkload(ctx, wl, ac, core.WorkloadSliceConfigurationFailure, msg); patchErr != nil {
 			return nil, nil, errors.Join(err, patchErr)
 		}
 		return nil, nil, errWorkloadEvicted
@@ -644,7 +645,7 @@ func (r *WorkloadReconciler) syncSlicesForAssignment(ctx context.Context, wl *ku
 			log.V(2).Info(fmt.Sprintf("Admission check %q updated state from %q to %q", ac.Name, ac.State, kueue.CheckStatePending), "reason", msg)
 			ac.State = kueue.CheckStatePending
 			ac.Message = api.TruncateConditionMessage(msg)
-			patchErr := r.updateWorkloadAdmissionCheckStatus(ctx, wl, ac)
+			patchErr := r.updateWorkloadAdmissionCheckStatus(ctx, wl, ac, "")
 			if patchErr != nil {
 				return nil, nil, errors.Join(err, patchErr)
 			}
@@ -720,16 +721,36 @@ func (r *WorkloadReconciler) validatePartitionCount(
 	return nil
 }
 
-func (r *WorkloadReconciler) evictWorkload(ctx context.Context, wl *kueue.Workload, ac *kueue.AdmissionCheckState, message string) error {
+func (r *WorkloadReconciler) evictWorkload(ctx context.Context, wl *kueue.Workload, ac *kueue.AdmissionCheckState, reason, message string) error {
 	ac.State = kueue.CheckStateRetry
 	ac.RequeueAfterSeconds = ptr.To(int32(r.retryDelayOnSliceFailure.Round(time.Second).Seconds()))
 	ac.Message = api.TruncateConditionMessage(message)
-	return r.updateWorkloadAdmissionCheckStatus(ctx, wl, ac)
+	return r.updateWorkloadAdmissionCheckStatus(ctx, wl, ac, reason)
 }
 
-func (r *WorkloadReconciler) updateWorkloadAdmissionCheckStatus(ctx context.Context, wl *kueue.Workload, ac *kueue.AdmissionCheckState) error {
+func (r *WorkloadReconciler) updateWorkloadAdmissionCheckStatus(ctx context.Context, wl *kueue.Workload, ac *kueue.AdmissionCheckState, evictedReason string) error {
 	wlPatch := workload.BaseSSAWorkload(wl, true)
 	workload.SetAdmissionCheckState(&wlPatch.Status.AdmissionChecks, *ac, r.clock)
+
+	if evictedReason != "" {
+		evictionCond := metav1.Condition{
+			Type:    core.WorkloadSliceFailureConditionType,
+			Status:  metav1.ConditionTrue,
+			Reason:  evictedReason,
+			Message: ac.Message,
+		}
+		apimeta.SetStatusCondition(&wlPatch.Status.Conditions, evictionCond)
+	} else if ac.State != kueue.CheckStateRetry {
+		if oldCond := apimeta.FindStatusCondition(wl.Status.Conditions, core.WorkloadSliceFailureConditionType); oldCond != nil {
+			apimeta.SetStatusCondition(&wlPatch.Status.Conditions, metav1.Condition{
+				Type:    core.WorkloadSliceFailureConditionType,
+				Status:  metav1.ConditionFalse,
+				Reason:  oldCond.Reason,
+				Message: api.TruncateConditionMessage("Previously: " + oldCond.Message),
+			})
+		}
+	}
+
 	//nolint:staticcheck //SA1019: client.Apply is deprecated
 	err := r.client.Status().Patch(ctx, wlPatch, client.Apply, client.FieldOwner(SliceControllerName), client.ForceOwnership)
 	if err != nil && !apierrors.IsNotFound(err) {
@@ -743,14 +764,14 @@ func (r *WorkloadReconciler) syncAdmissionCheckStatus(ctx context.Context, wl *k
 	originalState := ac.State
 	originalMessage := ac.Message
 
-	r.prepareAdmissionCheckStatus(ctx, wl, ac, slices, desiredSlicesCount)
+	evictedReason := r.prepareAdmissionCheckStatus(ctx, wl, ac, slices, desiredSlicesCount)
 
 	// No changes.
 	if originalState == ac.State && ac.Message == originalMessage {
 		return nil
 	}
 
-	if err := r.updateWorkloadAdmissionCheckStatus(ctx, wl, ac); err != nil {
+	if err := r.updateWorkloadAdmissionCheckStatus(ctx, wl, ac, evictedReason); err != nil {
 		return err
 	}
 
@@ -799,11 +820,11 @@ func calculateEffectiveSliceCounts(slicesByState map[core.SliceState][]v1beta1.S
 	return effectiveActiveCount, effectiveFailedCount
 }
 
-func (r *WorkloadReconciler) prepareAdmissionCheckStatus(ctx context.Context, wl *kueue.Workload, ac *kueue.AdmissionCheckState, slices []v1beta1.Slice, desiredSlicesCount int) {
+func (r *WorkloadReconciler) prepareAdmissionCheckStatus(ctx context.Context, wl *kueue.Workload, ac *kueue.AdmissionCheckState, slices []v1beta1.Slice, desiredSlicesCount int) string {
 	log := ctrl.LoggerFrom(ctx)
 	// wait for Kueue to reset check to Pending after eviction
 	if ac.State == kueue.CheckStateRetry {
-		return
+		return ""
 	}
 	slicesByState := core.GroupSlicesByState(slices, r.activationTimeout)
 	podSetRequiresHealthy := make(map[string]bool)
@@ -814,6 +835,7 @@ func (r *WorkloadReconciler) prepareAdmissionCheckStatus(ctx context.Context, wl
 	}
 	effectiveActiveCount, effectiveFailedCount := calculateEffectiveSliceCounts(slicesByState, wl, podSetRequiresHealthy)
 
+	var reason string
 	switch {
 	case desiredSlicesCount == effectiveActiveCount:
 		ac.State = kueue.CheckStateReady
@@ -821,6 +843,7 @@ func (r *WorkloadReconciler) prepareAdmissionCheckStatus(ctx context.Context, wl
 	case effectiveFailedCount > 0:
 		ac.State = kueue.CheckStateRetry
 		ac.RequeueAfterSeconds = ptr.To(int32(r.retryDelayOnSliceFailure.Round(time.Second).Seconds()))
+		reason = core.WorkloadSliceRuntimeFailure
 	case (features.Enabled(features.UseRetryMechanismForSliceCreation) && len(slicesByState[core.SliceStateStale]) > 0):
 		var staleSliceNames []string
 		for _, s := range slicesByState[core.SliceStateStale] {
@@ -830,10 +853,12 @@ func (r *WorkloadReconciler) prepareAdmissionCheckStatus(ctx context.Context, wl
 			"staleSlices", staleSliceNames)
 		ac.State = kueue.CheckStateRetry
 		ac.RequeueAfterSeconds = ptr.To(int32(r.retryDelayOnSliceFailure.Round(time.Second).Seconds()))
+		reason = core.WorkloadSliceFormationTimeout
 	default:
 		ac.State = kueue.CheckStatePending
 	}
 	ac.Message = buildAdmissionCheckMessage(slicesByState, effectiveFailedCount, wl, podSetRequiresHealthy)
+	return reason
 }
 
 func buildPodSetUpdates(wl *kueue.Workload) []kueue.PodSetUpdate {

--- a/slice/internal/controller/workload_controller.go
+++ b/slice/internal/controller/workload_controller.go
@@ -29,7 +29,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
-	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
@@ -739,11 +738,11 @@ func (r *WorkloadReconciler) updateWorkloadAdmissionCheckStatus(ctx context.Cont
 			Reason:  evictedReason,
 			Message: ac.Message,
 		}
-		apimeta.SetStatusCondition(&wlPatch.Status.Conditions, evictionCond)
+		meta.SetStatusCondition(&wlPatch.Status.Conditions, evictionCond)
 	} else if ac.State != kueue.CheckStateRetry {
-		oldCond := apimeta.FindStatusCondition(wl.Status.Conditions, core.WorkloadSliceFailureConditionType)
+		oldCond := meta.FindStatusCondition(wl.Status.Conditions, core.WorkloadSliceFailureConditionType)
 		if oldCond != nil && oldCond.Status == metav1.ConditionTrue {
-			apimeta.SetStatusCondition(&wlPatch.Status.Conditions, metav1.Condition{
+			meta.SetStatusCondition(&wlPatch.Status.Conditions, metav1.Condition{
 				Type:    core.WorkloadSliceFailureConditionType,
 				Status:  metav1.ConditionFalse,
 				Reason:  oldCond.Reason,

--- a/slice/internal/controller/workload_controller_test.go
+++ b/slice/internal/controller/workload_controller_test.go
@@ -1951,7 +1951,7 @@ func TestWorkloadReconciler(t *testing.T) {
 			},
 			wantResult: reconcile.Result{RequeueAfter: initializationRetryAfter},
 		},
-		"should set SliceFailure condition to False when slice are activating": {
+		"should set SliceFailure condition to False when slices are activating": {
 			request: baseRequest,
 			objs: []client.Object{
 				worker1Node.DeepCopy(),

--- a/slice/internal/controller/workload_controller_test.go
+++ b/slice/internal/controller/workload_controller_test.go
@@ -1923,7 +1923,7 @@ func TestWorkloadReconciler(t *testing.T) {
 					ReserveQuota(baseAdmission, now).
 					ControllerReference(jobSetGVK, baseJobSetName, baseJobSetName).
 					Finalizers(SliceControllerName).
-					SliceFailure(core.WorkloadSliceRuntimeFailure, "Slices are in states: 1 ACTIVE, 1 FAILED").
+					SliceFailure(core.WorkloadSliceRuntimeFailure, "Slices are in states: 1 ACTIVE, 1 FAILED. Errors: default-workload-ps2-0: Error by test").
 					Obj(),
 			},
 			wantWorkloads: []kueue.Workload{
@@ -1937,7 +1937,7 @@ func TestWorkloadReconciler(t *testing.T) {
 						Type:    core.WorkloadSliceFailureConditionType,
 						Status:  metav1.ConditionFalse,
 						Reason:  core.WorkloadSliceRuntimeFailure,
-						Message: "Previously: Slices are in states: 1 ACTIVE, 1 FAILED",
+						Message: "Previously: Slices are in states: 1 ACTIVE, 1 FAILED. Errors: default-workload-ps2-0: Error by test",
 					}).
 					Obj(),
 			},
@@ -1962,7 +1962,7 @@ func TestWorkloadReconciler(t *testing.T) {
 					ReserveQuota(baseAdmission, now).
 					ControllerReference(jobSetGVK, baseJobSetName, baseJobSetName).
 					Finalizers(SliceControllerName).
-					SliceFailure(core.WorkloadSliceRuntimeFailure, "Slices are in states: 1 ACTIVE, 1 FAILED").
+					SliceFailure(core.WorkloadSliceRuntimeFailure, "Slices are in states: 1 ACTIVE, 1 FAILED. Errors: default-workload-ps2-0: Error by test").
 					Obj(),
 				baseSlice1Wrapper.Clone().Activating().Obj(),
 				baseSlice2Wrapper.Clone().Activating().Obj(),
@@ -1978,7 +1978,7 @@ func TestWorkloadReconciler(t *testing.T) {
 						Type:    core.WorkloadSliceFailureConditionType,
 						Status:  metav1.ConditionFalse,
 						Reason:  core.WorkloadSliceRuntimeFailure,
-						Message: "Previously: Slices are in states: 1 ACTIVE, 1 FAILED",
+						Message: "Previously: Slices are in states: 1 ACTIVE, 1 FAILED. Errors: default-workload-ps2-0: Error by test",
 					}).
 					Obj(),
 			},
@@ -2000,7 +2000,7 @@ func TestWorkloadReconciler(t *testing.T) {
 					ControllerReference(jobSetGVK, baseJobSetName, baseJobSetName).
 					Finalizers(SliceControllerName).
 					AdmissionCheck(buildAdmissionCheckStateWithRequeue(kueue.CheckStateRetry, "retrying", ptr.To(int32(10)))).
-					SliceFailure(core.WorkloadSliceRuntimeFailure, "Slices are in states: 1 ACTIVE, 1 FAILED").
+					SliceFailure(core.WorkloadSliceRuntimeFailure, "Slices are in states: 1 ACTIVE, 1 FAILED. Errors: default-workload-ps2-0: Error by test").
 					Obj(),
 			},
 			wantWorkloads: []kueue.Workload{
@@ -2010,7 +2010,7 @@ func TestWorkloadReconciler(t *testing.T) {
 					ControllerReference(jobSetGVK, baseJobSetName, baseJobSetName).
 					Finalizers(SliceControllerName).
 					AdmissionCheck(buildAdmissionCheckStateWithRequeue(kueue.CheckStateRetry, "retrying", ptr.To(int32(10)))).
-					SliceFailure(core.WorkloadSliceRuntimeFailure, "Slices are in states: 1 ACTIVE, 1 FAILED").
+					SliceFailure(core.WorkloadSliceRuntimeFailure, "Slices are in states: 1 ACTIVE, 1 FAILED. Errors: default-workload-ps2-0: Error by test").
 					Obj(),
 			},
 		},

--- a/slice/internal/controller/workload_controller_test.go
+++ b/slice/internal/controller/workload_controller_test.go
@@ -59,6 +59,7 @@ var (
 		cmpopts.IgnoreFields(metav1.Condition{}, "LastTransitionTime"),
 		cmpopts.IgnoreFields(metav1.ObjectMeta{}, "CreationTimestamp"),
 		cmpopts.EquateApproxTime(time.Second),
+		cmpopts.SortSlices(func(a, b metav1.Condition) bool { return a.Type < b.Type }),
 	}
 	errTest = errors.New("test error")
 )
@@ -1071,6 +1072,7 @@ func TestWorkloadReconciler(t *testing.T) {
 					Finalizers(SliceControllerName).
 					AdmissionCheck(buildAdmissionCheckStateWithRequeue(kueue.CheckStateRetry,
 						`partition IDs ["subblock1 (used by default-workload-ps1-0)"] are already used by existing Slices`, ptr.To(int32(10)))).
+					SliceFailure(core.WorkloadSliceConfigurationFailure, `partition IDs ["subblock1 (used by default-workload-ps1-0)"] are already used by existing Slices`).
 					Obj(),
 			},
 			wantSlices: []slice.Slice{
@@ -1205,6 +1207,7 @@ func TestWorkloadReconciler(t *testing.T) {
 					Finalizers(SliceControllerName).
 					AdmissionCheck(buildAdmissionCheckStateWithRequeue(kueue.CheckStateRetry,
 						`incorrect number of partitions for slices: [default-workload-ps1-0]`, ptr.To(int32(10)))).
+					SliceFailure(core.WorkloadSliceConfigurationFailure, `incorrect number of partitions for slices: [default-workload-ps1-0]`).
 					Obj(),
 			},
 			wantResult: reconcile.Result{RequeueAfter: initializationRetryAfter},
@@ -1909,6 +1912,109 @@ func TestWorkloadReconciler(t *testing.T) {
 					fmt.Sprintf(`Admission check %q updated state from "Pending" to "Ready"`, baseACName)),
 			},
 		},
+		"should set SliceFailure condition to False when slices are recreated": {
+			request: baseRequest,
+			objs: []client.Object{
+				worker1Node.DeepCopy(),
+				worker2Node.DeepCopy(),
+				baseAdmissionCheckWrapper.DeepCopy(),
+				baseWorkloadWrapper.Clone().
+					PodSets(basePodSets...).
+					ReserveQuota(baseAdmission, now).
+					ControllerReference(jobSetGVK, baseJobSetName, baseJobSetName).
+					Finalizers(SliceControllerName).
+					SliceFailure(core.WorkloadSliceRuntimeFailure, "Slices are in states: 1 ACTIVE, 1 FAILED").
+					Obj(),
+			},
+			wantWorkloads: []kueue.Workload{
+				*baseWorkloadWrapper.Clone().
+					PodSets(basePodSets...).
+					ReserveQuota(baseAdmission, now).
+					ControllerReference(jobSetGVK, baseJobSetName, baseJobSetName).
+					Finalizers(SliceControllerName).
+					AdmissionCheck(buildAdmissionCheckState(kueue.CheckStatePending, `Slices are in states: 2 CREATED`)).
+					Condition(metav1.Condition{
+						Type:    core.WorkloadSliceFailureConditionType,
+						Status:  metav1.ConditionFalse,
+						Reason:  core.WorkloadSliceRuntimeFailure,
+						Message: "Previously: Slices are in states: 1 ACTIVE, 1 FAILED",
+					}).
+					Obj(),
+			},
+			wantSlices: []slice.Slice{
+				*baseSlice1Wrapper.DeepCopy(),
+				*baseSlice2Wrapper.DeepCopy(),
+			},
+			wantEvents: []utiltesting.EventRecord{
+				buildEventRecord(corev1.NamespaceDefault, corev1.EventTypeNormal, SlicesCreatedEventType,
+					`The Slices "default-workload-ps1-0", "default-workload-ps2-0" have been created`),
+			},
+			wantResult: reconcile.Result{RequeueAfter: initializationRetryAfter},
+		},
+		"should set SliceFailure condition to False when slice are activating": {
+			request: baseRequest,
+			objs: []client.Object{
+				worker1Node.DeepCopy(),
+				worker2Node.DeepCopy(),
+				baseAdmissionCheckWrapper.DeepCopy(),
+				baseWorkloadWrapper.Clone().
+					PodSets(basePodSets...).
+					ReserveQuota(baseAdmission, now).
+					ControllerReference(jobSetGVK, baseJobSetName, baseJobSetName).
+					Finalizers(SliceControllerName).
+					SliceFailure(core.WorkloadSliceRuntimeFailure, "Slices are in states: 1 ACTIVE, 1 FAILED").
+					Obj(),
+				baseSlice1Wrapper.Clone().Activating().Obj(),
+				baseSlice2Wrapper.Clone().Activating().Obj(),
+			},
+			wantWorkloads: []kueue.Workload{
+				*baseWorkloadWrapper.Clone().
+					PodSets(basePodSets...).
+					ReserveQuota(baseAdmission, now).
+					ControllerReference(jobSetGVK, baseJobSetName, baseJobSetName).
+					Finalizers(SliceControllerName).
+					AdmissionCheck(buildAdmissionCheckState(kueue.CheckStatePending, `Slices are in states: 2 ACTIVATING`)).
+					Condition(metav1.Condition{
+						Type:    core.WorkloadSliceFailureConditionType,
+						Status:  metav1.ConditionFalse,
+						Reason:  core.WorkloadSliceRuntimeFailure,
+						Message: "Previously: Slices are in states: 1 ACTIVE, 1 FAILED",
+					}).
+					Obj(),
+			},
+			wantSlices: []slice.Slice{
+				*baseSlice1Wrapper.Clone().Activating().Obj(),
+				*baseSlice2Wrapper.Clone().Activating().Obj(),
+			},
+			wantResult: reconcile.Result{RequeueAfter: initializationRetryAfter},
+		},
+		"should not reset SliceFailure condition to False when Admission Check remains Retry": {
+			request: baseRequest,
+			objs: []client.Object{
+				worker1Node.DeepCopy(),
+				worker2Node.DeepCopy(),
+				baseAdmissionCheckWrapper.DeepCopy(),
+				baseWorkloadWrapper.Clone().
+					PodSets(basePodSets...).
+					ReserveQuota(baseAdmission, now).
+					ControllerReference(jobSetGVK, baseJobSetName, baseJobSetName).
+					Finalizers(SliceControllerName).
+					AdmissionCheck(buildAdmissionCheckStateWithRequeue(kueue.CheckStateRetry, "retrying", ptr.To(int32(10)))).
+					SliceFailure(core.WorkloadSliceRuntimeFailure, "Slices are in states: 1 ACTIVE, 1 FAILED").
+					Obj(),
+			},
+			wantWorkloads: []kueue.Workload{
+				*baseWorkloadWrapper.Clone().
+					PodSets(basePodSets...).
+					ReserveQuota(baseAdmission, now).
+					ControllerReference(jobSetGVK, baseJobSetName, baseJobSetName).
+					Finalizers(SliceControllerName).
+					AdmissionCheck(buildAdmissionCheckStateWithRequeue(kueue.CheckStateRetry, "retrying", ptr.To(int32(10)))).
+					SliceFailure(core.WorkloadSliceRuntimeFailure, "Slices are in states: 1 ACTIVE, 1 FAILED").
+					Obj(),
+			},
+		},
+
 		"should update the Workload's AdmissionCheckState when one Slice is in the Ready state and another is in the Degraded state": {
 			request: baseRequest,
 			objs: []client.Object{
@@ -1977,6 +2083,7 @@ func TestWorkloadReconciler(t *testing.T) {
 					Finalizers(SliceControllerName).
 					AdmissionCheck(buildAdmissionCheckStateWithRequeue(kueue.CheckStateRetry,
 						`Slices are in states: 1 ACTIVE, 1 FAILED. Errors: Error by test`, ptr.To(int32(10)))).
+					SliceFailure(core.WorkloadSliceRuntimeFailure, `Slices are in states: 1 ACTIVE, 1 FAILED. Errors: Error by test`).
 					Obj(),
 			},
 			wantEvents: []utiltesting.EventRecord{
@@ -2035,6 +2142,7 @@ func TestWorkloadReconciler(t *testing.T) {
 					ControllerReference(jobSetGVK, baseJobSetName, baseJobSetName).
 					Finalizers(SliceControllerName).
 					AdmissionCheck(buildAdmissionCheckStateWithRequeue(kueue.CheckStateRetry, `Slices are in states: 1 ACTIVE, 1 STALE`, ptr.To(int32(10)))).
+					SliceFailure(core.WorkloadSliceFormationTimeout, `Slices are in states: 1 ACTIVE, 1 STALE`).
 					Obj(),
 			},
 			wantEvents: []utiltesting.EventRecord{
@@ -2065,6 +2173,7 @@ func TestWorkloadReconciler(t *testing.T) {
 					Finalizers(SliceControllerName).
 					AdmissionCheck(buildAdmissionCheckStateWithRequeue(kueue.CheckStateRetry,
 						"Slice has been deleted", ptr.To(int32(10)))).
+					SliceFailure(core.WorkloadSliceDeletion, "Slice has been deleted").
 					Obj(),
 			},
 		},
@@ -2092,6 +2201,7 @@ func TestWorkloadReconciler(t *testing.T) {
 					Finalizers(SliceControllerName).
 					AdmissionCheck(buildAdmissionCheckStateWithRequeue(kueue.CheckStateRetry,
 						"Slice has been deleted", ptr.To(int32(10)))).
+					SliceFailure(core.WorkloadSliceDeletion, "Slice has been deleted").
 					Obj(),
 			},
 			wantSlices: []slice.Slice{
@@ -2437,6 +2547,7 @@ func TestWorkloadReconciler(t *testing.T) {
 					Finalizers(SliceControllerName).
 					AdmissionCheck(buildAdmissionCheckStateWithRequeue(kueue.CheckStateRetry,
 						`Slices are in states: 1 ACTIVE, 1 ACTIVE_DEGRADED. Errors: Hardware failure (degraded)`, ptr.To(int32(10)))).
+					SliceFailure(core.WorkloadSliceRuntimeFailure, `Slices are in states: 1 ACTIVE, 1 ACTIVE_DEGRADED. Errors: Hardware failure (degraded)`).
 					Obj(),
 			},
 			wantJobSets: []jobset.JobSet{*baseJobSetWrapper.Clone().Obj()},

--- a/slice/internal/controller/workload_controller_test.go
+++ b/slice/internal/controller/workload_controller_test.go
@@ -2082,8 +2082,8 @@ func TestWorkloadReconciler(t *testing.T) {
 					ControllerReference(jobSetGVK, baseJobSetName, baseJobSetName).
 					Finalizers(SliceControllerName).
 					AdmissionCheck(buildAdmissionCheckStateWithRequeue(kueue.CheckStateRetry,
-						`Slices are in states: 1 ACTIVE, 1 FAILED. Errors: Error by test`, ptr.To(int32(10)))).
-					SliceFailure(core.WorkloadSliceRuntimeFailure, `Slices are in states: 1 ACTIVE, 1 FAILED. Errors: Error by test`).
+						`Slices are in states: 1 ACTIVE, 1 FAILED. Errors: default-workload-ps2-0: Error by test`, ptr.To(int32(10)))).
+					SliceFailure(core.WorkloadSliceRuntimeFailure, `Slices are in states: 1 ACTIVE, 1 FAILED. Errors: default-workload-ps2-0: Error by test`).
 					Obj(),
 			},
 			wantEvents: []utiltesting.EventRecord{
@@ -2141,8 +2141,8 @@ func TestWorkloadReconciler(t *testing.T) {
 					ReserveQuota(baseAdmission, now).
 					ControllerReference(jobSetGVK, baseJobSetName, baseJobSetName).
 					Finalizers(SliceControllerName).
-					AdmissionCheck(buildAdmissionCheckStateWithRequeue(kueue.CheckStateRetry, `Slices are in states: 1 ACTIVE, 1 STALE`, ptr.To(int32(10)))).
-					SliceFailure(core.WorkloadSliceFormationTimeout, `Slices are in states: 1 ACTIVE, 1 STALE`).
+					AdmissionCheck(buildAdmissionCheckStateWithRequeue(kueue.CheckStateRetry, `Slices are in states: 1 ACTIVE, 1 STALE. Errors: default-workload-ps2-0: Stale by test (stale)`, ptr.To(int32(10)))).
+					SliceFailure(core.WorkloadSliceFormationTimeout, `Slices are in states: 1 ACTIVE, 1 STALE. Errors: default-workload-ps2-0: Stale by test (stale)`).
 					Obj(),
 			},
 			wantEvents: []utiltesting.EventRecord{
@@ -2546,8 +2546,8 @@ func TestWorkloadReconciler(t *testing.T) {
 					ControllerReference(jobSetGVK, baseJobSetName, baseJobSetName).
 					Finalizers(SliceControllerName).
 					AdmissionCheck(buildAdmissionCheckStateWithRequeue(kueue.CheckStateRetry,
-						`Slices are in states: 1 ACTIVE, 1 ACTIVE_DEGRADED. Errors: Hardware failure (degraded)`, ptr.To(int32(10)))).
-					SliceFailure(core.WorkloadSliceRuntimeFailure, `Slices are in states: 1 ACTIVE, 1 ACTIVE_DEGRADED. Errors: Hardware failure (degraded)`).
+						`Slices are in states: 1 ACTIVE, 1 ACTIVE_DEGRADED. Errors: default-workload-ps1-0: Hardware failure (degraded)`, ptr.To(int32(10)))).
+					SliceFailure(core.WorkloadSliceRuntimeFailure, `Slices are in states: 1 ACTIVE, 1 ACTIVE_DEGRADED. Errors: default-workload-ps1-0: Hardware failure (degraded)`).
 					Obj(),
 			},
 			wantJobSets: []jobset.JobSet{*baseJobSetWrapper.Clone().Obj()},
@@ -2980,6 +2980,7 @@ func TestBuildAdmissionCheckMessage(t *testing.T) {
 	testCases := map[string]struct {
 		slicesByState         map[core.SliceState][]slice.Slice
 		effectiveFailedCount  int
+		enableRetryMechanism  bool
 		wl                    *kueue.Workload
 		podSetRequiresHealthy map[string]bool
 		want                  string
@@ -3015,12 +3016,27 @@ func TestBuildAdmissionCheckMessage(t *testing.T) {
 			effectiveFailedCount:  1,
 			wl:                    wl,
 			podSetRequiresHealthy: map[string]bool{},
-			want:                  "Slices are in states: 1 FAILED. Errors: Hardware failure",
+			want:                  "Slices are in states: 1 FAILED. Errors: slice1: Hardware failure",
+		},
+		"stale slices treated as failed": {
+			slicesByState: map[core.SliceState][]slice.Slice{
+				core.SliceStateStale: {
+					*utiltesting.MakeSliceWrapper("slice1").Obj(),
+				},
+			},
+			effectiveFailedCount:  0,
+			enableRetryMechanism:  true,
+			wl:                    wl,
+			podSetRequiresHealthy: map[string]bool{},
+			want:                  "Slices are in states: 1 STALE. Errors: slice1: stale",
 		},
 	}
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
+			if tc.enableRetryMechanism {
+				features.SetFeatureGateDuringTest(t, features.UseRetryMechanismForSliceCreation, true)
+			}
 			got := buildAdmissionCheckMessage(tc.slicesByState, tc.effectiveFailedCount, tc.wl, tc.podSetRequiresHealthy)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("Unexpected message (-want,+got):\n%s", diff)

--- a/slice/internal/core/constants.go
+++ b/slice/internal/core/constants.go
@@ -76,10 +76,17 @@ const (
 	LWSLeaderPodSetName = "leader"
 
 	WorkloadSliceFailureConditionType = "TPUSliceFailure"
-	WorkloadSliceDeletion             = "Deletion"
+
+	// WorkloadSliceDeletion indicates that the slice associated with the workload has been deleted
+	// (eg. manually with "kubectl delete").
+	WorkloadSliceDeletion = "Deletion"
+	// WorkloadSliceConfigurationFailure indicates a misconfiguration in the slice definition
+	// that prevents the slice from being created.
 	WorkloadSliceConfigurationFailure = "ConfigurationFailure"
-	WorkloadSliceRuntimeFailure       = "RuntimeFailure"
-	WorkloadSliceFormationTimeout     = "FormationTimeout"
+	// WorkloadSliceRuntimeFailure indicates a failure during the slice's operation.
+	WorkloadSliceRuntimeFailure = "RuntimeFailure"
+	// WorkloadSliceFormationTimeout indicates that the slice activation did not complete within the expected time.
+	WorkloadSliceFormationTimeout = "FormationTimeout"
 )
 
 var (

--- a/slice/internal/core/constants.go
+++ b/slice/internal/core/constants.go
@@ -75,7 +75,7 @@ const (
 
 	LWSLeaderPodSetName = "leader"
 
-	WorkloadSliceFailureConditionType = "SliceFailure"
+	WorkloadSliceFailureConditionType = "TPUSliceFailure"
 	WorkloadSliceDeletion             = "Deletion"
 	WorkloadSliceConfigurationFailure = "ConfigurationFailure"
 	WorkloadSliceRuntimeFailure       = "RuntimeFailure"

--- a/slice/internal/core/constants.go
+++ b/slice/internal/core/constants.go
@@ -74,6 +74,12 @@ const (
 	OwnerPodSetNameAnnotation        = "accelerator.gke.io/owner-podset-name"
 
 	LWSLeaderPodSetName = "leader"
+
+	WorkloadSliceFailureConditionType = "SliceFailure"
+	WorkloadSliceDeletion             = "Deletion"
+	WorkloadSliceConfigurationFailure = "ConfigurationFailure"
+	WorkloadSliceRuntimeFailure       = "RuntimeFailure"
+	WorkloadSliceFormationTimeout     = "FormationTimeout"
 )
 
 var (

--- a/slice/internal/util/testing/wrappers.go
+++ b/slice/internal/util/testing/wrappers.go
@@ -155,6 +155,23 @@ func (w *WorkloadWrapper) Evicted() *WorkloadWrapper {
 	return w
 }
 
+func (w *WorkloadWrapper) SliceFailure(reason, message string) *WorkloadWrapper {
+	cond := metav1.Condition{
+		Type:               core.WorkloadSliceFailureConditionType,
+		Status:             metav1.ConditionTrue,
+		LastTransitionTime: metav1.Now(),
+		Reason:             reason,
+		Message:            message,
+	}
+	apimeta.SetStatusCondition(&w.Status.Conditions, cond)
+	return w
+}
+
+func (w *WorkloadWrapper) Condition(cond metav1.Condition) *WorkloadWrapper {
+	apimeta.SetStatusCondition(&w.Status.Conditions, cond)
+	return w
+}
+
 func (w *WorkloadWrapper) Active(a bool) *WorkloadWrapper {
 	w.Spec.Active = ptr.To(a)
 	return w


### PR DESCRIPTION
# Description
<!--
Describe your change. 
What does it introduce?
Why do we need it?
If you are releasing a feature, have you updated documentation?
-->
When evicting the workload (by setting the admission check to Retry) due to some slice issue, we would like to specify the reason for eviction in a new dedicated workload condition. I identified 4 possible issues:
1. Slice runtime failure (slice in state FAILED).
2. Slice formation timeout. If slice does not get ACTIVE within the specified time despite the retry mechanism being on.
3. Slice deletion (eg. with `kubectl delete ...`)
4. Slice configuration issue (eg. number of cubes not matching the topology)


# Issue
<!--
Is there any related issue this change is trying to fix?
-->

# Testing
<!--
Have you performed any manual testing on your change?
Have you verified use cases affected by goldens?
-->
