### PR TITLE
xpk: add `xpk workload status` for team-routed workload diagnostics

### DIFF
--- a/recipes/Workload_create.md
+++ b/recipes/Workload_create.md
@@ -30,14 +30,16 @@ kubectl get configmap golden-cluster-resources-configmap -o=custom-columns="Conf
 [XPK] Task: `Upload Container Image` is implemented by the following command not running since it is a dry run. 
 crane mutate python:3.10 --append e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 --platform linux/amd64 --tag gcr.io/golden-project/dry-run-runner:prefix-current --workdir /app
 [XPK] Deleting container image archive e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-[XPK] Temp file (39eda1549f4c0d68a4f11e6cbd89ba655d49d2faeef6898a140f476e6e70ae0e) content: 
+[XPK] Temp file (6c836ab49434183bb0f726898c5fe816f7ed437079b90ed4ddfbd2d7c7a76e84) content: 
 apiVersion: jobset.x-k8s.io/v1alpha2
 kind: JobSet
 metadata:
   name: golden-workload
+  
   labels:
     kueue.x-k8s.io/queue-name: multislice-queue  # Name of the LocalQueue
     xpk.google.com/workload: golden-workload
+    
   annotations:
     alpha.jobset.sigs.k8s.io/exclusive-topology: cloud.google.com/gke-nodepool
 spec:
@@ -70,6 +72,7 @@ spec:
             metadata:
               labels:
                 xpk.google.com/workload: golden-workload
+                
               annotations:
                 
                 
@@ -139,7 +142,7 @@ spec:
               
 
 [XPK] Task: `Creating Workload` is implemented by the following command not running since it is a dry run. 
-kubectl apply -f 39eda1549f4c0d68a4f11e6cbd89ba655d49d2faeef6898a140f476e6e70ae0e
+kubectl apply -f 6c836ab49434183bb0f726898c5fe816f7ed437079b90ed4ddfbd2d7c7a76e84
 [XPK] Task: `GKE Dashboard List` is implemented by the following command not running since it is a dry run. 
 gcloud monitoring dashboards list --project=golden-project --filter="displayName:'GKE - TPU Monitoring Dashboard'" --format="value(name)" --verbosity=error
 [XPK] Check statistics and outlier mode of GKE metrics here: https://console.cloud.google.com/monitoring/dashboards/builder/0?project=golden-project&f.rlabel.cluster_name.ClusterName=golden-cluster. To view the metric data for your workload, select golden-workload from the JobName filter on the dashboard.

--- a/recipes/Workload_create_sub-slicing.md
+++ b/recipes/Workload_create_sub-slicing.md
@@ -34,14 +34,16 @@ kubectl get configmap golden-cluster-resources-configmap -o=custom-columns="Conf
 [XPK] Task: `Upload Container Image` is implemented by the following command not running since it is a dry run. 
 crane mutate python:3.10 --append e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 --platform linux/amd64 --tag gcr.io/golden-project/dry-run-runner:prefix-current --workdir /app
 [XPK] Deleting container image archive e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-[XPK] Temp file (2018fe16498f36301979a10667302a0aff6beb09956705b64ff396373af777ba) content: 
+[XPK] Temp file (7833616bd7d41bf12e4c54931e5c34fd465acc327fd31e91629ebd8d288c18b8) content: 
 apiVersion: jobset.x-k8s.io/v1alpha2
 kind: JobSet
 metadata:
   name: golden-workload
+  
   labels:
     kueue.x-k8s.io/queue-name: multislice-queue  # Name of the LocalQueue
     xpk.google.com/workload: golden-workload
+    
   annotations:
     
 spec:
@@ -74,6 +76,7 @@ spec:
             metadata:
               labels:
                 xpk.google.com/workload: golden-workload
+                
               annotations:
                 
                 kueue.x-k8s.io/podset-required-topology: "cloud.google.com/gke-tpu-slice-2x4-id"
@@ -144,7 +147,7 @@ spec:
               
 
 [XPK] Task: `Creating Workload` is implemented by the following command not running since it is a dry run. 
-kubectl apply -f 2018fe16498f36301979a10667302a0aff6beb09956705b64ff396373af777ba
+kubectl apply -f 7833616bd7d41bf12e4c54931e5c34fd465acc327fd31e91629ebd8d288c18b8
 [XPK] Task: `GKE Dashboard List` is implemented by the following command not running since it is a dry run. 
 gcloud monitoring dashboards list --project=golden-project --filter="displayName:'GKE - TPU Monitoring Dashboard'" --format="value(name)" --verbosity=error
 [XPK] Check statistics and outlier mode of GKE metrics here: https://console.cloud.google.com/monitoring/dashboards/builder/0?project=golden-project&f.rlabel.cluster_name.ClusterName=golden-cluster. To view the metric data for your workload, select golden-workload from the JobName filter on the dashboard.

--- a/recipes/Workload_create_super-slicing.md
+++ b/recipes/Workload_create_super-slicing.md
@@ -34,14 +34,16 @@ kubectl get configmap golden-cluster-resources-configmap -o=custom-columns="Conf
 [XPK] Task: `Upload Container Image` is implemented by the following command not running since it is a dry run. 
 crane mutate python:3.10 --append e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 --platform linux/amd64 --tag gcr.io/golden-project/dry-run-runner:prefix-current --workdir /app
 [XPK] Deleting container image archive e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-[XPK] Temp file (608e1382aabe2b0335855e5e99876a2e67de954453ebfa4cf12eb82c966f85da) content: 
+[XPK] Temp file (11bdd9d57ce9cce06793e06a03f51eafdeb896fa93ecd0d93c81b0924eee2c95) content: 
 apiVersion: jobset.x-k8s.io/v1alpha2
 kind: JobSet
 metadata:
   name: golden-workload
+  
   labels:
     kueue.x-k8s.io/queue-name: multislice-queue  # Name of the LocalQueue
     xpk.google.com/workload: golden-workload
+    
   annotations:
     
 spec:
@@ -80,6 +82,7 @@ spec:
             metadata:
               labels:
                 xpk.google.com/workload: golden-workload
+                
               annotations:
                 
                 
@@ -184,7 +187,7 @@ spec:
               
 
 [XPK] Task: `Creating Workload` is implemented by the following command not running since it is a dry run. 
-kubectl apply -f 608e1382aabe2b0335855e5e99876a2e67de954453ebfa4cf12eb82c966f85da
+kubectl apply -f 11bdd9d57ce9cce06793e06a03f51eafdeb896fa93ecd0d93c81b0924eee2c95
 [XPK] Task: `GKE Dashboard List` is implemented by the following command not running since it is a dry run. 
 gcloud monitoring dashboards list --project=golden-project --filter="displayName:'GKE - TPU Monitoring Dashboard'" --format="value(name)" --verbosity=error
 [XPK] Check statistics and outlier mode of GKE metrics here: https://console.cloud.google.com/monitoring/dashboards/builder/0?project=golden-project&f.rlabel.cluster_name.ClusterName=golden-cluster. To view the metric data for your workload, select golden-workload from the JobName filter on the dashboard.

--- a/recipes/Workload_create_with_output-manifest-file.md
+++ b/recipes/Workload_create_with_output-manifest-file.md
@@ -31,14 +31,16 @@ kubectl get configmap golden-cluster-resources-configmap -o=custom-columns="Conf
 crane mutate python:3.10 --append e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 --platform linux/amd64 --tag gcr.io/golden-project/dry-run-runner:prefix-current --workdir /app
 [XPK] Deleting container image archive e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 [XPK] Workload golden-workload manifest written to /var/tmp/manifest.yaml
-[XPK] Temp file (39eda1549f4c0d68a4f11e6cbd89ba655d49d2faeef6898a140f476e6e70ae0e) content: 
+[XPK] Temp file (6c836ab49434183bb0f726898c5fe816f7ed437079b90ed4ddfbd2d7c7a76e84) content: 
 apiVersion: jobset.x-k8s.io/v1alpha2
 kind: JobSet
 metadata:
   name: golden-workload
+  
   labels:
     kueue.x-k8s.io/queue-name: multislice-queue  # Name of the LocalQueue
     xpk.google.com/workload: golden-workload
+    
   annotations:
     alpha.jobset.sigs.k8s.io/exclusive-topology: cloud.google.com/gke-nodepool
 spec:
@@ -71,6 +73,7 @@ spec:
             metadata:
               labels:
                 xpk.google.com/workload: golden-workload
+                
               annotations:
                 
                 
@@ -140,7 +143,7 @@ spec:
               
 
 [XPK] Task: `Creating Workload` is implemented by the following command not running since it is a dry run. 
-kubectl apply -f 39eda1549f4c0d68a4f11e6cbd89ba655d49d2faeef6898a140f476e6e70ae0e
+kubectl apply -f 6c836ab49434183bb0f726898c5fe816f7ed437079b90ed4ddfbd2d7c7a76e84
 [XPK] Task: `GKE Dashboard List` is implemented by the following command not running since it is a dry run. 
 gcloud monitoring dashboards list --project=golden-project --filter="displayName:'GKE - TPU Monitoring Dashboard'" --format="value(name)" --verbosity=error
 [XPK] Check statistics and outlier mode of GKE metrics here: https://console.cloud.google.com/monitoring/dashboards/builder/0?project=golden-project&f.rlabel.cluster_name.ClusterName=golden-cluster. To view the metric data for your workload, select golden-workload from the JobName filter on the dashboard.

--- a/src/xpk/commands/workload.py
+++ b/src/xpk/commands/workload.py
@@ -27,7 +27,7 @@ from ..core.cluster import (
     get_cluster_credentials,
     setup_k8s_env,
 )
-from ..core.commands import run_command_with_updates, run_commands
+from ..core.commands import run_command_with_updates, run_commands, run_command_for_value
 from ..core.config import (VERTEX_TENSORBOARD_FEATURE_FLAG, XPK_CURRENT_VERSION)
 from ..core.docker_container import (
     get_main_container_docker_image,
@@ -1074,5 +1074,296 @@ def workload_list(args) -> None:
 
   workload_list_gcp_link = get_jobsets_list_gcp_link(project=args.project)
   xpk_print(f'See your workloads in Cloud Console: {workload_list_gcp_link}')
+
+  xpk_exit(0)
+
+
+# ---------------------------------------------------------------------------
+# workload status — PoC queue health diagnostic
+# ---------------------------------------------------------------------------
+
+def workload_status(args) -> None:
+  """Show PoC Kueue queue status for a workload or an entire team namespace.
+
+  Tells the user if their workload is running, queued normally, or stuck,
+  and provides a plain-English diagnosis with fix instructions.
+
+  Args:
+    args: user provided arguments (--cluster, --team, --workload).
+  """
+  import json as _json
+  from datetime import datetime, timezone
+
+  import subprocess as _subprocess
+
+  if should_validate_dependencies(args):
+    validate_dependencies_list(
+        args, [SystemDependency.KUBECTL, SystemDependency.GCLOUD]
+    )
+
+  # Fill project from gcloud config if not provided.
+  if not getattr(args, 'project', None):
+    r = _subprocess.run(
+        ['gcloud', 'config', 'get', 'project'], capture_output=True, text=True
+    )
+    args.project = r.stdout.strip().splitlines()[-1] if r.returncode == 0 else ''
+  if not args.project:
+    xpk_print('ERROR: --project not set and could not be determined from gcloud config.')
+    xpk_exit(1)
+
+  # Look up the cluster location directly — avoids requiring compute/zone in
+  # gcloud config (which get_cluster_credentials needs but users often lack).
+  if not getattr(args, 'zone', None):
+    rc, loc = run_command_for_value(
+        f'gcloud container clusters list --project={args.project}'
+        f' --filter=name={args.cluster} --format="value(location)"',
+        task='Find cluster location',
+        quiet=True,
+    )
+    if rc != 0 or not loc.strip():
+      xpk_print(f'ERROR: Could not find cluster "{args.cluster}" in project {args.project}.')
+      xpk_exit(1)
+    args.zone = loc.strip()
+
+  get_cluster_credentials(args)
+
+  team = args.team
+  namespace, _lq, _pc = POC_TEAM_CONFIG[team]
+  cq_name = namespace  # ClusterQueue name matches namespace name
+
+  # ------------------------------------------------------------------
+  # Internal helpers (no --context needed; xpk sets up kubeconfig)
+  # ------------------------------------------------------------------
+
+  def _kube_json(*kubectl_args):
+    cmd = 'kubectl ' + ' '.join(kubectl_args) + ' -o json'
+    rc, out = run_command_for_value(cmd, task=cmd, quiet=True)
+    if rc != 0 or not out:
+      return None
+    try:
+      return _json.loads(out)
+    except _json.JSONDecodeError:
+      return None
+
+  def _events_text(ns, name):
+    cmd = (
+        f'kubectl get events -n {ns}'
+        f' --field-selector involvedObject.name={name}'
+        f' --sort-by=.lastTimestamp'
+    )
+    rc, out = run_command_for_value(cmd, task='get events', quiet=True)
+    return out.strip() if rc == 0 else ''
+
+  def _age(ts_str):
+    if not ts_str:
+      return '?'
+    ts = datetime.fromisoformat(ts_str.replace('Z', '+00:00'))
+    s = int((datetime.now(timezone.utc) - ts).total_seconds())
+    if s < 60:
+      return f'{s}s'
+    if s < 3600:
+      return f'{s // 60}m'
+    return f'{s // 3600}h{(s % 3600) // 60}m'
+
+  def _cond(wl, ctype):
+    for c in wl.get('status', {}).get('conditions', []):
+      if c.get('type') == ctype:
+        return c
+    return None
+
+  def _is_true(c):
+    return c is not None and c.get('status') == 'True'
+
+  def _cq_chips(cq, section):
+    total = 0
+    for flavor in cq.get('status', {}).get(section, []):
+      for res in flavor.get('resources', []):
+        if res.get('name') == 'google.com/tpu':
+          total += int(res.get('total', 0))
+    return total
+
+  def _cq_quota(cq):
+    nominal, borrow = 0, 0
+    for rg in cq.get('spec', {}).get('resourceGroups', []):
+      for flavor in rg.get('flavors', []):
+        for res in flavor.get('resources', []):
+          if res.get('name') == 'google.com/tpu':
+            nominal += int(res.get('nominalQuota', 0))
+            b = res.get('borrowingLimit')
+            if b is not None:
+              borrow += int(b)
+    return nominal, borrow
+
+  def _ordinal(n):
+    return f"{n}{['th','st','nd','rd','th'][min(n % 10, 4) if n % 100 not in (11,12,13) else 0]}"
+
+  def _xpk_name_of(wl):
+    name = wl['metadata'].get('labels', {}).get('xpk.google.com/workload')
+    if name:
+      return name
+    for ref in wl['metadata'].get('ownerReferences', []):
+      if ref.get('kind') in ('JobSet', 'Job'):
+        return ref.get('name', '')
+    n = wl['metadata']['name']
+    if n.startswith('jobset-'):
+      n = n[len('jobset-'):]
+    if len(n) > 6 and n[-6] == '-':
+      n = n[:-6]
+    return n
+
+  def _print_cq_summary(cq):
+    if not cq:
+      return
+    st = cq.get('status', {})
+    nominal, borrow_limit = _cq_quota(cq)
+    running_chips  = _cq_chips(cq, 'flavorsUsage')
+    reserved_chips = _cq_chips(cq, 'flavorsReservation')
+    admitted   = st.get('admittedWorkloads', 0)
+    reserving  = st.get('reservingWorkloads', 0)
+    pending    = st.get('pendingWorkloads', 0)
+    xpk_print(f'  Quota   : {nominal} chips nominal  +{borrow_limit} borrow  ='
+              f' {nominal + borrow_limit} max')
+    if reserved_chips > 0 and reserved_chips != running_chips:
+      xpk_print(f'  Reserved: {reserved_chips} chips'
+                f' ({reserving} workload(s) — quota held, awaiting admission)')
+    xpk_print(f'  Running : {running_chips} chips ({admitted} workload(s) admitted)')
+    xpk_print(f'  Queued  : {pending} workload(s) waiting for quota')
+
+  def _diagnose_one(wl, all_items, cq):
+    kueue_name = wl['metadata']['name']
+    xpk_name   = _xpk_name_of(wl)
+    created_at = wl['metadata']['creationTimestamp']
+
+    cond_reserved = _cond(wl, 'QuotaReserved')
+    cond_admitted = _cond(wl, 'Admitted')
+    cond_finished = _cond(wl, 'Finished')
+
+    is_admitted = _is_true(cond_admitted)
+    is_reserved = _is_true(cond_reserved)
+    is_finished = _is_true(cond_finished)
+    finish_reason = cond_finished.get('reason', '') if cond_finished else ''
+
+    xpk_print(f'Workload : {xpk_name}  ->  {kueue_name}')
+    xpk_print(f'Age      : {_age(created_at)}')
+
+    if is_finished:
+      status_word = 'success' if finish_reason == 'Succeeded' else finish_reason
+      xpk_print(f'Status   : FINISHED ({status_word})')
+      msg = (cond_finished or {}).get('message', '')
+      if msg:
+        xpk_print(f'           {msg}')
+      xpk_print('')
+      return
+
+    if is_admitted:
+      admitted_ts = (cond_admitted or {}).get('lastTransitionTime', '')
+      xpk_print(f'Status   : RUNNING  (admitted {_age(admitted_ts)} ago)')
+      xpk_print(f'Team quota ({cq_name}):')
+      _print_cq_summary(cq)
+      xpk_print('')
+      return
+
+    if is_reserved:
+      reserved_ts = (cond_reserved or {}).get('lastTransitionTime', '')
+      xpk_print(f'Status   : STUCK — quota reserved but not admitted ({_age(reserved_ts)} ago)')
+      xpk_print(f'Team quota ({cq_name}):')
+      _print_cq_summary(cq)
+      events = _events_text(namespace, kueue_name)
+      warn = [l for l in events.splitlines()
+              if any(w in l for w in ('Warning', 'Error', 'Failed', 'error', 'failed'))]
+      if warn:
+        xpk_print('Diagnosis: AdmissionCheck failed. Error(s):')
+        for line in warn[-3:]:
+          xpk_print(f'  {line.strip()}')
+        if 'more than 49 characters' in events:
+          import re
+          m = re.search(r'"([^"]*-slice-job-\d+)"', events)
+          max_len = 23 - len(namespace)
+          xpk_print(f'')
+          xpk_print(f'  Fix: --workload name "{xpk_name}" ({len(xpk_name)} chars)'
+                    f' exceeds the {max_len}-char limit for {namespace}.')
+          xpk_print(f'       Delete the JobSet and resubmit with a name <= {max_len} chars.')
+          xpk_print(f'       Example: {xpk_name[:max_len]}')
+      else:
+        xpk_print('Diagnosis: AdmissionCheck still processing (no errors yet).')
+        xpk_print(f'  kubectl describe workload {kueue_name} -n {namespace}')
+      xpk_print('')
+      return
+
+    # Queued — compute position
+    my_ts  = created_at
+    my_pri = wl.get('spec', {}).get('priority') or 0
+    ahead = []
+    for other in all_items:
+      oname = other['metadata']['name']
+      if oname == kueue_name:
+        continue
+      if _is_true(_cond(other, 'Admitted')) or _is_true(_cond(other, 'Finished')):
+        continue
+      if _is_true(_cond(other, 'QuotaReserved')):
+        continue
+      other_ts  = other['metadata']['creationTimestamp']
+      other_pri = other.get('spec', {}).get('priority') or 0
+      if other_pri > my_pri or (other_pri == my_pri and other_ts < my_ts):
+        ahead.append(_xpk_name_of(other))
+
+    pos = len(ahead) + 1
+    xpk_print(f'Status   : QUEUED — waiting for quota')
+    if ahead:
+      sample = ', '.join(ahead[:3]) + ('...' if len(ahead) > 3 else '')
+      xpk_print(f'Position : {_ordinal(pos)} in line  ({len(ahead)} workload(s) ahead: {sample})')
+    else:
+      xpk_print(f'Position : {_ordinal(pos)} in line  (nothing ahead of you in this queue)')
+    xpk_print(f'Team quota ({cq_name}):')
+    _print_cq_summary(cq)
+
+    # Anomaly detection
+    st = (cq or {}).get('status', {})
+    nominal, _ = _cq_quota(cq) if cq else (0, 0)
+    running = _cq_chips(cq, 'flavorsUsage') if cq else 0
+    if pos == 1 and st.get('admittedWorkloads', 0) == 0 and running == 0 and nominal > 0:
+      xpk_print('Diagnosis: You\'re 1st in line with quota available but nothing running.')
+      xpk_print(f'  This is unusual. Check: kubectl describe workload {kueue_name} -n {namespace}')
+    elif pos == 1 and nominal > 0 and running < nominal * 0.9:
+      xpk_print(f'Diagnosis: You\'re 1st in line and quota is not full — should be admitted soon.')
+      xpk_print(f'  If still queued in a few minutes, check:')
+      xpk_print(f'  kubectl describe workload {kueue_name} -n {namespace}')
+    else:
+      xpk_print('Diagnosis: Things look normal — waiting behind other workloads.')
+    xpk_print('')
+
+  # ------------------------------------------------------------------
+  # Fetch data and run diagnostics
+  # ------------------------------------------------------------------
+  cq = _kube_json('get', 'clusterqueue', cq_name)
+  all_wl_data = _kube_json('get', 'workload', '-n', namespace)
+  all_items = all_wl_data.get('items', []) if all_wl_data else []
+
+  if args.workload:
+    prefix = f'jobset-{args.workload}-'
+    matches = [i for i in all_items if i['metadata']['name'].startswith(prefix)]
+    if not matches:
+      xpk_print(f'No workload found matching "{prefix}*" in {namespace}')
+      xpk_exit(1)
+    if len(matches) > 1:
+      names = [i['metadata']['name'] for i in matches]
+      xpk_print(f'Multiple matches: {names}. Use the full Kueue name with --workload.')
+      xpk_exit(1)
+    _diagnose_one(matches[0], all_items, cq)
+  else:
+    if not all_items:
+      xpk_print(f'No workloads in {namespace} — queue is empty.')
+      xpk_print(f'Team quota ({cq_name}):')
+      if cq:
+        nominal, borrow = _cq_quota(cq)
+        xpk_print(f'  Quota: {nominal} chips nominal  +{borrow} borrow  = {nominal + borrow} max')
+      xpk_exit(0)
+
+    def _sort_key(i):
+      return (0 if _is_true(_cond(i, 'Admitted')) else 1,
+              i['metadata']['creationTimestamp'])
+
+    for item in sorted(all_items, key=_sort_key):
+      _diagnose_one(item, all_items, cq)
 
   xpk_exit(0)

--- a/src/xpk/commands/workload.py
+++ b/src/xpk/commands/workload.py
@@ -34,12 +34,12 @@ from ..core.docker_container import (
     get_user_workload_container,
 )
 from ..core.kueue_manager import LOCAL_QUEUE_NAME, derive_k8s_workload_name
-from ..core.poc_discovery import (
+from ..core.quota_discovery import (
     CONFIG_CM_NAME,
     CONFIG_CM_NAMESPACE,
     available_teams,
     available_value_classes,
-    fetch_poc_config,
+    fetch_quota_config,
     max_k8s_workload_name_len,
     resolve_team,
     suggest,
@@ -116,21 +116,26 @@ _PATHWAYS_WORKLOAD_TEMPLATE = 'pathways_workload_create.yaml.j2'
 _SUPER_SLICING_WORKLOAD_NAME_LIMIT = 28
 
 
-def _load_poc_cfg(args) -> dict | None:
-  """Fetch the PoC ConfigMap once per invocation and cache on args. Returns
-  None if --team is unset (so upstream, non-PoC behavior is preserved)."""
-  if not getattr(args, 'team', None):
+def _load_quota_cfg(args) -> dict | None:
+  """Fetch the team-quota ConfigMap once per invocation and cache on args.
+
+  Returns None if --team is unset (so upstream, non-team-routing behavior is
+  preserved). Robust against unit-test code that passes a MagicMock for args:
+  we require args.team to be a non-empty string, not just truthy.
+  """
+  team = getattr(args, 'team', None)
+  if not isinstance(team, str) or not team.strip():
     return None
-  cached = getattr(args, '_poc_cfg', None)
+  cached = getattr(args, '_quota_cfg', None)
   if cached is not None:
     return cached
-  cfg = fetch_poc_config()
+  cfg = fetch_quota_config()
   if cfg is None:
     xpk_print(
-        f'ERROR: --team={args.team!r} requires the PoC ConfigMap'
+        f'ERROR: --team={args.team!r} requires the team-quota ConfigMap'
         f' "{CONFIG_CM_NAMESPACE}/{CONFIG_CM_NAME}" on the target cluster.'
-        ' Deploy cluster-management/poc/chart first, or drop --team to bypass'
-        ' PoC routing.'
+        ' Deploy the cluster quota chart first, or drop --team to bypass'
+        ' team-based routing.'
     )
     xpk_exit(1)
   if args.team not in (cfg.get('teams') or {}):
@@ -152,23 +157,34 @@ def _load_poc_cfg(args) -> dict | None:
           f'{hint_line} Available: {", ".join(vcs)}'
       )
       xpk_exit(1)
-  args._poc_cfg = cfg
+  args._quota_cfg = cfg
   return cfg
 
 
-def _resolve_poc_team(args) -> tuple[str, str, str]:
-  """Return (namespace, local_queue_name, priority_class) for --team, or defaults."""
-  cfg = _load_poc_cfg(args)
+def _resolve_quota_team(args):
+  """Return TeamRouting for --team, or upstream defaults wrapped equivalently.
+
+  When --team is unset, returns an empty namespace and the upstream
+  LOCAL_QUEUE_NAME / args.priority so callers can format the YAML uniformly.
+  """
+  cfg = _load_quota_cfg(args)
   if cfg is None:
-    return ('', LOCAL_QUEUE_NAME, args.priority)
+    # Mimic the dataclass shape so callers can use attribute access uniformly.
+    from ..core.quota_discovery import TeamRouting
+    return TeamRouting(namespace='', local_queue=LOCAL_QUEUE_NAME, priority_class=args.priority)
   return resolve_team(cfg, args.team)
 
 
-def _build_poc_labels(args) -> str:
-  """Return YAML label lines for PoC quota labels, or empty string."""
-  if not getattr(args, 'team', None):
+def _build_team_labels(args) -> str:
+  """Return YAML label lines for team-routing labels, or empty string.
+
+  These labels are read by the cluster-side time-limit and quota controllers
+  to enforce per-team duration caps and value-class accounting.
+  """
+  team = getattr(args, 'team', None)
+  if not isinstance(team, str) or not team.strip():
     return ''
-  lines = [f'team: {args.team}']
+  lines = [f'team: {team}']
   if getattr(args, 'value_class', None):
     lines.append(f'value-class: {args.value_class}')
   if getattr(args, 'declared_duration_minutes', None) is not None:
@@ -177,14 +193,15 @@ def _build_poc_labels(args) -> str:
   return ('\n    ').join(lines)
 
 
-def _build_poc_pod_template_labels(args) -> str:
-  """Return YAML label lines for PoC labels that must appear in pod template.
+def _build_team_pod_template_labels(args) -> str:
+  """Return YAML label lines for team labels that must appear in pod template.
 
   Kueue does NOT propagate arbitrary JobSet metadata labels to the Workload
   object, so the time-limit controller reads declared-duration-minutes from
   spec.podSets[*].template.metadata.labels instead.
   """
-  if not getattr(args, 'team', None):
+  team = getattr(args, 'team', None)
+  if not isinstance(team, str) or not team.strip():
     return ''
   if getattr(args, 'declared_duration_minutes', None) is None:
     return ''
@@ -206,7 +223,7 @@ metadata:
   labels:
     kueue.x-k8s.io/queue-name: {local_queue_name}  # Name of the LocalQueue
     xpk.google.com/workload: {args.workload}
-    {poc_labels}
+    {team_labels}
   annotations:
     {jobset_annotations}
 spec:
@@ -227,7 +244,7 @@ spec:
             metadata:
               labels:
                 xpk.google.com/workload: {args.workload}
-                {poc_pod_template_labels}
+                {team_pod_template_labels}
               annotations:
                 {storage_annotations}
                 {sub_slicing_annotations}
@@ -486,8 +503,8 @@ def workload_create(args) -> None:
     k8s_api_client = setup_k8s_env(args)
     setup_k8s_service_accounts()
 
-  # Default PoC routing values; the TPU non-pathways path below may override.
-  poc_namespace = ''
+  # Default team-routing values; the TPU non-pathways path below may override.
+  team_namespace = ''
   k8s_name = args.workload
 
   workload_exists = check_if_workload_exists(args)
@@ -567,10 +584,11 @@ def workload_create(args) -> None:
 
   parse_env_config(args, tensorboard_config)
 
-  # For PoC teams, inject the user's full display name as XPK_WORKLOAD_NAME so
-  # training scripts can reference it for GCS artifact paths regardless of the
-  # short K8s name xpk derives for the JobSet.
-  if getattr(args, 'team', None):
+  # When --team is set, inject the user's full display name as XPK_WORKLOAD_NAME
+  # so training scripts can reference it for GCS artifact paths regardless of
+  # the (potentially shortened) K8s name xpk derives for the JobSet.
+  team = getattr(args, 'team', None)
+  if isinstance(team, str) and team.strip():
     args.env.setdefault('XPK_WORKLOAD_NAME', args.workload)
 
   autoprovisioning_args = ''
@@ -848,16 +866,29 @@ def workload_create(args) -> None:
         args, workload_system, parallel_containers
     )
 
-    poc_namespace, poc_local_queue, poc_priority = _resolve_poc_team(args)
-    # Derive a short K8s-safe JobSet name for PoC teams; use display name as-is otherwise.
-    if poc_namespace:
-      max_len = max_k8s_workload_name_len(args._poc_cfg, poc_namespace)
-      k8s_name = derive_k8s_workload_name(args.workload, max_len)
-      args.priority = poc_priority
-      xpk_print(
-          f'PoC workload "{args.workload}" → K8s JobSet name: "{k8s_name}"'
-          f' (use $XPK_WORKLOAD_NAME in your command for GCS artifact paths)'
-      )
+    routing = _resolve_quota_team(args)
+    team_namespace = routing.namespace
+    # Derive a short K8s-safe JobSet name when the workload is routed to a
+    # team namespace AND the user-facing workload name exceeds the
+    # super-slice admission controller's per-name budget. See
+    # core.kueue_manager.derive_k8s_workload_name and
+    # core.quota_discovery.max_k8s_workload_name_len for the budget math.
+    # The user can disable shortening with --no-shorten-jobset-name.
+    if team_namespace:
+      max_len = max_k8s_workload_name_len(args._quota_cfg, team_namespace)
+      shorten = not getattr(args, 'no_shorten_jobset_name', False)
+      if shorten:
+        k8s_name = derive_k8s_workload_name(args.workload, max_len)
+      else:
+        k8s_name = args.workload
+      args.priority = routing.priority_class
+      if k8s_name != args.workload:
+        xpk_print(
+            f'workload "{args.workload}" → K8s JobSet name: "{k8s_name}"'
+            f' (shortened to fit super-slice charLimit; use'
+            f' $XPK_WORKLOAD_NAME in your command for GCS artifact paths;'
+            f' pass --no-shorten-jobset-name to disable)'
+        )
     else:
       k8s_name = args.workload
     yml_string = WORKLOAD_CREATE_YAML.format(
@@ -878,10 +909,10 @@ def workload_create(args) -> None:
         placement_policy_label=placement_policy_label,
         node_selector_machine_label=node_selector_machine_label,
         tpu_slice_topology_annotation=tpu_slice_topology_annotation,
-        local_queue_name=poc_local_queue,
-        namespace_field=f'namespace: {poc_namespace}' if poc_namespace else '',
-        poc_labels=_build_poc_labels(args),
-        poc_pod_template_labels=_build_poc_pod_template_labels(args),
+        local_queue_name=routing.local_queue,
+        namespace_field=f'namespace: {team_namespace}' if team_namespace else '',
+        team_labels=_build_team_labels(args),
+        team_pod_template_labels=_build_team_pod_template_labels(args),
         autoprovisioning_args=autoprovisioning_args,
         volumes=get_volumes(args, workload_system),
         storage_annotations=('\n' + (' ' * 16)).join(
@@ -965,9 +996,11 @@ def workload_create(args) -> None:
         f'{get_pathways_unified_query_link(args)}'
     )
   else:
-    # PoC teams route to a per-team namespace and use a short K8s JobSet name
-    # derived from args.workload. Fall back to upstream defaults otherwise.
-    log_namespace = poc_namespace or 'default'
+    # When --team is in use, the workload routes to a per-team namespace and
+    # the K8s JobSet name may be shortened from args.workload. Use those
+    # actual values for the dashboard / Cloud Logging URLs so links land on
+    # the right resource. Falls back to upstream defaults otherwise.
+    log_namespace = team_namespace or 'default'
     log_pod_prefix = k8s_name
     xpk_print(
         'Follow your workload here:'
@@ -1144,292 +1177,3 @@ def workload_list(args) -> None:
   xpk_exit(0)
 
 
-# ---------------------------------------------------------------------------
-# workload status — PoC queue health diagnostic
-# ---------------------------------------------------------------------------
-
-def workload_status(args) -> None:
-  """Show PoC Kueue queue status for a workload or an entire team namespace.
-
-  Tells the user if their workload is running, queued normally, or stuck,
-  and provides a plain-English diagnosis with fix instructions.
-
-  Args:
-    args: user provided arguments (--cluster, --team, --workload).
-  """
-  import json as _json
-  from datetime import datetime, timezone
-
-  import subprocess as _subprocess
-
-  if should_validate_dependencies(args):
-    validate_dependencies_list(
-        args, [SystemDependency.KUBECTL, SystemDependency.GCLOUD]
-    )
-
-  # Fill project from gcloud config if not provided.
-  if not getattr(args, 'project', None):
-    r = _subprocess.run(
-        ['gcloud', 'config', 'get', 'project'], capture_output=True, text=True
-    )
-    args.project = r.stdout.strip().splitlines()[-1] if r.returncode == 0 else ''
-  if not args.project:
-    xpk_print('ERROR: --project not set and could not be determined from gcloud config.')
-    xpk_exit(1)
-
-  # Look up the cluster location directly — avoids requiring compute/zone in
-  # gcloud config (which get_cluster_credentials needs but users often lack).
-  if not getattr(args, 'zone', None):
-    rc, loc = run_command_for_value(
-        f'gcloud container clusters list --project={args.project}'
-        f' --filter=name={args.cluster} --format="value(location)"',
-        task='Find cluster location',
-        quiet=True,
-    )
-    if rc != 0 or not loc.strip():
-      xpk_print(f'ERROR: Could not find cluster "{args.cluster}" in project {args.project}.')
-      xpk_exit(1)
-    args.zone = loc.strip()
-
-  get_cluster_credentials(args)
-
-  team = args.team
-  namespace, _lq, _pc = _resolve_poc_team(args)
-  cq_name = namespace  # ClusterQueue name matches namespace name
-
-  # ------------------------------------------------------------------
-  # Internal helpers (no --context needed; xpk sets up kubeconfig)
-  # ------------------------------------------------------------------
-
-  def _kube_json(*kubectl_args):
-    cmd = 'kubectl ' + ' '.join(kubectl_args) + ' -o json'
-    rc, out = run_command_for_value(cmd, task=cmd, quiet=True)
-    if rc != 0 or not out:
-      return None
-    try:
-      return _json.loads(out)
-    except _json.JSONDecodeError:
-      return None
-
-  def _events_text(ns, name):
-    cmd = (
-        f'kubectl get events -n {ns}'
-        f' --field-selector involvedObject.name={name}'
-        f' --sort-by=.lastTimestamp'
-    )
-    rc, out = run_command_for_value(cmd, task='get events', quiet=True)
-    return out.strip() if rc == 0 else ''
-
-  def _age(ts_str):
-    if not ts_str:
-      return '?'
-    ts = datetime.fromisoformat(ts_str.replace('Z', '+00:00'))
-    s = int((datetime.now(timezone.utc) - ts).total_seconds())
-    if s < 60:
-      return f'{s}s'
-    if s < 3600:
-      return f'{s // 60}m'
-    return f'{s // 3600}h{(s % 3600) // 60}m'
-
-  def _cond(wl, ctype):
-    for c in wl.get('status', {}).get('conditions', []):
-      if c.get('type') == ctype:
-        return c
-    return None
-
-  def _is_true(c):
-    return c is not None and c.get('status') == 'True'
-
-  def _cq_chips(cq, section):
-    total = 0
-    for flavor in cq.get('status', {}).get(section, []):
-      for res in flavor.get('resources', []):
-        if res.get('name') == 'google.com/tpu':
-          total += int(res.get('total', 0))
-    return total
-
-  def _cq_quota(cq):
-    nominal, borrow = 0, 0
-    for rg in cq.get('spec', {}).get('resourceGroups', []):
-      for flavor in rg.get('flavors', []):
-        for res in flavor.get('resources', []):
-          if res.get('name') == 'google.com/tpu':
-            nominal += int(res.get('nominalQuota', 0))
-            b = res.get('borrowingLimit')
-            if b is not None:
-              borrow += int(b)
-    return nominal, borrow
-
-  def _ordinal(n):
-    return f"{n}{['th','st','nd','rd','th'][min(n % 10, 4) if n % 100 not in (11,12,13) else 0]}"
-
-  def _xpk_name_of(wl):
-    name = wl['metadata'].get('labels', {}).get('xpk.google.com/workload')
-    if name:
-      return name
-    for ref in wl['metadata'].get('ownerReferences', []):
-      if ref.get('kind') in ('JobSet', 'Job'):
-        return ref.get('name', '')
-    n = wl['metadata']['name']
-    if n.startswith('jobset-'):
-      n = n[len('jobset-'):]
-    if len(n) > 6 and n[-6] == '-':
-      n = n[:-6]
-    return n
-
-  def _print_cq_summary(cq):
-    if not cq:
-      return
-    st = cq.get('status', {})
-    nominal, borrow_limit = _cq_quota(cq)
-    running_chips  = _cq_chips(cq, 'flavorsUsage')
-    reserved_chips = _cq_chips(cq, 'flavorsReservation')
-    admitted   = st.get('admittedWorkloads', 0)
-    reserving  = st.get('reservingWorkloads', 0)
-    pending    = st.get('pendingWorkloads', 0)
-    xpk_print(f'  Quota   : {nominal} chips nominal  +{borrow_limit} borrow  ='
-              f' {nominal + borrow_limit} max')
-    if reserved_chips > 0 and reserved_chips != running_chips:
-      xpk_print(f'  Reserved: {reserved_chips} chips'
-                f' ({reserving} workload(s) — quota held, awaiting admission)')
-    xpk_print(f'  Running : {running_chips} chips ({admitted} workload(s) admitted)')
-    xpk_print(f'  Queued  : {pending} workload(s) waiting for quota')
-
-  def _diagnose_one(wl, all_items, cq):
-    kueue_name = wl['metadata']['name']
-    xpk_name   = _xpk_name_of(wl)
-    created_at = wl['metadata']['creationTimestamp']
-
-    cond_reserved = _cond(wl, 'QuotaReserved')
-    cond_admitted = _cond(wl, 'Admitted')
-    cond_finished = _cond(wl, 'Finished')
-
-    is_admitted = _is_true(cond_admitted)
-    is_reserved = _is_true(cond_reserved)
-    is_finished = _is_true(cond_finished)
-    finish_reason = cond_finished.get('reason', '') if cond_finished else ''
-
-    xpk_print(f'Workload : {xpk_name}  ->  {kueue_name}')
-    xpk_print(f'Age      : {_age(created_at)}')
-
-    if is_finished:
-      status_word = 'success' if finish_reason == 'Succeeded' else finish_reason
-      xpk_print(f'Status   : FINISHED ({status_word})')
-      msg = (cond_finished or {}).get('message', '')
-      if msg:
-        xpk_print(f'           {msg}')
-      xpk_print('')
-      return
-
-    if is_admitted:
-      admitted_ts = (cond_admitted or {}).get('lastTransitionTime', '')
-      xpk_print(f'Status   : RUNNING  (admitted {_age(admitted_ts)} ago)')
-      xpk_print(f'Team quota ({cq_name}):')
-      _print_cq_summary(cq)
-      xpk_print('')
-      return
-
-    if is_reserved:
-      reserved_ts = (cond_reserved or {}).get('lastTransitionTime', '')
-      xpk_print(f'Status   : STUCK — quota reserved but not admitted ({_age(reserved_ts)} ago)')
-      xpk_print(f'Team quota ({cq_name}):')
-      _print_cq_summary(cq)
-      events = _events_text(namespace, kueue_name)
-      warn = [l for l in events.splitlines()
-              if any(w in l for w in ('Warning', 'Error', 'Failed', 'error', 'failed'))]
-      if warn:
-        xpk_print('Diagnosis: AdmissionCheck failed. Error(s):')
-        for line in warn[-3:]:
-          xpk_print(f'  {line.strip()}')
-        if 'more than 49 characters' in events:
-          import re
-          m = re.search(r'"([^"]*-slice-job-\d+)"', events)
-          max_len = 23 - len(namespace)
-          xpk_print(f'')
-          xpk_print(f'  Fix: --workload name "{xpk_name}" ({len(xpk_name)} chars)'
-                    f' exceeds the {max_len}-char limit for {namespace}.')
-          xpk_print(f'       Delete the JobSet and resubmit with a name <= {max_len} chars.')
-          xpk_print(f'       Example: {xpk_name[:max_len]}')
-      else:
-        xpk_print('Diagnosis: AdmissionCheck still processing (no errors yet).')
-        xpk_print(f'  kubectl describe workload {kueue_name} -n {namespace}')
-      xpk_print('')
-      return
-
-    # Queued — compute position
-    my_ts  = created_at
-    my_pri = wl.get('spec', {}).get('priority') or 0
-    ahead = []
-    for other in all_items:
-      oname = other['metadata']['name']
-      if oname == kueue_name:
-        continue
-      if _is_true(_cond(other, 'Admitted')) or _is_true(_cond(other, 'Finished')):
-        continue
-      if _is_true(_cond(other, 'QuotaReserved')):
-        continue
-      other_ts  = other['metadata']['creationTimestamp']
-      other_pri = other.get('spec', {}).get('priority') or 0
-      if other_pri > my_pri or (other_pri == my_pri and other_ts < my_ts):
-        ahead.append(_xpk_name_of(other))
-
-    pos = len(ahead) + 1
-    xpk_print(f'Status   : QUEUED — waiting for quota')
-    if ahead:
-      sample = ', '.join(ahead[:3]) + ('...' if len(ahead) > 3 else '')
-      xpk_print(f'Position : {_ordinal(pos)} in line  ({len(ahead)} workload(s) ahead: {sample})')
-    else:
-      xpk_print(f'Position : {_ordinal(pos)} in line  (nothing ahead of you in this queue)')
-    xpk_print(f'Team quota ({cq_name}):')
-    _print_cq_summary(cq)
-
-    # Anomaly detection
-    st = (cq or {}).get('status', {})
-    nominal, _ = _cq_quota(cq) if cq else (0, 0)
-    running = _cq_chips(cq, 'flavorsUsage') if cq else 0
-    if pos == 1 and st.get('admittedWorkloads', 0) == 0 and running == 0 and nominal > 0:
-      xpk_print('Diagnosis: You\'re 1st in line with quota available but nothing running.')
-      xpk_print(f'  This is unusual. Check: kubectl describe workload {kueue_name} -n {namespace}')
-    elif pos == 1 and nominal > 0 and running < nominal * 0.9:
-      xpk_print(f'Diagnosis: You\'re 1st in line and quota is not full — should be admitted soon.')
-      xpk_print(f'  If still queued in a few minutes, check:')
-      xpk_print(f'  kubectl describe workload {kueue_name} -n {namespace}')
-    else:
-      xpk_print('Diagnosis: Things look normal — waiting behind other workloads.')
-    xpk_print('')
-
-  # ------------------------------------------------------------------
-  # Fetch data and run diagnostics
-  # ------------------------------------------------------------------
-  cq = _kube_json('get', 'clusterqueue', cq_name)
-  all_wl_data = _kube_json('get', 'workload', '-n', namespace)
-  all_items = all_wl_data.get('items', []) if all_wl_data else []
-
-  if args.workload:
-    prefix = f'jobset-{args.workload}-'
-    matches = [i for i in all_items if i['metadata']['name'].startswith(prefix)]
-    if not matches:
-      xpk_print(f'No workload found matching "{prefix}*" in {namespace}')
-      xpk_exit(1)
-    if len(matches) > 1:
-      names = [i['metadata']['name'] for i in matches]
-      xpk_print(f'Multiple matches: {names}. Use the full Kueue name with --workload.')
-      xpk_exit(1)
-    _diagnose_one(matches[0], all_items, cq)
-  else:
-    if not all_items:
-      xpk_print(f'No workloads in {namespace} — queue is empty.')
-      xpk_print(f'Team quota ({cq_name}):')
-      if cq:
-        nominal, borrow = _cq_quota(cq)
-        xpk_print(f'  Quota: {nominal} chips nominal  +{borrow} borrow  = {nominal + borrow} max')
-      xpk_exit(0)
-
-    def _sort_key(i):
-      return (0 if _is_true(_cond(i, 'Admitted')) else 1,
-              i['metadata']['creationTimestamp'])
-
-    for item in sorted(all_items, key=_sort_key):
-      _diagnose_one(item, all_items, cq)
-
-  xpk_exit(0)

--- a/src/xpk/commands/workload.py
+++ b/src/xpk/commands/workload.py
@@ -154,8 +154,8 @@ def _load_quota_cfg(args) -> dict | None:
       hints = suggest(args.value_class, vcs)
       hint_line = f' Did you mean: {", ".join(hints)}?' if hints else ''
       xpk_print(
-          f'ERROR: --value-class={args.value_class!r} not valid on this cluster.'
-          f'{hint_line} Available: {", ".join(vcs)}'
+          f'ERROR: --value-class={args.value_class!r} not valid on this'
+          f' cluster.{hint_line} Available: {", ".join(vcs)}'
       )
       xpk_exit(1)
   args._quota_cfg = cfg  # pylint: disable=protected-access
@@ -171,7 +171,9 @@ def _resolve_quota_team(args):
   cfg = _load_quota_cfg(args)
   if cfg is None:
     # Mimic the dataclass shape so callers can use attribute access uniformly.
-    return TeamRouting(namespace='', local_queue=LOCAL_QUEUE_NAME, priority_class=args.priority)
+    return TeamRouting(
+        namespace='', local_queue=LOCAL_QUEUE_NAME, priority_class=args.priority
+    )
   return resolve_team(cfg, args.team)
 
 
@@ -188,7 +190,9 @@ def _build_team_labels(args) -> str:
   if getattr(args, 'value_class', None):
     lines.append(f'value-class: {args.value_class}')
   if getattr(args, 'declared_duration_minutes', None) is not None:
-    lines.append(f'declared-duration-minutes: "{args.declared_duration_minutes}"')
+    lines.append(
+        f'declared-duration-minutes: "{args.declared_duration_minutes}"'
+    )
   # indent to match template (4 spaces)
   return ('\n    ').join(lines)
 
@@ -886,9 +890,9 @@ def workload_create(args) -> None:
       if k8s_name != args.workload:
         xpk_print(
             f'workload "{args.workload}" → K8s JobSet name: "{k8s_name}"'
-            f' (shortened to fit super-slice charLimit; use'
-            f' $XPK_WORKLOAD_NAME in your command for GCS artifact paths;'
-            f' pass --no-shorten-jobset-name to disable)'
+            ' (shortened to fit super-slice charLimit; use'
+            ' $XPK_WORKLOAD_NAME in your command for GCS artifact paths;'
+            ' pass --no-shorten-jobset-name to disable)'
         )
     else:
       k8s_name = args.workload
@@ -911,7 +915,9 @@ def workload_create(args) -> None:
         node_selector_machine_label=node_selector_machine_label,
         tpu_slice_topology_annotation=tpu_slice_topology_annotation,
         local_queue_name=routing.local_queue,
-        namespace_field=f'namespace: {team_namespace}' if team_namespace else '',
+        namespace_field=f'namespace: {team_namespace}'
+        if team_namespace
+        else '',
         team_labels=_build_team_labels(args),
         team_pod_template_labels=_build_team_pod_template_labels(args),
         autoprovisioning_args=autoprovisioning_args,
@@ -1176,5 +1182,3 @@ def workload_list(args) -> None:
   xpk_print(f'See your workloads in Cloud Console: {workload_list_gcp_link}')
 
   xpk_exit(0)
-
-

--- a/src/xpk/commands/workload.py
+++ b/src/xpk/commands/workload.py
@@ -33,7 +33,7 @@ from ..core.docker_container import (
     get_main_container_docker_image,
     get_user_workload_container,
 )
-from ..core.kueue_manager import LOCAL_QUEUE_NAME
+from ..core.kueue_manager import LOCAL_QUEUE_NAME, POC_TEAM_CONFIG, POC_TEAM_MAX_WORKLOAD_NAME
 from ..core.docker_resources import get_volumes, parse_env_config
 from ..core.gcloud_context import add_zone_and_project
 from ..core.monitoring import get_gke_outlier_dashboard
@@ -104,6 +104,52 @@ from ..utils.templates import get_templates_absolute_path
 _PATHWAYS_WORKLOAD_TEMPLATE = 'pathways_workload_create.yaml.j2'
 
 _SUPER_SLICING_WORKLOAD_NAME_LIMIT = 28
+
+
+def _resolve_poc_team(args) -> tuple[str, str, str]:
+  """Return (namespace, local_queue_name, priority_class) for --team, or defaults."""
+  if not getattr(args, 'team', None):
+    return ('', LOCAL_QUEUE_NAME, args.priority)
+  namespace, lq, priority_class = POC_TEAM_CONFIG[args.team]
+  max_len = POC_TEAM_MAX_WORKLOAD_NAME[args.team]
+  if len(args.workload) > max_len:
+    xpk_exit(
+        f'Workload name "{args.workload}" is {len(args.workload)} chars; '
+        f'max for team {args.team} (namespace {namespace}) is {max_len} chars. '
+        f'The dynamic slice admission check generates a Slice name as '
+        f'"{namespace}-<workload>-sli-<hash>" which must be <=49 characters.'
+    )
+  return (namespace, lq, priority_class)
+
+
+def _build_poc_labels(args) -> str:
+  """Return YAML label lines for PoC quota labels, or empty string."""
+  if not getattr(args, 'team', None):
+    return ''
+  lines = [f'team: {args.team}']
+  if getattr(args, 'value_class', None):
+    lines.append(f'value-class: {args.value_class}')
+  if getattr(args, 'declared_duration_minutes', None) is not None:
+    lines.append(f'declared-duration-minutes: "{args.declared_duration_minutes}"')
+  # indent to match template (4 spaces)
+  return ('\n    ').join(lines)
+
+
+def _build_poc_pod_template_labels(args) -> str:
+  """Return YAML label lines for PoC labels that must appear in pod template.
+
+  Kueue does NOT propagate arbitrary JobSet metadata labels to the Workload
+  object, so the time-limit controller reads declared-duration-minutes from
+  spec.podSets[*].template.metadata.labels instead.
+  """
+  if not getattr(args, 'team', None):
+    return ''
+  if getattr(args, 'declared_duration_minutes', None) is None:
+    return ''
+  # indent to match pod template labels (16 spaces)
+  return f'declared-duration-minutes: "{args.declared_duration_minutes}"'
+
+
 """Maximum safe workload name length to avoid exceeding GCE's 63-character limit.
 
 Kueue/Jobset prefixes and suffixes consume characters: 8 (`default-`), 7 (`jobset-`),
@@ -114,9 +160,11 @@ WORKLOAD_CREATE_YAML = """apiVersion: jobset.x-k8s.io/v1alpha2
 kind: JobSet
 metadata:
   name: {args.workload}
+  {namespace_field}
   labels:
     kueue.x-k8s.io/queue-name: {local_queue_name}  # Name of the LocalQueue
     xpk.google.com/workload: {args.workload}
+    {poc_labels}
   annotations:
     {jobset_annotations}
 spec:
@@ -137,6 +185,7 @@ spec:
             metadata:
               labels:
                 xpk.google.com/workload: {args.workload}
+                {poc_pod_template_labels}
               annotations:
                 {storage_annotations}
                 {sub_slicing_annotations}
@@ -746,6 +795,10 @@ def workload_create(args) -> None:
         args, workload_system, parallel_containers
     )
 
+    poc_namespace, poc_local_queue, poc_priority = _resolve_poc_team(args)
+    # Override args.priority so the pod spec picks up the team priority class
+    if poc_namespace:
+      args.priority = poc_priority
     yml_string = WORKLOAD_CREATE_YAML.format(
         args=args,
         jobset_annotations=jobset_annotations,
@@ -763,7 +816,10 @@ def workload_create(args) -> None:
         placement_policy_label=placement_policy_label,
         node_selector_machine_label=node_selector_machine_label,
         tpu_slice_topology_annotation=tpu_slice_topology_annotation,
-        local_queue_name=LOCAL_QUEUE_NAME,
+        local_queue_name=poc_local_queue,
+        namespace_field=f'namespace: {poc_namespace}' if poc_namespace else '',
+        poc_labels=_build_poc_labels(args),
+        poc_pod_template_labels=_build_poc_pod_template_labels(args),
         autoprovisioning_args=autoprovisioning_args,
         volumes=get_volumes(args, workload_system),
         storage_annotations=('\n' + (' ' * 16)).join(

--- a/src/xpk/commands/workload.py
+++ b/src/xpk/commands/workload.py
@@ -33,7 +33,17 @@ from ..core.docker_container import (
     get_main_container_docker_image,
     get_user_workload_container,
 )
-from ..core.kueue_manager import LOCAL_QUEUE_NAME, POC_TEAM_CONFIG, POC_TEAM_MAX_WORKLOAD_NAME
+from ..core.kueue_manager import LOCAL_QUEUE_NAME, derive_k8s_workload_name
+from ..core.poc_discovery import (
+    CONFIG_CM_NAME,
+    CONFIG_CM_NAMESPACE,
+    available_teams,
+    available_value_classes,
+    fetch_poc_config,
+    max_k8s_workload_name_len,
+    resolve_team,
+    suggest,
+)
 from ..core.docker_resources import get_volumes, parse_env_config
 from ..core.gcloud_context import add_zone_and_project
 from ..core.monitoring import get_gke_outlier_dashboard
@@ -106,20 +116,52 @@ _PATHWAYS_WORKLOAD_TEMPLATE = 'pathways_workload_create.yaml.j2'
 _SUPER_SLICING_WORKLOAD_NAME_LIMIT = 28
 
 
+def _load_poc_cfg(args) -> dict | None:
+  """Fetch the PoC ConfigMap once per invocation and cache on args. Returns
+  None if --team is unset (so upstream, non-PoC behavior is preserved)."""
+  if not getattr(args, 'team', None):
+    return None
+  cached = getattr(args, '_poc_cfg', None)
+  if cached is not None:
+    return cached
+  cfg = fetch_poc_config()
+  if cfg is None:
+    xpk_print(
+        f'ERROR: --team={args.team!r} requires the PoC ConfigMap'
+        f' "{CONFIG_CM_NAMESPACE}/{CONFIG_CM_NAME}" on the target cluster.'
+        ' Deploy cluster-management/poc/chart first, or drop --team to bypass'
+        ' PoC routing.'
+    )
+    xpk_exit(1)
+  if args.team not in (cfg.get('teams') or {}):
+    teams = available_teams(cfg)
+    hints = suggest(args.team, teams)
+    hint_line = f' Did you mean: {", ".join(hints)}?' if hints else ''
+    xpk_print(
+        f'ERROR: --team={args.team!r} not found on this cluster.{hint_line}'
+        f' Available teams: {", ".join(teams) or "<none>"}'
+    )
+    xpk_exit(1)
+  if getattr(args, 'value_class', None):
+    vcs = available_value_classes(cfg)
+    if vcs and args.value_class not in vcs:
+      hints = suggest(args.value_class, vcs)
+      hint_line = f' Did you mean: {", ".join(hints)}?' if hints else ''
+      xpk_print(
+          f'ERROR: --value-class={args.value_class!r} not valid on this cluster.'
+          f'{hint_line} Available: {", ".join(vcs)}'
+      )
+      xpk_exit(1)
+  args._poc_cfg = cfg
+  return cfg
+
+
 def _resolve_poc_team(args) -> tuple[str, str, str]:
   """Return (namespace, local_queue_name, priority_class) for --team, or defaults."""
-  if not getattr(args, 'team', None):
+  cfg = _load_poc_cfg(args)
+  if cfg is None:
     return ('', LOCAL_QUEUE_NAME, args.priority)
-  namespace, lq, priority_class = POC_TEAM_CONFIG[args.team]
-  max_len = POC_TEAM_MAX_WORKLOAD_NAME[args.team]
-  if len(args.workload) > max_len:
-    xpk_exit(
-        f'Workload name "{args.workload}" is {len(args.workload)} chars; '
-        f'max for team {args.team} (namespace {namespace}) is {max_len} chars. '
-        f'The dynamic slice admission check generates a Slice name as '
-        f'"{namespace}-<workload>-sli-<hash>" which must be <=49 characters.'
-    )
-  return (namespace, lq, priority_class)
+  return resolve_team(cfg, args.team)
 
 
 def _build_poc_labels(args) -> str:
@@ -159,7 +201,7 @@ Kueue/Jobset prefixes and suffixes consume characters: 8 (`default-`), 7 (`jobse
 WORKLOAD_CREATE_YAML = """apiVersion: jobset.x-k8s.io/v1alpha2
 kind: JobSet
 metadata:
-  name: {args.workload}
+  name: {k8s_name}
   {namespace_field}
   labels:
     kueue.x-k8s.io/queue-name: {local_queue_name}  # Name of the LocalQueue
@@ -521,6 +563,12 @@ def workload_create(args) -> None:
 
   parse_env_config(args, tensorboard_config)
 
+  # For PoC teams, inject the user's full display name as XPK_WORKLOAD_NAME so
+  # training scripts can reference it for GCS artifact paths regardless of the
+  # short K8s name xpk derives for the JobSet.
+  if getattr(args, 'team', None):
+    args.env.setdefault('XPK_WORKLOAD_NAME', args.workload)
+
   autoprovisioning_args = ''
   autoprovisioning_enabled, return_code = is_autoprovisioning_enabled(
       args, workload_system
@@ -611,6 +659,7 @@ def workload_create(args) -> None:
 
   if (
       use_super_slicing
+      and not getattr(args, 'team', None)
       and len(args.workload) > _SUPER_SLICING_WORKLOAD_NAME_LIMIT
   ):
     xpk_print(
@@ -796,11 +845,20 @@ def workload_create(args) -> None:
     )
 
     poc_namespace, poc_local_queue, poc_priority = _resolve_poc_team(args)
-    # Override args.priority so the pod spec picks up the team priority class
+    # Derive a short K8s-safe JobSet name for PoC teams; use display name as-is otherwise.
     if poc_namespace:
+      max_len = max_k8s_workload_name_len(args._poc_cfg, poc_namespace)
+      k8s_name = derive_k8s_workload_name(args.workload, max_len)
       args.priority = poc_priority
+      xpk_print(
+          f'PoC workload "{args.workload}" → K8s JobSet name: "{k8s_name}"'
+          f' (use $XPK_WORKLOAD_NAME in your command for GCS artifact paths)'
+      )
+    else:
+      k8s_name = args.workload
     yml_string = WORKLOAD_CREATE_YAML.format(
         args=args,
+        k8s_name=k8s_name,
         jobset_annotations=jobset_annotations,
         container=container,
         vms_per_slice=workload_system.vms_per_slice,
@@ -1128,7 +1186,7 @@ def workload_status(args) -> None:
   get_cluster_credentials(args)
 
   team = args.team
-  namespace, _lq, _pc = POC_TEAM_CONFIG[team]
+  namespace, _lq, _pc = _resolve_poc_team(args)
   cq_name = namespace  # ClusterQueue name matches namespace name
 
   # ------------------------------------------------------------------

--- a/src/xpk/commands/workload.py
+++ b/src/xpk/commands/workload.py
@@ -27,7 +27,7 @@ from ..core.cluster import (
     get_cluster_credentials,
     setup_k8s_env,
 )
-from ..core.commands import run_command_with_updates, run_commands, run_command_for_value
+from ..core.commands import run_command_with_updates, run_commands
 from ..core.config import (VERTEX_TENSORBOARD_FEATURE_FLAG, XPK_CURRENT_VERSION)
 from ..core.docker_container import (
     get_main_container_docker_image,
@@ -37,6 +37,7 @@ from ..core.kueue_manager import LOCAL_QUEUE_NAME, derive_k8s_workload_name
 from ..core.quota_discovery import (
     CONFIG_CM_NAME,
     CONFIG_CM_NAMESPACE,
+    TeamRouting,
     available_teams,
     available_value_classes,
     fetch_quota_config,
@@ -157,7 +158,7 @@ def _load_quota_cfg(args) -> dict | None:
           f'{hint_line} Available: {", ".join(vcs)}'
       )
       xpk_exit(1)
-  args._quota_cfg = cfg
+  args._quota_cfg = cfg  # pylint: disable=protected-access
   return cfg
 
 
@@ -170,7 +171,6 @@ def _resolve_quota_team(args):
   cfg = _load_quota_cfg(args)
   if cfg is None:
     # Mimic the dataclass shape so callers can use attribute access uniformly.
-    from ..core.quota_discovery import TeamRouting
     return TeamRouting(namespace='', local_queue=LOCAL_QUEUE_NAME, priority_class=args.priority)
   return resolve_team(cfg, args.team)
 
@@ -875,6 +875,7 @@ def workload_create(args) -> None:
     # core.quota_discovery.max_k8s_workload_name_len for the budget math.
     # The user can disable shortening with --no-shorten-jobset-name.
     if team_namespace:
+      # pylint: disable-next=protected-access
       max_len = max_k8s_workload_name_len(args._quota_cfg, team_namespace)
       shorten = not getattr(args, 'no_shorten_jobset_name', False)
       if shorten:

--- a/src/xpk/commands/workload.py
+++ b/src/xpk/commands/workload.py
@@ -35,15 +35,9 @@ from ..core.docker_container import (
 )
 from ..core.kueue_manager import LOCAL_QUEUE_NAME, derive_k8s_workload_name
 from ..core.quota_discovery import (
-    CONFIG_CM_NAME,
-    CONFIG_CM_NAMESPACE,
     TeamRouting,
-    available_teams,
-    available_value_classes,
-    fetch_quota_config,
     max_k8s_workload_name_len,
-    resolve_team,
-    suggest,
+    resolve_team_for_args,
 )
 from ..core.docker_resources import get_volumes, parse_env_config
 from ..core.gcloud_context import add_zone_and_project
@@ -115,66 +109,6 @@ from ..utils.templates import get_templates_absolute_path
 _PATHWAYS_WORKLOAD_TEMPLATE = 'pathways_workload_create.yaml.j2'
 
 _SUPER_SLICING_WORKLOAD_NAME_LIMIT = 28
-
-
-def _load_quota_cfg(args) -> dict | None:
-  """Fetch the team-quota ConfigMap once per invocation and cache on args.
-
-  Returns None if --team is unset (so upstream, non-team-routing behavior is
-  preserved). Robust against unit-test code that passes a MagicMock for args:
-  we require args.team to be a non-empty string, not just truthy.
-  """
-  team = getattr(args, 'team', None)
-  if not isinstance(team, str) or not team.strip():
-    return None
-  cached = getattr(args, '_quota_cfg', None)
-  if isinstance(cached, dict):
-    return cached
-  cfg = fetch_quota_config()
-  if cfg is None:
-    xpk_print(
-        f'ERROR: --team={args.team!r} requires the team-quota ConfigMap'
-        f' "{CONFIG_CM_NAMESPACE}/{CONFIG_CM_NAME}" on the target cluster.'
-        ' Deploy the cluster quota chart first, or drop --team to bypass'
-        ' team-based routing.'
-    )
-    xpk_exit(1)
-  if args.team not in (cfg.get('teams') or {}):
-    teams = available_teams(cfg)
-    hints = suggest(args.team, teams)
-    hint_line = f' Did you mean: {", ".join(hints)}?' if hints else ''
-    xpk_print(
-        f'ERROR: --team={args.team!r} not found on this cluster.{hint_line}'
-        f' Available teams: {", ".join(teams) or "<none>"}'
-    )
-    xpk_exit(1)
-  if getattr(args, 'value_class', None):
-    vcs = available_value_classes(cfg)
-    if vcs and args.value_class not in vcs:
-      hints = suggest(args.value_class, vcs)
-      hint_line = f' Did you mean: {", ".join(hints)}?' if hints else ''
-      xpk_print(
-          f'ERROR: --value-class={args.value_class!r} not valid on this'
-          f' cluster.{hint_line} Available: {", ".join(vcs)}'
-      )
-      xpk_exit(1)
-  args._quota_cfg = cfg  # pylint: disable=protected-access
-  return cfg
-
-
-def _resolve_quota_team(args):
-  """Return TeamRouting for --team, or upstream defaults wrapped equivalently.
-
-  When --team is unset, returns an empty namespace and the upstream
-  LOCAL_QUEUE_NAME / args.priority so callers can format the YAML uniformly.
-  """
-  cfg = _load_quota_cfg(args)
-  if cfg is None:
-    # Mimic the dataclass shape so callers can use attribute access uniformly.
-    return TeamRouting(
-        namespace='', local_queue=LOCAL_QUEUE_NAME, priority_class=args.priority
-    )
-  return resolve_team(cfg, args.team)
 
 
 def _build_team_labels(args) -> str:
@@ -870,23 +804,22 @@ def workload_create(args) -> None:
         args, workload_system, parallel_containers
     )
 
-    routing = _resolve_quota_team(args)
-    team_namespace = routing.namespace
-    # Derive a short K8s-safe JobSet name when the workload is routed to a
-    # team namespace AND the user-facing workload name exceeds the
-    # super-slice admission controller's per-name budget. See
-    # core.kueue_manager.derive_k8s_workload_name and
-    # core.quota_discovery.max_k8s_workload_name_len for the budget math.
-    # The user can disable shortening with --no-shorten-jobset-name.
-    if team_namespace:
-      # pylint: disable-next=protected-access
-      max_len = max_k8s_workload_name_len(args._quota_cfg, team_namespace)
+    team_routing = resolve_team_for_args(args)
+    if team_routing is not None:
+      team_namespace = team_routing.namespace
+      # Derive a short K8s-safe JobSet name when the workload is routed to a
+      # team namespace AND the user-facing workload name exceeds the
+      # super-slice admission controller's per-name budget. See
+      # core.kueue_manager.derive_k8s_workload_name and
+      # core.quota_discovery.max_k8s_workload_name_len for the budget math.
+      # The user can disable shortening with --no-shorten-jobset-name.
+      max_len = max_k8s_workload_name_len(args.quota_cfg, team_namespace)
       shorten = not getattr(args, 'no_shorten_jobset_name', False)
       if shorten:
         k8s_name = derive_k8s_workload_name(args.workload, max_len)
       else:
         k8s_name = args.workload
-      args.priority = routing.priority_class
+      args.priority = team_routing.priority_class
       if k8s_name != args.workload:
         xpk_print(
             f'workload "{args.workload}" → K8s JobSet name: "{k8s_name}"'
@@ -894,8 +827,15 @@ def workload_create(args) -> None:
             ' $XPK_WORKLOAD_NAME in your command for GCS artifact paths;'
             ' pass --no-shorten-jobset-name to disable)'
         )
+      routing = team_routing
     else:
+      team_namespace = ''
       k8s_name = args.workload
+      routing = TeamRouting(
+          namespace='',
+          local_queue=LOCAL_QUEUE_NAME,
+          priority_class=args.priority,
+      )
     yml_string = WORKLOAD_CREATE_YAML.format(
         args=args,
         k8s_name=k8s_name,

--- a/src/xpk/commands/workload.py
+++ b/src/xpk/commands/workload.py
@@ -128,7 +128,7 @@ def _load_quota_cfg(args) -> dict | None:
   if not isinstance(team, str) or not team.strip():
     return None
   cached = getattr(args, '_quota_cfg', None)
-  if cached is not None:
+  if isinstance(cached, dict):
     return cached
   cfg = fetch_quota_config()
   if cfg is None:

--- a/src/xpk/commands/workload.py
+++ b/src/xpk/commands/workload.py
@@ -486,6 +486,10 @@ def workload_create(args) -> None:
     k8s_api_client = setup_k8s_env(args)
     setup_k8s_service_accounts()
 
+  # Default PoC routing values; the TPU non-pathways path below may override.
+  poc_namespace = ''
+  k8s_name = args.workload
+
   workload_exists = check_if_workload_exists(args)
 
   if workload_exists:
@@ -961,10 +965,14 @@ def workload_create(args) -> None:
         f'{get_pathways_unified_query_link(args)}'
     )
   else:
+    # PoC teams route to a per-team namespace and use a short K8s JobSet name
+    # derived from args.workload. Fall back to upstream defaults otherwise.
+    log_namespace = poc_namespace or 'default'
+    log_pod_prefix = k8s_name
     xpk_print(
         'Follow your workload here:'
         # pylint: disable=line-too-long
-        f' https://console.cloud.google.com/kubernetes/service/{get_cluster_location(args.project, args.cluster, args.zone)}/{args.cluster}/default/{args.workload}/details?project={args.project}'
+        f' https://console.cloud.google.com/kubernetes/service/{get_cluster_location(args.project, args.cluster, args.zone)}/{args.cluster}/{log_namespace}/{log_pod_prefix}/details?project={args.project}'
     )
     duration_of_logs = 'P1D'  # Past 1 Day
     log_filter = (
@@ -972,8 +980,8 @@ def workload_create(args) -> None:
         f'resource.labels.project_id="{args.project}"\n'
         f'resource.labels.location="{get_cluster_location(args.project, args.cluster, args.zone)}"\n'
         f'resource.labels.cluster_name="{args.cluster}"\n'
-        'resource.labels.namespace_name="default"\n'
-        f'resource.labels.pod_name:"{args.workload}-slice-job-0-0-"\n'
+        f'resource.labels.namespace_name="{log_namespace}"\n'
+        f'resource.labels.pod_name:"{log_pod_prefix}-slice-job-0-0-"\n'
         'severity>=DEFAULT'
     )
     encoded_filter = urllib.parse.quote(log_filter, safe='')

--- a/src/xpk/commands/workload_status.py
+++ b/src/xpk/commands/workload_status.py
@@ -23,11 +23,13 @@ Reads the team-quota ConfigMap to resolve the team's namespace + ClusterQueue.
 """
 
 import json as _json
-import subprocess as _subprocess
 from datetime import datetime, timezone
+from typing import Any
 
 from ..core.cluster import get_cluster_credentials
 from ..core.commands import run_command_for_value
+from ..core.kubectl_common import KubernetesCondition, parse_kubernetes_status
+from ..core.quota_discovery import resolve_team_for_args
 from ..utils.console import xpk_exit, xpk_print
 from ..utils.validation import (
     SystemDependency,
@@ -52,15 +54,12 @@ def workload_status(args) -> None:
 
   # Fill project from gcloud config if not provided.
   if not getattr(args, 'project', None):
-    r = _subprocess.run(
-        ['gcloud', 'config', 'get', 'project'],
-        capture_output=True,
-        text=True,
-        check=False,
+    rc, out = run_command_for_value(
+        'gcloud config get project',
+        task='gcloud config get project',
+        quiet=True,
     )
-    args.project = (
-        r.stdout.strip().splitlines()[-1] if r.returncode == 0 else ''
-    )
+    args.project = out.strip().splitlines()[-1] if rc == 0 and out else ''
   if not args.project:
     xpk_print(
         'ERROR: --project not set and could not be determined from gcloud'
@@ -87,25 +86,27 @@ def workload_status(args) -> None:
 
   get_cluster_credentials(args)
 
-  # Imported lazily to avoid a circular import: commands/workload.py imports
-  # this module's parser, and we'd otherwise close the loop.
-  from .workload import _resolve_quota_team  # pylint: disable=import-outside-toplevel
+  routing = resolve_team_for_args(args)
+  if routing is None:
+    xpk_print('ERROR: --team is required for `xpk workload status`.')
+    xpk_exit(1)
 
-  routing = _resolve_quota_team(args)
+  assert routing is not None  # narrow for type checker
   namespace = routing.namespace
   cq_name = namespace  # ClusterQueue name matches namespace name
 
-  def _kube_json(*kubectl_args):
+  def _kube_json(*kubectl_args: str) -> dict | None:
     cmd = 'kubectl ' + ' '.join(kubectl_args) + ' -o json'
     rc, out = run_command_for_value(cmd, task=cmd, quiet=True)
     if rc != 0 or not out:
       return None
     try:
-      return _json.loads(out)
+      payload = _json.loads(out)
     except _json.JSONDecodeError:
       return None
+    return payload if isinstance(payload, dict) else None
 
-  def _events_text(ns, name):
+  def _events_text(ns: str, name: str) -> str:
     cmd = (
         f'kubectl get events -n {ns}'
         f' --field-selector involvedObject.name={name}'
@@ -114,7 +115,7 @@ def workload_status(args) -> None:
     rc, out = run_command_for_value(cmd, task='get events', quiet=True)
     return out.strip() if rc == 0 else ''
 
-  def _age(ts_str):
+  def _age(ts_str: str | None) -> str:
     if not ts_str:
       return '?'
     ts = datetime.fromisoformat(ts_str.replace('Z', '+00:00'))
@@ -125,16 +126,19 @@ def workload_status(args) -> None:
       return f'{s // 60}m'
     return f'{s // 3600}h{(s % 3600) // 60}m'
 
-  def _cond(wl, ctype):
-    for c in wl.get('status', {}).get('conditions', []):
-      if c.get('type') == ctype:
+  def _cond(wl: dict, ctype: str) -> KubernetesCondition | None:
+    status = parse_kubernetes_status(wl.get('status'))
+    for c in status.conditions:
+      if c.type == ctype:
         return c
     return None
 
-  def _is_true(c):
-    return c is not None and c.get('status') == 'True'
+  def _is_true(c: KubernetesCondition | None) -> bool:
+    return c is not None and c.status == 'True'
 
-  def _cq_chips(cq, section):
+  def _cq_chips(cq: dict | None, section: str) -> int:
+    if not cq:
+      return 0
     total = 0
     for flavor in cq.get('status', {}).get(section, []):
       for res in flavor.get('resources', []):
@@ -142,7 +146,9 @@ def workload_status(args) -> None:
           total += int(res.get('total', 0))
     return total
 
-  def _cq_quota(cq):
+  def _cq_quota(cq: dict | None) -> tuple[int, int]:
+    if not cq:
+      return 0, 0
     nominal, borrow = 0, 0
     for rg in cq.get('spec', {}).get('resourceGroups', []):
       for flavor in rg.get('flavors', []):
@@ -154,26 +160,26 @@ def workload_status(args) -> None:
               borrow += int(b)
     return nominal, borrow
 
-  def _ordinal(n):
+  def _ordinal(n: int) -> str:
     return (
         f"{n}{['th','st','nd','rd','th'][min(n % 10, 4) if n % 100 not in (11,12,13) else 0]}"
     )
 
-  def _xpk_name_of(wl):
+  def _xpk_name_of(wl: dict) -> str:
     name = wl['metadata'].get('labels', {}).get('xpk.google.com/workload')
     if name:
-      return name
+      return str(name)
     for ref in wl['metadata'].get('ownerReferences', []):
       if ref.get('kind') in ('JobSet', 'Job'):
-        return ref.get('name', '')
+        return str(ref.get('name', ''))
     n = wl['metadata']['name']
     if n.startswith('jobset-'):
       n = n[len('jobset-') :]
     if len(n) > 6 and n[-6] == '-':
       n = n[:-6]
-    return n
+    return str(n)
 
-  def _print_cq_summary(cq):
+  def _print_cq_summary(cq: dict | None) -> None:
     if not cq:
       return
     st = cq.get('status', {})
@@ -197,7 +203,7 @@ def workload_status(args) -> None:
     )
     xpk_print(f'  Queued  : {pending} workload(s) waiting for quota')
 
-  def _diagnose_one(wl, all_items, cq):
+  def _diagnose_one(wl: dict, all_items: list[dict], cq: dict | None) -> None:
     kueue_name = wl['metadata']['name']
     xpk_name = _xpk_name_of(wl)
     created_at = wl['metadata']['creationTimestamp']
@@ -209,7 +215,7 @@ def workload_status(args) -> None:
     is_admitted = _is_true(cond_admitted)
     is_reserved = _is_true(cond_reserved)
     is_finished = _is_true(cond_finished)
-    finish_reason = cond_finished.get('reason', '') if cond_finished else ''
+    finish_reason = cond_finished.reason or '' if cond_finished else ''
 
     xpk_print(f'Workload : {xpk_name}  ->  {kueue_name}')
     xpk_print(f'Age      : {_age(created_at)}')
@@ -217,14 +223,14 @@ def workload_status(args) -> None:
     if is_finished:
       status_word = 'success' if finish_reason == 'Succeeded' else finish_reason
       xpk_print(f'Status   : FINISHED ({status_word})')
-      msg = (cond_finished or {}).get('message', '')
+      msg = cond_finished.message if cond_finished else ''
       if msg:
         xpk_print(f'           {msg}')
       xpk_print('')
       return
 
     if is_admitted:
-      admitted_ts = (cond_admitted or {}).get('lastTransitionTime', '')
+      admitted_ts = cond_admitted.lastTransitionTime if cond_admitted else ''
       xpk_print(f'Status   : RUNNING  (admitted {_age(admitted_ts)} ago)')
       xpk_print(f'Team quota ({cq_name}):')
       _print_cq_summary(cq)
@@ -232,7 +238,7 @@ def workload_status(args) -> None:
       return
 
     if is_reserved:
-      reserved_ts = (cond_reserved or {}).get('lastTransitionTime', '')
+      reserved_ts = cond_reserved.lastTransitionTime if cond_reserved else ''
       xpk_print(
           'Status   : STUCK — quota reserved but not admitted'
           f' ({_age(reserved_ts)} ago)'
@@ -272,7 +278,7 @@ def workload_status(args) -> None:
     # Queued — compute position
     my_ts = created_at
     my_pri = wl.get('spec', {}).get('priority') or 0
-    ahead = []
+    ahead: list[str] = []
     for other in all_items:
       oname = other['metadata']['name']
       if oname == kueue_name:
@@ -306,8 +312,8 @@ def workload_status(args) -> None:
 
     # Anomaly detection
     st = (cq or {}).get('status', {})
-    nominal, _ = _cq_quota(cq) if cq else (0, 0)
-    running = _cq_chips(cq, 'flavorsUsage') if cq else 0
+    nominal, _ = _cq_quota(cq)
+    running = _cq_chips(cq, 'flavorsUsage')
     if (
         pos == 1
         and st.get('admittedWorkloads', 0) == 0
@@ -364,7 +370,7 @@ def workload_status(args) -> None:
         )
       xpk_exit(0)
 
-    def _sort_key(i):
+    def _sort_key(i: dict) -> tuple[int, Any]:
       return (
           0 if _is_true(_cond(i, 'Admitted')) else 1,
           i['metadata']['creationTimestamp'],

--- a/src/xpk/commands/workload_status.py
+++ b/src/xpk/commands/workload_status.py
@@ -1,0 +1,315 @@
+"""
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+"""`xpk workload status` — focused, plain-English diagnosis for a single workload.
+
+Differs from `xpk inspector` (which dumps cluster-wide raw state for SREs):
+this command answers "why is *my* job stuck?" with a 3-line answer plus a
+specific fix when an AdmissionCheck error or queue position can be diagnosed.
+Reads the team-quota ConfigMap to resolve the team's namespace + ClusterQueue.
+"""
+
+import json as _json
+import re
+import subprocess as _subprocess
+from datetime import datetime, timezone
+
+from ..core.cluster import get_cluster_credentials
+from ..core.commands import run_command_for_value
+from ..utils.console import xpk_exit, xpk_print
+from ..utils.validation import (
+    SystemDependency,
+    should_validate_dependencies,
+    validate_dependencies_list,
+)
+
+
+def workload_status(args) -> None:
+  """Show team-Kueue queue status for a workload or an entire team namespace.
+
+  Tells the user if their workload is running, queued normally, or stuck,
+  and provides a plain-English diagnosis with fix instructions.
+
+  Args:
+    args: user provided arguments (--cluster, --team, --workload).
+  """
+  if should_validate_dependencies(args):
+    validate_dependencies_list(
+        args, [SystemDependency.KUBECTL, SystemDependency.GCLOUD]
+    )
+
+  # Fill project from gcloud config if not provided.
+  if not getattr(args, 'project', None):
+    r = _subprocess.run(
+        ['gcloud', 'config', 'get', 'project'], capture_output=True, text=True
+    )
+    args.project = r.stdout.strip().splitlines()[-1] if r.returncode == 0 else ''
+  if not args.project:
+    xpk_print('ERROR: --project not set and could not be determined from gcloud config.')
+    xpk_exit(1)
+
+  # Look up the cluster location directly — avoids requiring compute/zone in
+  # gcloud config (which get_cluster_credentials needs but users often lack).
+  if not getattr(args, 'zone', None):
+    rc, loc = run_command_for_value(
+        f'gcloud container clusters list --project={args.project}'
+        f' --filter=name={args.cluster} --format="value(location)"',
+        task='Find cluster location',
+        quiet=True,
+    )
+    if rc != 0 or not loc.strip():
+      xpk_print(f'ERROR: Could not find cluster "{args.cluster}" in project {args.project}.')
+      xpk_exit(1)
+    args.zone = loc.strip()
+
+  get_cluster_credentials(args)
+
+  # Imported lazily to avoid a circular import: commands/workload.py imports
+  # this module's parser, and we'd otherwise close the loop.
+  from .workload import _resolve_quota_team
+
+  routing = _resolve_quota_team(args)
+  namespace = routing.namespace
+  cq_name = namespace  # ClusterQueue name matches namespace name
+
+  def _kube_json(*kubectl_args):
+    cmd = 'kubectl ' + ' '.join(kubectl_args) + ' -o json'
+    rc, out = run_command_for_value(cmd, task=cmd, quiet=True)
+    if rc != 0 or not out:
+      return None
+    try:
+      return _json.loads(out)
+    except _json.JSONDecodeError:
+      return None
+
+  def _events_text(ns, name):
+    cmd = (
+        f'kubectl get events -n {ns}'
+        f' --field-selector involvedObject.name={name}'
+        f' --sort-by=.lastTimestamp'
+    )
+    rc, out = run_command_for_value(cmd, task='get events', quiet=True)
+    return out.strip() if rc == 0 else ''
+
+  def _age(ts_str):
+    if not ts_str:
+      return '?'
+    ts = datetime.fromisoformat(ts_str.replace('Z', '+00:00'))
+    s = int((datetime.now(timezone.utc) - ts).total_seconds())
+    if s < 60:
+      return f'{s}s'
+    if s < 3600:
+      return f'{s // 60}m'
+    return f'{s // 3600}h{(s % 3600) // 60}m'
+
+  def _cond(wl, ctype):
+    for c in wl.get('status', {}).get('conditions', []):
+      if c.get('type') == ctype:
+        return c
+    return None
+
+  def _is_true(c):
+    return c is not None and c.get('status') == 'True'
+
+  def _cq_chips(cq, section):
+    total = 0
+    for flavor in cq.get('status', {}).get(section, []):
+      for res in flavor.get('resources', []):
+        if res.get('name') == 'google.com/tpu':
+          total += int(res.get('total', 0))
+    return total
+
+  def _cq_quota(cq):
+    nominal, borrow = 0, 0
+    for rg in cq.get('spec', {}).get('resourceGroups', []):
+      for flavor in rg.get('flavors', []):
+        for res in flavor.get('resources', []):
+          if res.get('name') == 'google.com/tpu':
+            nominal += int(res.get('nominalQuota', 0))
+            b = res.get('borrowingLimit')
+            if b is not None:
+              borrow += int(b)
+    return nominal, borrow
+
+  def _ordinal(n):
+    return f"{n}{['th','st','nd','rd','th'][min(n % 10, 4) if n % 100 not in (11,12,13) else 0]}"
+
+  def _xpk_name_of(wl):
+    name = wl['metadata'].get('labels', {}).get('xpk.google.com/workload')
+    if name:
+      return name
+    for ref in wl['metadata'].get('ownerReferences', []):
+      if ref.get('kind') in ('JobSet', 'Job'):
+        return ref.get('name', '')
+    n = wl['metadata']['name']
+    if n.startswith('jobset-'):
+      n = n[len('jobset-'):]
+    if len(n) > 6 and n[-6] == '-':
+      n = n[:-6]
+    return n
+
+  def _print_cq_summary(cq):
+    if not cq:
+      return
+    st = cq.get('status', {})
+    nominal, borrow_limit = _cq_quota(cq)
+    running_chips  = _cq_chips(cq, 'flavorsUsage')
+    reserved_chips = _cq_chips(cq, 'flavorsReservation')
+    admitted   = st.get('admittedWorkloads', 0)
+    reserving  = st.get('reservingWorkloads', 0)
+    pending    = st.get('pendingWorkloads', 0)
+    xpk_print(f'  Quota   : {nominal} chips nominal  +{borrow_limit} borrow  ='
+              f' {nominal + borrow_limit} max')
+    if reserved_chips > 0 and reserved_chips != running_chips:
+      xpk_print(f'  Reserved: {reserved_chips} chips'
+                f' ({reserving} workload(s) — quota held, awaiting admission)')
+    xpk_print(f'  Running : {running_chips} chips ({admitted} workload(s) admitted)')
+    xpk_print(f'  Queued  : {pending} workload(s) waiting for quota')
+
+  def _diagnose_one(wl, all_items, cq):
+    kueue_name = wl['metadata']['name']
+    xpk_name   = _xpk_name_of(wl)
+    created_at = wl['metadata']['creationTimestamp']
+
+    cond_reserved = _cond(wl, 'QuotaReserved')
+    cond_admitted = _cond(wl, 'Admitted')
+    cond_finished = _cond(wl, 'Finished')
+
+    is_admitted = _is_true(cond_admitted)
+    is_reserved = _is_true(cond_reserved)
+    is_finished = _is_true(cond_finished)
+    finish_reason = cond_finished.get('reason', '') if cond_finished else ''
+
+    xpk_print(f'Workload : {xpk_name}  ->  {kueue_name}')
+    xpk_print(f'Age      : {_age(created_at)}')
+
+    if is_finished:
+      status_word = 'success' if finish_reason == 'Succeeded' else finish_reason
+      xpk_print(f'Status   : FINISHED ({status_word})')
+      msg = (cond_finished or {}).get('message', '')
+      if msg:
+        xpk_print(f'           {msg}')
+      xpk_print('')
+      return
+
+    if is_admitted:
+      admitted_ts = (cond_admitted or {}).get('lastTransitionTime', '')
+      xpk_print(f'Status   : RUNNING  (admitted {_age(admitted_ts)} ago)')
+      xpk_print(f'Team quota ({cq_name}):')
+      _print_cq_summary(cq)
+      xpk_print('')
+      return
+
+    if is_reserved:
+      reserved_ts = (cond_reserved or {}).get('lastTransitionTime', '')
+      xpk_print(f'Status   : STUCK — quota reserved but not admitted ({_age(reserved_ts)} ago)')
+      xpk_print(f'Team quota ({cq_name}):')
+      _print_cq_summary(cq)
+      events = _events_text(namespace, kueue_name)
+      warn = [l for l in events.splitlines()
+              if any(w in l for w in ('Warning', 'Error', 'Failed', 'error', 'failed'))]
+      if warn:
+        xpk_print('Diagnosis: AdmissionCheck failed. Error(s):')
+        for line in warn[-3:]:
+          xpk_print(f'  {line.strip()}')
+        if 'more than 49 characters' in events:
+          m = re.search(r'"([^"]*-slice-job-\d+)"', events)
+          max_len = 23 - len(namespace)
+          xpk_print('')
+          xpk_print(f'  Fix: --workload name "{xpk_name}" ({len(xpk_name)} chars)'
+                    f' exceeds the {max_len}-char limit for {namespace}.')
+          xpk_print(f'       Delete the JobSet and resubmit with a name <= {max_len} chars.')
+          xpk_print(f'       Example: {xpk_name[:max_len]}')
+      else:
+        xpk_print('Diagnosis: AdmissionCheck still processing (no errors yet).')
+        xpk_print(f'  kubectl describe workload {kueue_name} -n {namespace}')
+      xpk_print('')
+      return
+
+    # Queued — compute position
+    my_ts  = created_at
+    my_pri = wl.get('spec', {}).get('priority') or 0
+    ahead = []
+    for other in all_items:
+      oname = other['metadata']['name']
+      if oname == kueue_name:
+        continue
+      if _is_true(_cond(other, 'Admitted')) or _is_true(_cond(other, 'Finished')):
+        continue
+      if _is_true(_cond(other, 'QuotaReserved')):
+        continue
+      other_ts  = other['metadata']['creationTimestamp']
+      other_pri = other.get('spec', {}).get('priority') or 0
+      if other_pri > my_pri or (other_pri == my_pri and other_ts < my_ts):
+        ahead.append(_xpk_name_of(other))
+
+    pos = len(ahead) + 1
+    xpk_print('Status   : QUEUED — waiting for quota')
+    if ahead:
+      sample = ', '.join(ahead[:3]) + ('...' if len(ahead) > 3 else '')
+      xpk_print(f'Position : {_ordinal(pos)} in line  ({len(ahead)} workload(s) ahead: {sample})')
+    else:
+      xpk_print(f'Position : {_ordinal(pos)} in line  (nothing ahead of you in this queue)')
+    xpk_print(f'Team quota ({cq_name}):')
+    _print_cq_summary(cq)
+
+    # Anomaly detection
+    st = (cq or {}).get('status', {})
+    nominal, _ = _cq_quota(cq) if cq else (0, 0)
+    running = _cq_chips(cq, 'flavorsUsage') if cq else 0
+    if pos == 1 and st.get('admittedWorkloads', 0) == 0 and running == 0 and nominal > 0:
+      xpk_print('Diagnosis: You\'re 1st in line with quota available but nothing running.')
+      xpk_print(f'  This is unusual. Check: kubectl describe workload {kueue_name} -n {namespace}')
+    elif pos == 1 and nominal > 0 and running < nominal * 0.9:
+      xpk_print('Diagnosis: You\'re 1st in line and quota is not full — should be admitted soon.')
+      xpk_print('  If still queued in a few minutes, check:')
+      xpk_print(f'  kubectl describe workload {kueue_name} -n {namespace}')
+    else:
+      xpk_print('Diagnosis: Things look normal — waiting behind other workloads.')
+    xpk_print('')
+
+  cq = _kube_json('get', 'clusterqueue', cq_name)
+  all_wl_data = _kube_json('get', 'workload', '-n', namespace)
+  all_items = all_wl_data.get('items', []) if all_wl_data else []
+
+  if args.workload:
+    prefix = f'jobset-{args.workload}-'
+    matches = [i for i in all_items if i['metadata']['name'].startswith(prefix)]
+    if not matches:
+      xpk_print(f'No workload found matching "{prefix}*" in {namespace}')
+      xpk_exit(1)
+    if len(matches) > 1:
+      names = [i['metadata']['name'] for i in matches]
+      xpk_print(f'Multiple matches: {names}. Use the full Kueue name with --workload.')
+      xpk_exit(1)
+    _diagnose_one(matches[0], all_items, cq)
+  else:
+    if not all_items:
+      xpk_print(f'No workloads in {namespace} — queue is empty.')
+      xpk_print(f'Team quota ({cq_name}):')
+      if cq:
+        nominal, borrow = _cq_quota(cq)
+        xpk_print(f'  Quota: {nominal} chips nominal  +{borrow} borrow  = {nominal + borrow} max')
+      xpk_exit(0)
+
+    def _sort_key(i):
+      return (0 if _is_true(_cond(i, 'Admitted')) else 1,
+              i['metadata']['creationTimestamp'])
+
+    for item in sorted(all_items, key=_sort_key):
+      _diagnose_one(item, all_items, cq)
+
+  xpk_exit(0)

--- a/src/xpk/commands/workload_status.py
+++ b/src/xpk/commands/workload_status.py
@@ -23,7 +23,6 @@ Reads the team-quota ConfigMap to resolve the team's namespace + ClusterQueue.
 """
 
 import json as _json
-import re
 import subprocess as _subprocess
 from datetime import datetime, timezone
 
@@ -54,7 +53,8 @@ def workload_status(args) -> None:
   # Fill project from gcloud config if not provided.
   if not getattr(args, 'project', None):
     r = _subprocess.run(
-        ['gcloud', 'config', 'get', 'project'], capture_output=True, text=True
+        ['gcloud', 'config', 'get', 'project'],
+        capture_output=True, text=True, check=False,
     )
     args.project = r.stdout.strip().splitlines()[-1] if r.returncode == 0 else ''
   if not args.project:
@@ -79,7 +79,7 @@ def workload_status(args) -> None:
 
   # Imported lazily to avoid a circular import: commands/workload.py imports
   # this module's parser, and we'd otherwise close the loop.
-  from .workload import _resolve_quota_team
+  from .workload import _resolve_quota_team  # pylint: disable=import-outside-toplevel
 
   routing = _resolve_quota_team(args)
   namespace = routing.namespace
@@ -226,7 +226,6 @@ def workload_status(args) -> None:
         for line in warn[-3:]:
           xpk_print(f'  {line.strip()}')
         if 'more than 49 characters' in events:
-          m = re.search(r'"([^"]*-slice-job-\d+)"', events)
           max_len = 23 - len(namespace)
           xpk_print('')
           xpk_print(f'  Fix: --workload name "{xpk_name}" ({len(xpk_name)} chars)'

--- a/src/xpk/commands/workload_status.py
+++ b/src/xpk/commands/workload_status.py
@@ -54,11 +54,18 @@ def workload_status(args) -> None:
   if not getattr(args, 'project', None):
     r = _subprocess.run(
         ['gcloud', 'config', 'get', 'project'],
-        capture_output=True, text=True, check=False,
+        capture_output=True,
+        text=True,
+        check=False,
     )
-    args.project = r.stdout.strip().splitlines()[-1] if r.returncode == 0 else ''
+    args.project = (
+        r.stdout.strip().splitlines()[-1] if r.returncode == 0 else ''
+    )
   if not args.project:
-    xpk_print('ERROR: --project not set and could not be determined from gcloud config.')
+    xpk_print(
+        'ERROR: --project not set and could not be determined from gcloud'
+        ' config.'
+    )
     xpk_exit(1)
 
   # Look up the cluster location directly — avoids requiring compute/zone in
@@ -71,7 +78,10 @@ def workload_status(args) -> None:
         quiet=True,
     )
     if rc != 0 or not loc.strip():
-      xpk_print(f'ERROR: Could not find cluster "{args.cluster}" in project {args.project}.')
+      xpk_print(
+          f'ERROR: Could not find cluster "{args.cluster}" in project'
+          f' {args.project}.'
+      )
       xpk_exit(1)
     args.zone = loc.strip()
 
@@ -99,7 +109,7 @@ def workload_status(args) -> None:
     cmd = (
         f'kubectl get events -n {ns}'
         f' --field-selector involvedObject.name={name}'
-        f' --sort-by=.lastTimestamp'
+        ' --sort-by=.lastTimestamp'
     )
     rc, out = run_command_for_value(cmd, task='get events', quiet=True)
     return out.strip() if rc == 0 else ''
@@ -145,7 +155,9 @@ def workload_status(args) -> None:
     return nominal, borrow
 
   def _ordinal(n):
-    return f"{n}{['th','st','nd','rd','th'][min(n % 10, 4) if n % 100 not in (11,12,13) else 0]}"
+    return (
+        f"{n}{['th','st','nd','rd','th'][min(n % 10, 4) if n % 100 not in (11,12,13) else 0]}"
+    )
 
   def _xpk_name_of(wl):
     name = wl['metadata'].get('labels', {}).get('xpk.google.com/workload')
@@ -156,7 +168,7 @@ def workload_status(args) -> None:
         return ref.get('name', '')
     n = wl['metadata']['name']
     if n.startswith('jobset-'):
-      n = n[len('jobset-'):]
+      n = n[len('jobset-') :]
     if len(n) > 6 and n[-6] == '-':
       n = n[:-6]
     return n
@@ -166,22 +178,28 @@ def workload_status(args) -> None:
       return
     st = cq.get('status', {})
     nominal, borrow_limit = _cq_quota(cq)
-    running_chips  = _cq_chips(cq, 'flavorsUsage')
+    running_chips = _cq_chips(cq, 'flavorsUsage')
     reserved_chips = _cq_chips(cq, 'flavorsReservation')
-    admitted   = st.get('admittedWorkloads', 0)
-    reserving  = st.get('reservingWorkloads', 0)
-    pending    = st.get('pendingWorkloads', 0)
-    xpk_print(f'  Quota   : {nominal} chips nominal  +{borrow_limit} borrow  ='
-              f' {nominal + borrow_limit} max')
+    admitted = st.get('admittedWorkloads', 0)
+    reserving = st.get('reservingWorkloads', 0)
+    pending = st.get('pendingWorkloads', 0)
+    xpk_print(
+        f'  Quota   : {nominal} chips nominal  +{borrow_limit} borrow  ='
+        f' {nominal + borrow_limit} max'
+    )
     if reserved_chips > 0 and reserved_chips != running_chips:
-      xpk_print(f'  Reserved: {reserved_chips} chips'
-                f' ({reserving} workload(s) — quota held, awaiting admission)')
-    xpk_print(f'  Running : {running_chips} chips ({admitted} workload(s) admitted)')
+      xpk_print(
+          f'  Reserved: {reserved_chips} chips'
+          f' ({reserving} workload(s) — quota held, awaiting admission)'
+      )
+    xpk_print(
+        f'  Running : {running_chips} chips ({admitted} workload(s) admitted)'
+    )
     xpk_print(f'  Queued  : {pending} workload(s) waiting for quota')
 
   def _diagnose_one(wl, all_items, cq):
     kueue_name = wl['metadata']['name']
-    xpk_name   = _xpk_name_of(wl)
+    xpk_name = _xpk_name_of(wl)
     created_at = wl['metadata']['creationTimestamp']
 
     cond_reserved = _cond(wl, 'QuotaReserved')
@@ -215,12 +233,20 @@ def workload_status(args) -> None:
 
     if is_reserved:
       reserved_ts = (cond_reserved or {}).get('lastTransitionTime', '')
-      xpk_print(f'Status   : STUCK — quota reserved but not admitted ({_age(reserved_ts)} ago)')
+      xpk_print(
+          'Status   : STUCK — quota reserved but not admitted'
+          f' ({_age(reserved_ts)} ago)'
+      )
       xpk_print(f'Team quota ({cq_name}):')
       _print_cq_summary(cq)
       events = _events_text(namespace, kueue_name)
-      warn = [l for l in events.splitlines()
-              if any(w in l for w in ('Warning', 'Error', 'Failed', 'error', 'failed'))]
+      warn = [
+          l
+          for l in events.splitlines()
+          if any(
+              w in l for w in ('Warning', 'Error', 'Failed', 'error', 'failed')
+          )
+      ]
       if warn:
         xpk_print('Diagnosis: AdmissionCheck failed. Error(s):')
         for line in warn[-3:]:
@@ -228,9 +254,14 @@ def workload_status(args) -> None:
         if 'more than 49 characters' in events:
           max_len = 23 - len(namespace)
           xpk_print('')
-          xpk_print(f'  Fix: --workload name "{xpk_name}" ({len(xpk_name)} chars)'
-                    f' exceeds the {max_len}-char limit for {namespace}.')
-          xpk_print(f'       Delete the JobSet and resubmit with a name <= {max_len} chars.')
+          xpk_print(
+              f'  Fix: --workload name "{xpk_name}" ({len(xpk_name)} chars)'
+              f' exceeds the {max_len}-char limit for {namespace}.'
+          )
+          xpk_print(
+              '       Delete the JobSet and resubmit with a name <='
+              f' {max_len} chars.'
+          )
           xpk_print(f'       Example: {xpk_name[:max_len]}')
       else:
         xpk_print('Diagnosis: AdmissionCheck still processing (no errors yet).')
@@ -239,18 +270,20 @@ def workload_status(args) -> None:
       return
 
     # Queued — compute position
-    my_ts  = created_at
+    my_ts = created_at
     my_pri = wl.get('spec', {}).get('priority') or 0
     ahead = []
     for other in all_items:
       oname = other['metadata']['name']
       if oname == kueue_name:
         continue
-      if _is_true(_cond(other, 'Admitted')) or _is_true(_cond(other, 'Finished')):
+      if _is_true(_cond(other, 'Admitted')) or _is_true(
+          _cond(other, 'Finished')
+      ):
         continue
       if _is_true(_cond(other, 'QuotaReserved')):
         continue
-      other_ts  = other['metadata']['creationTimestamp']
+      other_ts = other['metadata']['creationTimestamp']
       other_pri = other.get('spec', {}).get('priority') or 0
       if other_pri > my_pri or (other_pri == my_pri and other_ts < my_ts):
         ahead.append(_xpk_name_of(other))
@@ -259,9 +292,15 @@ def workload_status(args) -> None:
     xpk_print('Status   : QUEUED — waiting for quota')
     if ahead:
       sample = ', '.join(ahead[:3]) + ('...' if len(ahead) > 3 else '')
-      xpk_print(f'Position : {_ordinal(pos)} in line  ({len(ahead)} workload(s) ahead: {sample})')
+      xpk_print(
+          f'Position : {_ordinal(pos)} in line  ({len(ahead)} workload(s)'
+          f' ahead: {sample})'
+      )
     else:
-      xpk_print(f'Position : {_ordinal(pos)} in line  (nothing ahead of you in this queue)')
+      xpk_print(
+          f'Position : {_ordinal(pos)} in line  (nothing ahead of you in this'
+          ' queue)'
+      )
     xpk_print(f'Team quota ({cq_name}):')
     _print_cq_summary(cq)
 
@@ -269,15 +308,31 @@ def workload_status(args) -> None:
     st = (cq or {}).get('status', {})
     nominal, _ = _cq_quota(cq) if cq else (0, 0)
     running = _cq_chips(cq, 'flavorsUsage') if cq else 0
-    if pos == 1 and st.get('admittedWorkloads', 0) == 0 and running == 0 and nominal > 0:
-      xpk_print('Diagnosis: You\'re 1st in line with quota available but nothing running.')
-      xpk_print(f'  This is unusual. Check: kubectl describe workload {kueue_name} -n {namespace}')
+    if (
+        pos == 1
+        and st.get('admittedWorkloads', 0) == 0
+        and running == 0
+        and nominal > 0
+    ):
+      xpk_print(
+          "Diagnosis: You're 1st in line with quota available but nothing"
+          ' running.'
+      )
+      xpk_print(
+          f'  This is unusual. Check: kubectl describe workload {kueue_name} -n'
+          f' {namespace}'
+      )
     elif pos == 1 and nominal > 0 and running < nominal * 0.9:
-      xpk_print('Diagnosis: You\'re 1st in line and quota is not full — should be admitted soon.')
+      xpk_print(
+          "Diagnosis: You're 1st in line and quota is not full — should be"
+          ' admitted soon.'
+      )
       xpk_print('  If still queued in a few minutes, check:')
       xpk_print(f'  kubectl describe workload {kueue_name} -n {namespace}')
     else:
-      xpk_print('Diagnosis: Things look normal — waiting behind other workloads.')
+      xpk_print(
+          'Diagnosis: Things look normal — waiting behind other workloads.'
+      )
     xpk_print('')
 
   cq = _kube_json('get', 'clusterqueue', cq_name)
@@ -292,7 +347,9 @@ def workload_status(args) -> None:
       xpk_exit(1)
     if len(matches) > 1:
       names = [i['metadata']['name'] for i in matches]
-      xpk_print(f'Multiple matches: {names}. Use the full Kueue name with --workload.')
+      xpk_print(
+          f'Multiple matches: {names}. Use the full Kueue name with --workload.'
+      )
       xpk_exit(1)
     _diagnose_one(matches[0], all_items, cq)
   else:
@@ -301,12 +358,17 @@ def workload_status(args) -> None:
       xpk_print(f'Team quota ({cq_name}):')
       if cq:
         nominal, borrow = _cq_quota(cq)
-        xpk_print(f'  Quota: {nominal} chips nominal  +{borrow} borrow  = {nominal + borrow} max')
+        xpk_print(
+            f'  Quota: {nominal} chips nominal  +{borrow} borrow  ='
+            f' {nominal + borrow} max'
+        )
       xpk_exit(0)
 
     def _sort_key(i):
-      return (0 if _is_true(_cond(i, 'Admitted')) else 1,
-              i['metadata']['creationTimestamp'])
+      return (
+          0 if _is_true(_cond(i, 'Admitted')) else 1,
+          i['metadata']['creationTimestamp'],
+      )
 
     for item in sorted(all_items, key=_sort_key):
       _diagnose_one(item, all_items, cq)

--- a/src/xpk/core/kubectl_common.py
+++ b/src/xpk/core/kubectl_common.py
@@ -28,6 +28,7 @@ class KubernetesCondition:
   status: str | None = None
   lastTransitionTime: str | None = None
   message: str | None = None
+  reason: str | None = None
 
 
 @dataclass(frozen=True)
@@ -51,6 +52,7 @@ def parse_kubernetes_status(
             status=c.get("status") or None,
             lastTransitionTime=c.get("lastTransitionTime") or None,
             message=c.get("message") or None,
+            reason=c.get("reason") or None,
         )
     )
 

--- a/src/xpk/core/kubectl_common_test.py
+++ b/src/xpk/core/kubectl_common_test.py
@@ -180,6 +180,7 @@ def test_parse_kubernetes_status():
               "status": "True",
               "lastTransitionTime": "2023-01-01T00:00:00Z",
               "message": "All good",
+              "reason": "Healthy",
           },
           {"type": "Test", "status": "", "lastTransitionTime": None},
       ]
@@ -192,11 +193,13 @@ def test_parse_kubernetes_status():
   assert status.conditions[0].status == "True"
   assert status.conditions[0].lastTransitionTime == "2023-01-01T00:00:00Z"
   assert status.conditions[0].message == "All good"
+  assert status.conditions[0].reason == "Healthy"
 
   assert status.conditions[1].type == "Test"
   assert status.conditions[1].status is None
   assert status.conditions[1].lastTransitionTime is None
   assert status.conditions[1].message is None
+  assert status.conditions[1].reason is None
 
 
 def test_parse_kubernetes_status_empty():

--- a/src/xpk/core/kueue_manager.py
+++ b/src/xpk/core/kueue_manager.py
@@ -47,6 +47,28 @@ LATEST_BREAKING_VERSION = Version("v0.15.0")
 WAIT_FOR_KUEUE_TIMEOUT = "10m"
 CLUSTER_QUEUE_NAME = "cluster-queue"
 LOCAL_QUEUE_NAME = "multislice-queue"
+
+# PoC quota system: team → (namespace, local-queue, priority-class)
+# When --team is specified, these override the defaults above.
+POC_TEAM_CONFIG = {
+    "ml-perf":            ("poc-ml-perf",            "lq", "poc-ml-perf-priority"),
+    "nightly-regression": ("poc-nightly",            "lq", "poc-nightly-priority"),
+    "gsc":                ("poc-gsc",                "lq", "poc-gsc-priority"),
+    "dev":                ("poc-dev",                "lq", "poc-dev-priority"),
+    "scale-test":         ("poc-scale-test",         "lq", "poc-scale-test-priority"),
+}
+
+# Max safe JobSet name length per PoC namespace (= xpk --workload argument).
+# Kueue auto-names the Workload as "jobset-{name}-{hash5}" (13+len(name) chars).
+# The slice controller shortens the Slice name to "{ns}-{workload}-s-{hash5}".
+# Full constraint: len(ns)+1+(13+len(name))+8 <= 49  =>  len(name) <= 27-len(ns)
+POC_TEAM_MAX_WORKLOAD_NAME = {
+    "ml-perf":            16,  # namespace=poc-ml-perf (11):            27-11=16
+    "nightly-regression": 16,  # namespace=poc-nightly (11):            27-11=16
+    "gsc":                20,  # namespace=poc-gsc (7):                 27-7=20
+    "dev":                20,  # namespace=poc-dev (7):                 27-7=20
+    "scale-test":         13,  # namespace=poc-scale-test (14):         27-14=13
+}
 SUB_SLICE_TOPOLOGY_NAME = "sub-slice-topology"
 SUPER_SLICE_TOPOLOGY_NAME = "super-slice-topology"
 KUEUE_CONFIG_JINJA_FILE = "kueue_config.yaml.j2"

--- a/src/xpk/core/kueue_manager.py
+++ b/src/xpk/core/kueue_manager.py
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import hashlib
 import math
 from dataclasses import dataclass
 from typing import Optional, List, Dict, Any
@@ -48,27 +49,32 @@ WAIT_FOR_KUEUE_TIMEOUT = "10m"
 CLUSTER_QUEUE_NAME = "cluster-queue"
 LOCAL_QUEUE_NAME = "multislice-queue"
 
-# PoC quota system: team → (namespace, local-queue, priority-class)
-# When --team is specified, these override the defaults above.
-POC_TEAM_CONFIG = {
-    "ml-perf":            ("poc-ml-perf",            "lq", "poc-ml-perf-priority"),
-    "nightly-regression": ("poc-nightly",            "lq", "poc-nightly-priority"),
-    "gsc":                ("poc-gsc",                "lq", "poc-gsc-priority"),
-    "dev":                ("poc-dev",                "lq", "poc-dev-priority"),
-    "scale-test":         ("poc-scale-test",         "lq", "poc-scale-test-priority"),
-}
+def derive_k8s_workload_name(display_name: str, max_len: int) -> str:
+  """Derive a short K8s-safe JobSet name from a user-provided display name.
 
-# Max safe JobSet name length per PoC namespace (= xpk --workload argument).
-# Kueue auto-names the Workload as "jobset-{name}-{hash5}" (13+len(name) chars).
-# The slice controller shortens the Slice name to "{ns}-{workload}-s-{hash5}".
-# Full constraint: len(ns)+1+(13+len(name))+8 <= 49  =>  len(name) <= 27-len(ns)
-POC_TEAM_MAX_WORKLOAD_NAME = {
-    "ml-perf":            16,  # namespace=poc-ml-perf (11):            27-11=16
-    "nightly-regression": 16,  # namespace=poc-nightly (11):            27-11=16
-    "gsc":                20,  # namespace=poc-gsc (7):                 27-7=20
-    "dev":                20,  # namespace=poc-dev (7):                 27-7=20
-    "scale-test":         13,  # namespace=poc-scale-test (14):         27-14=13
-}
+  The superslice admission controller requires slice names ≤ 49 chars:
+    {namespace}-jobset-{k8s_name}-{kueue_hash5}-slice-job-{i}
+  So k8s_name must be ≤ max_len chars. max_len comes from the cluster's
+  poc-team-config ConfigMap (see poc_discovery.max_k8s_workload_name_len),
+  computed from len(namespace) and the super-slice admission controller's
+  char-limit / fixed-overhead constants.
+
+  Format: {ldap_prefix}-{hex4}
+  - ldap_prefix: display_name up to the first '-', truncated to fit
+  - hex4: first 4 hex chars of SHA256(display_name) — deterministic, so
+    'xpk workload delete/status --workload=<display_name>' can reconstruct
+    the same k8s_name for lookup (though the label is the primary lookup key).
+
+  The mapping is deterministic: same display_name → same k8s_name.
+  Users avoid collisions by including a unique suffix in their display name
+  (e.g. 'amandaliang-run42'), which propagates into the hex4.
+  """
+  # Reserve 5 chars for '-' + 4 hex digits
+  max_prefix = max_len - 5
+  ldap = display_name.split('-')[0]
+  prefix = ldap[:max_prefix]
+  hex4 = hashlib.sha256(display_name.encode()).hexdigest()[:4]
+  return f'{prefix}-{hex4}'
 SUB_SLICE_TOPOLOGY_NAME = "sub-slice-topology"
 SUPER_SLICE_TOPOLOGY_NAME = "super-slice-topology"
 KUEUE_CONFIG_JINJA_FILE = "kueue_config.yaml.j2"

--- a/src/xpk/core/kueue_manager.py
+++ b/src/xpk/core/kueue_manager.py
@@ -49,13 +49,26 @@ WAIT_FOR_KUEUE_TIMEOUT = "10m"
 CLUSTER_QUEUE_NAME = "cluster-queue"
 LOCAL_QUEUE_NAME = "multislice-queue"
 
+SUB_SLICE_TOPOLOGY_NAME = "sub-slice-topology"
+SUPER_SLICE_TOPOLOGY_NAME = "super-slice-topology"
+KUEUE_CONFIG_JINJA_FILE = "kueue_config.yaml.j2"
+KUEUE_GKE_DEFAULT_TOPOLOGY_JINJA_FILE = "kueue_gke_default_topology.yaml.j2"
+KUEUE_CONTROLLER_MANAGER_JINJA_FILE = "kueue_controller_manager.yaml.j2"
+KUEUE_SUB_SLICING_TOPOLOGY_JINJA_FILE = "kueue_sub_slicing_topology.yaml.j2"
+KUEUE_SUPER_SLICING_TOPOLOGY_JINJA_FILE = "kueue_super_slicing_topology.yaml.j2"
+MEMORY_SIZE_PER_VM = 32
+MIN_MEMORY_LIMIT_SIZE = 4096
+CPU_SIZE_PER_VM = 0.004
+MIN_CPU_LIMIT_SIZE = 2
+
+
 def derive_k8s_workload_name(display_name: str, max_len: int) -> str:
   """Derive a short K8s-safe JobSet name from a user-provided display name.
 
-  The superslice admission controller requires slice names ≤ 49 chars:
+  The super-slice admission controller requires slice names ≤ ~49 chars:
     {namespace}-jobset-{k8s_name}-{kueue_hash5}-slice-job-{i}
   So k8s_name must be ≤ max_len chars. max_len comes from the cluster's
-  poc-team-config ConfigMap (see poc_discovery.max_k8s_workload_name_len),
+  team-quota ConfigMap (see quota_discovery.max_k8s_workload_name_len),
   computed from len(namespace) and the super-slice admission controller's
   char-limit / fixed-overhead constants.
 
@@ -75,17 +88,6 @@ def derive_k8s_workload_name(display_name: str, max_len: int) -> str:
   prefix = ldap[:max_prefix]
   hex4 = hashlib.sha256(display_name.encode()).hexdigest()[:4]
   return f'{prefix}-{hex4}'
-SUB_SLICE_TOPOLOGY_NAME = "sub-slice-topology"
-SUPER_SLICE_TOPOLOGY_NAME = "super-slice-topology"
-KUEUE_CONFIG_JINJA_FILE = "kueue_config.yaml.j2"
-KUEUE_GKE_DEFAULT_TOPOLOGY_JINJA_FILE = "kueue_gke_default_topology.yaml.j2"
-KUEUE_CONTROLLER_MANAGER_JINJA_FILE = "kueue_controller_manager.yaml.j2"
-KUEUE_SUB_SLICING_TOPOLOGY_JINJA_FILE = "kueue_sub_slicing_topology.yaml.j2"
-KUEUE_SUPER_SLICING_TOPOLOGY_JINJA_FILE = "kueue_super_slicing_topology.yaml.j2"
-MEMORY_SIZE_PER_VM = 32
-MIN_MEMORY_LIMIT_SIZE = 4096
-CPU_SIZE_PER_VM = 0.004
-MIN_CPU_LIMIT_SIZE = 2
 
 
 @dataclass(frozen=True)

--- a/src/xpk/core/kueue_manager.py
+++ b/src/xpk/core/kueue_manager.py
@@ -84,10 +84,10 @@ def derive_k8s_workload_name(display_name: str, max_len: int) -> str:
   """
   # Reserve 5 chars for '-' + 4 hex digits
   max_prefix = max_len - 5
-  ldap = display_name.split('-')[0]
+  ldap = display_name.split("-")[0]
   prefix = ldap[:max_prefix]
   hex4 = hashlib.sha256(display_name.encode()).hexdigest()[:4]
-  return f'{prefix}-{hex4}'
+  return f"{prefix}-{hex4}"
 
 
 @dataclass(frozen=True)

--- a/src/xpk/core/kueue_manager_test.py
+++ b/src/xpk/core/kueue_manager_test.py
@@ -22,7 +22,7 @@ import yaml
 from unittest.mock import MagicMock, patch
 
 from xpk.core.kubectl_common import PatchResources
-from xpk.core.kueue_manager import KueueConfig, KueueManager, has_sub_slicing_enabled, has_super_slicing_enabled
+from xpk.core.kueue_manager import KueueConfig, KueueManager, derive_k8s_workload_name, has_sub_slicing_enabled, has_super_slicing_enabled
 from xpk.core.system_characteristics import GpuConfig, DockerPlatform, AcceleratorType, SystemCharacteristics, UserFacingNameToSystemCharacteristics
 from xpk.core.testing.commands_tester import CommandsTester
 from packaging.version import Version
@@ -722,8 +722,6 @@ def _first(generator: Generator[T, None, None]) -> T:
 # derive_k8s_workload_name
 # ---------------------------------------------------------------------------
 
-from xpk.core.kueue_manager import derive_k8s_workload_name
-
 
 def test_derive_k8s_workload_name_is_deterministic():
   a = derive_k8s_workload_name("amandaliang-run42", max_len=12)
@@ -742,7 +740,7 @@ def test_derive_k8s_workload_name_uses_ldap_prefix_before_first_dash():
   result = derive_k8s_workload_name("amandaliang-run42", max_len=12)
   assert result.startswith("amandal")  # first 7 chars of 'amandaliang'
   # Suffix is 4 hex chars.
-  assert len(result.split("-")[-1]) == 4
+  assert len(result.rsplit("-", maxsplit=1)[-1]) == 4
 
 
 def test_derive_k8s_workload_name_distinguishes_different_inputs():
@@ -756,4 +754,4 @@ def test_derive_k8s_workload_name_short_input_still_gets_hashed():
   # short hash-suffixed name (so callers can rely on the format).
   result = derive_k8s_workload_name("a", max_len=12)
   assert "-" in result
-  assert len(result.split("-")[-1]) == 4
+  assert len(result.rsplit("-", maxsplit=1)[-1]) == 4

--- a/src/xpk/core/kueue_manager_test.py
+++ b/src/xpk/core/kueue_manager_test.py
@@ -716,3 +716,44 @@ def _first(generator: Generator[T, None, None]) -> T:
   result = next(generator, None)
   assert result is not None
   return result
+
+
+# ---------------------------------------------------------------------------
+# derive_k8s_workload_name
+# ---------------------------------------------------------------------------
+
+from xpk.core.kueue_manager import derive_k8s_workload_name
+
+
+def test_derive_k8s_workload_name_is_deterministic():
+  a = derive_k8s_workload_name("amandaliang-run42", max_len=12)
+  b = derive_k8s_workload_name("amandaliang-run42", max_len=12)
+  assert a == b
+
+
+def test_derive_k8s_workload_name_respects_max_len():
+  result = derive_k8s_workload_name("very-long-display-name-that-overflows", max_len=12)
+  assert len(result) <= 12
+
+
+def test_derive_k8s_workload_name_uses_ldap_prefix_before_first_dash():
+  # Prefix is everything before the first '-', truncated. With max_len=12 and
+  # 5 chars reserved for '-' + 4-hex-suffix, prefix budget = 7 chars.
+  result = derive_k8s_workload_name("amandaliang-run42", max_len=12)
+  assert result.startswith("amandal")  # first 7 chars of 'amandaliang'
+  # Suffix is 4 hex chars.
+  assert len(result.split("-")[-1]) == 4
+
+
+def test_derive_k8s_workload_name_distinguishes_different_inputs():
+  a = derive_k8s_workload_name("alice-job1", max_len=12)
+  b = derive_k8s_workload_name("alice-job2", max_len=12)
+  assert a != b  # different inputs → different hex4 suffixes
+
+
+def test_derive_k8s_workload_name_short_input_still_gets_hashed():
+  # Even when input fits within max_len, the function still derives a
+  # short hash-suffixed name (so callers can rely on the format).
+  result = derive_k8s_workload_name("a", max_len=12)
+  assert "-" in result
+  assert len(result.split("-")[-1]) == 4

--- a/src/xpk/core/kueue_manager_test.py
+++ b/src/xpk/core/kueue_manager_test.py
@@ -718,11 +718,6 @@ def _first(generator: Generator[T, None, None]) -> T:
   return result
 
 
-# ---------------------------------------------------------------------------
-# derive_k8s_workload_name
-# ---------------------------------------------------------------------------
-
-
 def test_derive_k8s_workload_name_is_deterministic():
   a = derive_k8s_workload_name("amandaliang-run42", max_len=12)
   b = derive_k8s_workload_name("amandaliang-run42", max_len=12)

--- a/src/xpk/core/kueue_manager_test.py
+++ b/src/xpk/core/kueue_manager_test.py
@@ -730,7 +730,9 @@ def test_derive_k8s_workload_name_is_deterministic():
 
 
 def test_derive_k8s_workload_name_respects_max_len():
-  result = derive_k8s_workload_name("very-long-display-name-that-overflows", max_len=12)
+  result = derive_k8s_workload_name(
+      "very-long-display-name-that-overflows", max_len=12
+  )
   assert len(result) <= 12
 
 

--- a/src/xpk/core/local_cache.py
+++ b/src/xpk/core/local_cache.py
@@ -1,0 +1,164 @@
+"""
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+"""Tiny per-cluster cache of PoC config for faster errors + tab completion.
+
+Populated automatically whenever xpk successfully fetches the `poc-team-config`
+ConfigMap from a cluster. Read by:
+  - argcomplete completers (sub-second tab completion without a cluster call)
+  - error-message suggesters ("did you mean ...")
+
+No secrets are stored. The cache is advisory: if it is stale, out of sync, or
+absent, xpk falls through to live discovery with no behavior change.
+
+Layout:
+  ~/.xpk/poc-cache/<kubectl-context>.json
+"""
+
+import datetime as _dt
+import json
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+CACHE_DIR = Path.home() / ".xpk" / "poc-cache"
+DEFAULT_TTL = _dt.timedelta(hours=1)
+
+
+def _safe_key(name: str) -> str:
+  return "".join(c if c.isalnum() or c in "-._" else "_" for c in name)
+
+
+def _path_for(context: str) -> Path:
+  return CACHE_DIR / f"{_safe_key(context)}.json"
+
+
+def current_context() -> str | None:
+  """Return the current kubectl context, or None."""
+  try:
+    r = subprocess.run(
+        ["kubectl", "config", "current-context"],
+        capture_output=True, text=True, timeout=5,
+    )
+  except (FileNotFoundError, subprocess.TimeoutExpired):
+    return None
+  if r.returncode != 0:
+    return None
+  return (r.stdout or "").strip() or None
+
+
+def write(context: str, cfg: dict) -> None:
+  """Persist cfg under this cluster's context. Best-effort."""
+  if not context:
+    return
+  try:
+    CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    try:
+      os.chmod(CACHE_DIR, 0o700)
+    except OSError:
+      pass
+    payload = {
+        "context":      context,
+        "fetchedAt":    _dt.datetime.now(_dt.timezone.utc).isoformat(timespec="seconds"),
+        "teams":        sorted((cfg.get("teams") or {}).keys()),
+        "valueClasses": list(cfg.get("valueClasses") or []),
+        "sliceName":    cfg.get("sliceName") or {},
+    }
+    dst = _path_for(context)
+    with tempfile.NamedTemporaryFile(
+        "w", dir=CACHE_DIR, delete=False, encoding="utf-8"
+    ) as tmp:
+      json.dump(payload, tmp, indent=2)
+      tmp.flush()
+      os.fsync(tmp.fileno())
+      tmp_path = Path(tmp.name)
+    os.chmod(tmp_path, 0o600)
+    tmp_path.replace(dst)
+  except Exception:  # pylint: disable=broad-except
+    pass  # cache is strictly best-effort
+
+
+def read(context: str) -> dict | None:
+  """Return cached payload for this context, or None."""
+  if not context:
+    return None
+  try:
+    p = _path_for(context)
+    if not p.exists():
+      return None
+    return json.loads(p.read_text())
+  except Exception:  # pylint: disable=broad-except
+    return None
+
+
+def invalidate(context: str) -> None:
+  try:
+    _path_for(context).unlink(missing_ok=True)
+  except Exception:  # pylint: disable=broad-except
+    pass
+
+
+def is_fresh(payload: dict, ttl: _dt.timedelta = DEFAULT_TTL) -> bool:
+  try:
+    ts = _dt.datetime.fromisoformat(payload["fetchedAt"])
+  except (KeyError, ValueError):
+    return False
+  if ts.tzinfo is None:
+    ts = ts.replace(tzinfo=_dt.timezone.utc)
+  return _dt.datetime.now(_dt.timezone.utc) - ts <= ttl
+
+
+def all_contexts() -> list[str]:
+  """Every cluster context we've cached — used by completers when the user
+  hasn't yet specified --cluster."""
+  if not CACHE_DIR.exists():
+    return []
+  out = []
+  for p in CACHE_DIR.glob("*.json"):
+    try:
+      c = json.loads(p.read_text()).get("context")
+      if c:
+        out.append(c)
+    except Exception:  # pylint: disable=broad-except
+      continue
+  return out
+
+
+def gke_contexts_from_kubeconfig() -> list[str]:
+  """Return kubectl contexts that look like GKE clusters (prefix gke_).
+  Used to tab-complete the --cluster flag."""
+  try:
+    r = subprocess.run(
+        ["kubectl", "config", "get-contexts", "-o", "name"],
+        capture_output=True, text=True, timeout=5,
+    )
+  except (FileNotFoundError, subprocess.TimeoutExpired):
+    return []
+  if r.returncode != 0:
+    return []
+  ctxs = [line.strip() for line in r.stdout.splitlines() if line.strip()]
+  # xpk uses the short cluster name, not the full context — strip the GKE prefix
+  # pattern: gke_<project>_<location>_<cluster>
+  names = set()
+  for c in ctxs:
+    if c.startswith("gke_"):
+      parts = c.split("_", 3)
+      if len(parts) == 4:
+        names.add(parts[3])
+    else:
+      names.add(c)
+  return sorted(names)

--- a/src/xpk/core/local_cache.py
+++ b/src/xpk/core/local_cache.py
@@ -52,7 +52,10 @@ def current_context() -> str | None:
   try:
     r = subprocess.run(
         ["kubectl", "config", "current-context"],
-        capture_output=True, text=True, timeout=5, check=False,
+        capture_output=True,
+        text=True,
+        timeout=5,
+        check=False,
     )
   except (FileNotFoundError, subprocess.TimeoutExpired):
     return None
@@ -72,11 +75,13 @@ def write(context: str, cfg: dict) -> None:
     except OSError:
       pass
     payload = {
-        "context":      context,
-        "fetchedAt":    _dt.datetime.now(_dt.timezone.utc).isoformat(timespec="seconds"),
-        "teams":        sorted((cfg.get("teams") or {}).keys()),
+        "context": context,
+        "fetchedAt": _dt.datetime.now(_dt.timezone.utc).isoformat(
+            timespec="seconds"
+        ),
+        "teams": sorted((cfg.get("teams") or {}).keys()),
         "valueClasses": list(cfg.get("valueClasses") or []),
-        "sliceName":    cfg.get("sliceName") or {},
+        "sliceName": cfg.get("sliceName") or {},
     }
     dst = _path_for(context)
     with tempfile.NamedTemporaryFile(
@@ -144,7 +149,10 @@ def gke_contexts_from_kubeconfig() -> list[str]:
   try:
     r = subprocess.run(
         ["kubectl", "config", "get-contexts", "-o", "name"],
-        capture_output=True, text=True, timeout=5, check=False,
+        capture_output=True,
+        text=True,
+        timeout=5,
+        check=False,
     )
   except (FileNotFoundError, subprocess.TimeoutExpired):
     return []

--- a/src/xpk/core/local_cache.py
+++ b/src/xpk/core/local_cache.py
@@ -14,10 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-"""Tiny per-cluster cache of PoC config for faster errors + tab completion.
+"""Tiny per-cluster cache of team-quota config for faster errors + tab completion.
 
-Populated automatically whenever xpk successfully fetches the `poc-team-config`
-ConfigMap from a cluster. Read by:
+Populated automatically whenever xpk successfully fetches the team-quota
+ConfigMap from a cluster (see core/quota_discovery.py). Read by:
   - argcomplete completers (sub-second tab completion without a cluster call)
   - error-message suggesters ("did you mean ...")
 
@@ -25,7 +25,7 @@ No secrets are stored. The cache is advisory: if it is stale, out of sync, or
 absent, xpk falls through to live discovery with no behavior change.
 
 Layout:
-  ~/.xpk/poc-cache/<kubectl-context>.json
+  ~/.xpk/quota-cache/<kubectl-context>.json
 """
 
 import datetime as _dt
@@ -35,7 +35,7 @@ import subprocess
 import tempfile
 from pathlib import Path
 
-CACHE_DIR = Path.home() / ".xpk" / "poc-cache"
+CACHE_DIR = Path.home() / ".xpk" / "quota-cache"
 DEFAULT_TTL = _dt.timedelta(hours=1)
 
 

--- a/src/xpk/core/local_cache.py
+++ b/src/xpk/core/local_cache.py
@@ -52,7 +52,7 @@ def current_context() -> str | None:
   try:
     r = subprocess.run(
         ["kubectl", "config", "current-context"],
-        capture_output=True, text=True, timeout=5,
+        capture_output=True, text=True, timeout=5, check=False,
     )
   except (FileNotFoundError, subprocess.TimeoutExpired):
     return None
@@ -144,7 +144,7 @@ def gke_contexts_from_kubeconfig() -> list[str]:
   try:
     r = subprocess.run(
         ["kubectl", "config", "get-contexts", "-o", "name"],
-        capture_output=True, text=True, timeout=5,
+        capture_output=True, text=True, timeout=5, check=False,
     )
   except (FileNotFoundError, subprocess.TimeoutExpired):
     return []

--- a/src/xpk/core/local_cache.py
+++ b/src/xpk/core/local_cache.py
@@ -105,7 +105,8 @@ def read(context: str) -> dict | None:
     p = _path_for(context)
     if not p.exists():
       return None
-    return json.loads(p.read_text())
+    payload = json.loads(p.read_text())
+    return payload if isinstance(payload, dict) else None
   except Exception:  # pylint: disable=broad-except
     return None
 

--- a/src/xpk/core/poc_discovery.py
+++ b/src/xpk/core/poc_discovery.py
@@ -1,0 +1,103 @@
+"""
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+"""Discover PoC team configuration from the cluster's poc-team-config ConfigMap.
+
+The ConfigMap is rendered by the Helm chart in cluster-management/poc/chart
+from a single values.yaml — so a cluster admin can add/remove/retune teams
+without any xpk code change.
+
+Callers should have run `get_cluster_credentials(args)` (or otherwise set up
+kubectl) before calling into this module.
+"""
+
+import difflib
+import json
+
+from . import local_cache
+from .commands import run_command_for_value
+
+CONFIG_CM_NAMESPACE = "kueue-system"
+CONFIG_CM_NAME      = "poc-team-config"
+CONFIG_CM_KEY       = "config.json"
+
+
+def fetch_poc_config() -> dict | None:
+  """Return the parsed ConfigMap payload, or None if unavailable/malformed.
+
+  On success, refreshes ~/.xpk/poc-cache/<context>.json as a side effect so
+  that argcomplete and did-you-mean suggestions work even when the cluster
+  isn't reachable.
+  """
+  cmd = f'kubectl get configmap -n {CONFIG_CM_NAMESPACE} {CONFIG_CM_NAME} -o json'
+  rc, out = run_command_for_value(cmd, task=cmd, quiet=True)
+  if rc != 0 or not out:
+    return None
+  try:
+    cm = json.loads(out)
+  except json.JSONDecodeError:
+    return None
+  raw = (cm.get('data') or {}).get(CONFIG_CM_KEY)
+  if not raw:
+    return None
+  try:
+    cfg = json.loads(raw)
+  except json.JSONDecodeError:
+    return None
+  ctx = local_cache.current_context()
+  if ctx:
+    local_cache.write(ctx, cfg)
+  return cfg
+
+
+def suggest(user_input: str, candidates: list[str], limit: int = 3) -> list[str]:
+  """Return up to `limit` closest matches for an unknown value."""
+  return difflib.get_close_matches(user_input, candidates, n=limit, cutoff=0.5)
+
+
+def available_teams(cfg: dict) -> list[str]:
+  return sorted((cfg.get('teams') or {}).keys())
+
+
+def available_value_classes(cfg: dict) -> list[str]:
+  return list(cfg.get('valueClasses') or [])
+
+
+def resolve_team(cfg: dict, team: str) -> tuple[str, str, str]:
+  """Return (namespace, local_queue, priority_class) for the team.
+
+  Raises KeyError with a listing of available teams if not found.
+  """
+  teams = cfg.get('teams') or {}
+  if team not in teams:
+    raise KeyError(
+        f'--team={team!r} not found on this cluster. '
+        f'Available teams: {", ".join(available_teams(cfg)) or "<none>"}'
+    )
+  t = teams[team]
+  return (t['namespace'], t['localQueue'], t['priorityClass'])
+
+
+def max_k8s_workload_name_len(cfg: dict, namespace: str) -> int:
+  """Max safe JobSet name length = sliceName.charLimit - fixedOverhead - len(ns).
+
+  Defaults match the super-slice admission controller constraint (49 total,
+  26 fixed overhead from prefixes/suffixes).
+  """
+  sn = cfg.get('sliceName') or {}
+  char_limit = int(sn.get('charLimit', 49))
+  fixed      = int(sn.get('fixedOverhead', 26))
+  return char_limit - fixed - len(namespace)

--- a/src/xpk/core/quota_discovery.py
+++ b/src/xpk/core/quota_discovery.py
@@ -14,11 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-"""Discover PoC team configuration from the cluster's poc-team-config ConfigMap.
+"""Discover team-based Kueue quota configuration from a cluster ConfigMap.
 
-The ConfigMap is rendered by the Helm chart in cluster-management/poc/chart
-from a single values.yaml — so a cluster admin can add/remove/retune teams
-without any xpk code change.
+xpk's `--team` / `--value-class` / `--declared-duration-minutes` flags route a
+workload to a per-team Kueue namespace + ClusterQueue, with priority and slice-
+name sizing derived from cluster-side config. The config (which teams exist,
+their quotas, namespaces, priorities, and the JobSet-name length budget) is
+read at runtime from a ConfigMap so that adding/retuning a team requires no
+xpk code change.
 
 Callers should have run `get_cluster_credentials(args)` (or otherwise set up
 kubectl) before calling into this module.
@@ -26,16 +29,25 @@ kubectl) before calling into this module.
 
 import difflib
 import json
+from dataclasses import dataclass
 
 from . import local_cache
 from .commands import run_command_for_value
 
 CONFIG_CM_NAMESPACE = "kueue-system"
-CONFIG_CM_NAME      = "poc-team-config"
+CONFIG_CM_NAME      = "poc-team-config"   # cluster-side ConfigMap name; set by chart
 CONFIG_CM_KEY       = "config.json"
 
 
-def fetch_poc_config() -> dict | None:
+@dataclass(frozen=True)
+class TeamRouting:
+  """Per-team Kueue routing parameters resolved from the cluster ConfigMap."""
+  namespace: str
+  local_queue: str
+  priority_class: str
+
+
+def fetch_quota_config() -> dict | None:
   """Return the parsed ConfigMap payload, or None if unavailable/malformed.
 
   On success, refreshes ~/.xpk/poc-cache/<context>.json as a side effect so
@@ -76,8 +88,8 @@ def available_value_classes(cfg: dict) -> list[str]:
   return list(cfg.get('valueClasses') or [])
 
 
-def resolve_team(cfg: dict, team: str) -> tuple[str, str, str]:
-  """Return (namespace, local_queue, priority_class) for the team.
+def resolve_team(cfg: dict, team: str) -> TeamRouting:
+  """Return TeamRouting for the team.
 
   Raises KeyError with a listing of available teams if not found.
   """
@@ -88,14 +100,26 @@ def resolve_team(cfg: dict, team: str) -> tuple[str, str, str]:
         f'Available teams: {", ".join(available_teams(cfg)) or "<none>"}'
     )
   t = teams[team]
-  return (t['namespace'], t['localQueue'], t['priorityClass'])
+  return TeamRouting(
+      namespace=t['namespace'],
+      local_queue=t['localQueue'],
+      priority_class=t['priorityClass'],
+  )
 
 
 def max_k8s_workload_name_len(cfg: dict, namespace: str) -> int:
   """Max safe JobSet name length = sliceName.charLimit - fixedOverhead - len(ns).
 
-  Defaults match the super-slice admission controller constraint (49 total,
-  26 fixed overhead from prefixes/suffixes).
+  The super-slice admission controller enforces a hard length limit on the
+  Slice CRD names it creates from the JobSet, of the form
+  `<namespace>-<jobset-name>-slice-job-<replica-index>`. The total `charLimit`
+  (49 by default) minus the `fixedOverhead` (the 26-char framing for the
+  `-slice-job-N` suffix and the jobset-controller's own prefixing) minus the
+  namespace length yields the budget left for the actual JobSet (and hence
+  workload) name.
+
+  These values come from the cluster ConfigMap so a cluster admin can adjust
+  them without an xpk release.
   """
   sn = cfg.get('sliceName') or {}
   char_limit = int(sn.get('charLimit', 49))

--- a/src/xpk/core/quota_discovery.py
+++ b/src/xpk/core/quota_discovery.py
@@ -33,6 +33,7 @@ from dataclasses import dataclass
 
 from . import local_cache
 from .commands import run_command_for_value
+from ..utils.console import xpk_exit, xpk_print
 
 CONFIG_CM_NAMESPACE = 'kueue-system'
 CONFIG_CM_NAME = 'poc-team-config'  # cluster-side ConfigMap name; set by chart
@@ -112,6 +113,67 @@ def resolve_team(cfg: dict, team: str) -> TeamRouting:
       local_queue=t['localQueue'],
       priority_class=t['priorityClass'],
   )
+
+
+def load_quota_cfg(args) -> dict | None:
+  """Fetch + validate the team-quota ConfigMap once per invocation.
+
+  Returns None when --team is unset (so the upstream non-team-routing path
+  is preserved). Caches the result on `args.quota_cfg` so a single
+  invocation never hits the cluster twice.
+
+  Robust against unit-test code that passes a MagicMock for args:
+  args.team must be a non-empty *string*, not just truthy.
+  """
+  team = getattr(args, 'team', None)
+  if not isinstance(team, str) or not team.strip():
+    return None
+  cached = getattr(args, 'quota_cfg', None)
+  if isinstance(cached, dict):
+    return cached
+  cfg = fetch_quota_config()
+  if cfg is None:
+    xpk_print(
+        f'ERROR: --team={args.team!r} requires the team-quota ConfigMap'
+        f' "{CONFIG_CM_NAMESPACE}/{CONFIG_CM_NAME}" on the target cluster.'
+        ' Deploy the cluster quota chart first, or drop --team to bypass'
+        ' team-based routing.'
+    )
+    xpk_exit(1)
+  if args.team not in (cfg.get('teams') or {}):
+    teams = available_teams(cfg)
+    hints = suggest(args.team, teams)
+    hint_line = f' Did you mean: {", ".join(hints)}?' if hints else ''
+    xpk_print(
+        f'ERROR: --team={args.team!r} not found on this cluster.{hint_line}'
+        f' Available teams: {", ".join(teams) or "<none>"}'
+    )
+    xpk_exit(1)
+  if getattr(args, 'value_class', None):
+    vcs = available_value_classes(cfg)
+    if vcs and args.value_class not in vcs:
+      hints = suggest(args.value_class, vcs)
+      hint_line = f' Did you mean: {", ".join(hints)}?' if hints else ''
+      xpk_print(
+          f'ERROR: --value-class={args.value_class!r} not valid on this'
+          f' cluster.{hint_line} Available: {", ".join(vcs)}'
+      )
+      xpk_exit(1)
+  args.quota_cfg = cfg
+  return cfg
+
+
+def resolve_team_for_args(args) -> TeamRouting | None:
+  """Return TeamRouting when --team was set, or None when it was not.
+
+  Callers decide what to do with None — `workload create` falls back to
+  upstream LocalQueue + args.priority; `workload status` errors out
+  because --team is required there.
+  """
+  cfg = load_quota_cfg(args)
+  if cfg is None:
+    return None
+  return resolve_team(cfg, args.team)
 
 
 def max_k8s_workload_name_len(cfg: dict, namespace: str) -> int:

--- a/src/xpk/core/quota_discovery.py
+++ b/src/xpk/core/quota_discovery.py
@@ -34,14 +34,15 @@ from dataclasses import dataclass
 from . import local_cache
 from .commands import run_command_for_value
 
-CONFIG_CM_NAMESPACE = "kueue-system"
-CONFIG_CM_NAME      = "poc-team-config"   # cluster-side ConfigMap name; set by chart
-CONFIG_CM_KEY       = "config.json"
+CONFIG_CM_NAMESPACE = 'kueue-system'
+CONFIG_CM_NAME = 'poc-team-config'  # cluster-side ConfigMap name; set by chart
+CONFIG_CM_KEY = 'config.json'
 
 
 @dataclass(frozen=True)
 class TeamRouting:
   """Per-team Kueue routing parameters resolved from the cluster ConfigMap."""
+
   namespace: str
   local_queue: str
   priority_class: str
@@ -54,7 +55,9 @@ def fetch_quota_config() -> dict | None:
   that argcomplete and did-you-mean suggestions work even when the cluster
   isn't reachable.
   """
-  cmd = f'kubectl get configmap -n {CONFIG_CM_NAMESPACE} {CONFIG_CM_NAME} -o json'
+  cmd = (
+      f'kubectl get configmap -n {CONFIG_CM_NAMESPACE} {CONFIG_CM_NAME} -o json'
+  )
   rc, out = run_command_for_value(cmd, task=cmd, quiet=True)
   if rc != 0 or not out:
     return None
@@ -75,7 +78,9 @@ def fetch_quota_config() -> dict | None:
   return cfg
 
 
-def suggest(user_input: str, candidates: list[str], limit: int = 3) -> list[str]:
+def suggest(
+    user_input: str, candidates: list[str], limit: int = 3
+) -> list[str]:
   """Return up to `limit` closest matches for an unknown value."""
   return difflib.get_close_matches(user_input, candidates, n=limit, cutoff=0.5)
 
@@ -123,5 +128,5 @@ def max_k8s_workload_name_len(cfg: dict, namespace: str) -> int:
   """
   sn = cfg.get('sliceName') or {}
   char_limit = int(sn.get('charLimit', 49))
-  fixed      = int(sn.get('fixedOverhead', 26))
+  fixed = int(sn.get('fixedOverhead', 26))
   return char_limit - fixed - len(namespace)

--- a/src/xpk/core/quota_discovery.py
+++ b/src/xpk/core/quota_discovery.py
@@ -72,6 +72,8 @@ def fetch_quota_config() -> dict | None:
     cfg = json.loads(raw)
   except json.JSONDecodeError:
     return None
+  if not isinstance(cfg, dict):
+    return None
   ctx = local_cache.current_context()
   if ctx:
     local_cache.write(ctx, cfg)

--- a/src/xpk/core/quota_discovery_test.py
+++ b/src/xpk/core/quota_discovery_test.py
@@ -86,7 +86,7 @@ def test_available_teams_returns_sorted_keys():
 
 
 def test_available_teams_handles_missing_key():
-  assert available_teams({}) == []
+  assert not available_teams({})
 
 
 def test_available_value_classes_returns_list():
@@ -95,7 +95,7 @@ def test_available_value_classes_returns_list():
 
 
 def test_available_value_classes_handles_missing_key():
-  assert available_value_classes({}) == []
+  assert not available_value_classes({})
 
 
 # ---------- max_k8s_workload_name_len ----------

--- a/src/xpk/core/quota_discovery_test.py
+++ b/src/xpk/core/quota_discovery_test.py
@@ -1,0 +1,188 @@
+"""
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import json
+
+import pytest
+
+from .quota_discovery import (
+    TeamRouting,
+    available_teams,
+    available_value_classes,
+    fetch_quota_config,
+    max_k8s_workload_name_len,
+    resolve_team,
+    suggest,
+)
+
+
+def _sample_cfg() -> dict:
+  return {
+      'teams': {
+          'ml-perf': {
+              'namespace': 'poc-ml-perf',
+              'localQueue': 'lq',
+              'priorityClass': 'poc-ml-perf-priority',
+          },
+          'dev': {
+              'namespace': 'poc-dev',
+              'localQueue': 'lq',
+              'priorityClass': 'poc-dev-priority',
+          },
+      },
+      'valueClasses': ['benchmark', 'regression', 'development'],
+      'sliceName': {'charLimit': 49, 'fixedOverhead': 26},
+  }
+
+
+# ---------- resolve_team ----------
+
+
+def test_resolve_team_returns_dataclass_for_known_team():
+  cfg = _sample_cfg()
+  routing = resolve_team(cfg, 'ml-perf')
+  assert isinstance(routing, TeamRouting)
+  assert routing.namespace == 'poc-ml-perf'
+  assert routing.local_queue == 'lq'
+  assert routing.priority_class == 'poc-ml-perf-priority'
+
+
+def test_resolve_team_raises_keyerror_for_unknown_team():
+  cfg = _sample_cfg()
+  with pytest.raises(KeyError) as exc_info:
+    resolve_team(cfg, 'nonexistent')
+  assert 'nonexistent' in str(exc_info.value)
+  # Available teams should be listed for the user.
+  assert 'ml-perf' in str(exc_info.value)
+  assert 'dev' in str(exc_info.value)
+
+
+def test_resolve_team_handles_empty_teams_map():
+  cfg = {'teams': {}}
+  with pytest.raises(KeyError) as exc_info:
+    resolve_team(cfg, 'ml-perf')
+  assert '<none>' in str(exc_info.value)
+
+
+# ---------- available_teams / available_value_classes ----------
+
+
+def test_available_teams_returns_sorted_keys():
+  cfg = _sample_cfg()
+  assert available_teams(cfg) == ['dev', 'ml-perf']
+
+
+def test_available_teams_handles_missing_key():
+  assert available_teams({}) == []
+
+
+def test_available_value_classes_returns_list():
+  cfg = _sample_cfg()
+  assert available_value_classes(cfg) == ['benchmark', 'regression', 'development']
+
+
+def test_available_value_classes_handles_missing_key():
+  assert available_value_classes({}) == []
+
+
+# ---------- max_k8s_workload_name_len ----------
+
+
+def test_max_k8s_workload_name_len_uses_cfg_values():
+  cfg = _sample_cfg()
+  # 49 - 26 - len('poc-ml-perf') = 49 - 26 - 11 = 12
+  assert max_k8s_workload_name_len(cfg, 'poc-ml-perf') == 12
+
+
+def test_max_k8s_workload_name_len_falls_back_to_defaults():
+  # No sliceName section present -> use defaults (49, 26)
+  assert max_k8s_workload_name_len({}, 'poc-dev') == 49 - 26 - len('poc-dev')
+
+
+def test_max_k8s_workload_name_len_handles_partial_overrides():
+  cfg = {'sliceName': {'charLimit': 60}}  # fixedOverhead falls back to default 26
+  assert max_k8s_workload_name_len(cfg, 'foo') == 60 - 26 - 3
+
+
+# ---------- suggest ----------
+
+
+def test_suggest_returns_close_matches_when_typo():
+  candidates = ['ml-perf', 'dev', 'gsc', 'nightly']
+  assert suggest('ml-pref', candidates) == ['ml-perf']
+
+
+def test_suggest_returns_empty_for_no_match():
+  candidates = ['ml-perf', 'dev']
+  assert suggest('zzzzz', candidates) == []
+
+
+def test_suggest_respects_limit():
+  candidates = ['xa', 'xb', 'xc', 'xd', 'xe']
+  assert len(suggest('x', candidates, limit=2)) <= 2
+
+
+# ---------- fetch_quota_config (mocked) ----------
+
+
+def test_fetch_quota_config_returns_parsed_payload(mocker):
+  cfg = _sample_cfg()
+  cm = {'data': {'config.json': json.dumps(cfg)}}
+  mocker.patch(
+      'xpk.core.quota_discovery.run_command_for_value',
+      return_value=(0, json.dumps(cm)),
+  )
+  mocker.patch('xpk.core.quota_discovery.local_cache.current_context', return_value=None)
+  out = fetch_quota_config()
+  assert out == cfg
+
+
+def test_fetch_quota_config_returns_none_if_kubectl_fails(mocker):
+  mocker.patch(
+      'xpk.core.quota_discovery.run_command_for_value',
+      return_value=(1, ''),
+  )
+  assert fetch_quota_config() is None
+
+
+def test_fetch_quota_config_returns_none_if_no_data_section(mocker):
+  cm = {'kind': 'ConfigMap'}  # no 'data' key
+  mocker.patch(
+      'xpk.core.quota_discovery.run_command_for_value',
+      return_value=(0, json.dumps(cm)),
+  )
+  assert fetch_quota_config() is None
+
+
+def test_fetch_quota_config_returns_none_on_malformed_json(mocker):
+  mocker.patch(
+      'xpk.core.quota_discovery.run_command_for_value',
+      return_value=(0, 'not-json'),
+  )
+  assert fetch_quota_config() is None
+
+
+def test_fetch_quota_config_writes_cache_when_context_known(mocker):
+  cfg = _sample_cfg()
+  cm = {'data': {'config.json': json.dumps(cfg)}}
+  mocker.patch(
+      'xpk.core.quota_discovery.run_command_for_value',
+      return_value=(0, json.dumps(cm)),
+  )
+  mocker.patch('xpk.core.quota_discovery.local_cache.current_context', return_value='gke_proj_zone_cluster')
+  cache_write = mocker.patch('xpk.core.quota_discovery.local_cache.write')
+  fetch_quota_config()
+  cache_write.assert_called_once_with('gke_proj_zone_cluster', cfg)

--- a/src/xpk/core/quota_discovery_test.py
+++ b/src/xpk/core/quota_discovery_test.py
@@ -91,7 +91,11 @@ def test_available_teams_handles_missing_key():
 
 def test_available_value_classes_returns_list():
   cfg = _sample_cfg()
-  assert available_value_classes(cfg) == ['benchmark', 'regression', 'development']
+  assert available_value_classes(cfg) == [
+      'benchmark',
+      'regression',
+      'development',
+  ]
 
 
 def test_available_value_classes_handles_missing_key():
@@ -113,7 +117,9 @@ def test_max_k8s_workload_name_len_falls_back_to_defaults():
 
 
 def test_max_k8s_workload_name_len_handles_partial_overrides():
-  cfg = {'sliceName': {'charLimit': 60}}  # fixedOverhead falls back to default 26
+  cfg = {
+      'sliceName': {'charLimit': 60}
+  }  # fixedOverhead falls back to default 26
   assert max_k8s_workload_name_len(cfg, 'foo') == 60 - 26 - 3
 
 
@@ -145,7 +151,9 @@ def test_fetch_quota_config_returns_parsed_payload(mocker):
       'xpk.core.quota_discovery.run_command_for_value',
       return_value=(0, json.dumps(cm)),
   )
-  mocker.patch('xpk.core.quota_discovery.local_cache.current_context', return_value=None)
+  mocker.patch(
+      'xpk.core.quota_discovery.local_cache.current_context', return_value=None
+  )
   out = fetch_quota_config()
   assert out == cfg
 
@@ -182,7 +190,10 @@ def test_fetch_quota_config_writes_cache_when_context_known(mocker):
       'xpk.core.quota_discovery.run_command_for_value',
       return_value=(0, json.dumps(cm)),
   )
-  mocker.patch('xpk.core.quota_discovery.local_cache.current_context', return_value='gke_proj_zone_cluster')
+  mocker.patch(
+      'xpk.core.quota_discovery.local_cache.current_context',
+      return_value='gke_proj_zone_cluster',
+  )
   cache_write = mocker.patch('xpk.core.quota_discovery.local_cache.write')
   fetch_quota_config()
   cache_write.assert_called_once_with('gke_proj_zone_cluster', cfg)

--- a/src/xpk/parser/workload.py
+++ b/src/xpk/parser/workload.py
@@ -21,6 +21,7 @@ from ..commands.workload import (
     workload_create_pathways,
     workload_delete,
     workload_list,
+    workload_status,
 )
 from ..core.docker_image import DEFAULT_DOCKER_IMAGE, DEFAULT_SCRIPT_DIR
 from .common import add_shared_arguments, add_tpu_type_argument, add_tpu_and_device_type_arguments
@@ -60,6 +61,13 @@ def set_workload_parsers(workload_parser: ArgumentParser):
       'list', help='List jobs.'
   )
   set_workload_list_parser(workload_list_parser)
+
+  # "workload status" command parser.
+  workload_status_parser = workload_subcommands.add_parser(
+      'status',
+      help='Show PoC queue status and diagnose stuck or queued workloads.',
+  )
+  set_workload_status_parser(workload_status_parser)
 
 
 def set_workload_create_parser(workload_create_parser: ArgumentParser):
@@ -542,6 +550,35 @@ def set_workload_list_parser(workload_list_parser: ArgumentParser):
   add_shared_arguments(workload_list_parser)
 
   workload_list_parser.set_defaults(func=workload_list)
+
+
+def set_workload_status_parser(workload_status_parser: ArgumentParser):
+  """Configure the 'xpk workload status' subcommand."""
+  workload_status_parser.add_argument(
+      '--cluster',
+      type=name_type,
+      default=None,
+      required=True,
+      help='The name of the PoC cluster.',
+  )
+  workload_status_parser.add_argument(
+      '--team',
+      type=str,
+      required=True,
+      choices=['ml-perf', 'nightly-regression', 'gsc', 'dev', 'reactant', 'scale-test'],
+      help='Your PoC team name.',
+  )
+  workload_status_parser.add_argument(
+      '--workload',
+      type=str,
+      default=None,
+      help=(
+          'xpk --workload name to inspect (as passed to workload create).'
+          ' Omit to show all workloads for your team.'
+      ),
+  )
+  add_shared_arguments(workload_status_parser)
+  workload_status_parser.set_defaults(func=workload_status)
 
 
 def add_shared_workload_create_required_arguments(args_parsers):

--- a/src/xpk/parser/workload.py
+++ b/src/xpk/parser/workload.py
@@ -660,6 +660,35 @@ def add_shared_workload_create_optional_arguments(args_parsers):
             ' the workload.'
         ),
     )
+    # PoC quota system flags
+    custom_parser.add_argument(
+        '--team',
+        type=str,
+        default=None,
+        choices=['ml-perf', 'nightly-regression', 'gsc', 'dev', 'scale-test'],
+        help=(
+            'PoC quota system: team name. When set, automatically routes the job'
+            ' to the correct namespace (poc-<team>), LocalQueue (lq), and'
+            ' PriorityClass. Overrides --priority.'
+        ),
+    )
+    custom_parser.add_argument(
+        '--value-class',
+        type=str,
+        default=None,
+        choices=['regression', 'benchmark', 'scale-test', 'development'],
+        help='PoC quota system: job type label for audit and priority ordering.',
+    )
+    custom_parser.add_argument(
+        '--declared-duration-minutes',
+        type=int,
+        default=None,
+        help=(
+            'PoC quota system: honest p90 estimate of job runtime in minutes.'
+            ' Used by the time-limit controller to stop overrunning jobs.'
+            ' Required when --team is set.'
+        ),
+    )
 
 
 def add_shared_workload_create_env_arguments(args_parsers):

--- a/src/xpk/parser/workload.py
+++ b/src/xpk/parser/workload.py
@@ -599,7 +599,7 @@ def set_workload_status_parser(workload_status_parser: ArgumentParser):
       required=True,
       help='The name of the cluster.',
   ).completer = _cluster_completer  # type: ignore[attr-defined]
-  workload_status_parser.add_argument(
+  team_arg = workload_status_parser.add_argument(
       '--team',
       type=str,
       required=True,
@@ -607,9 +607,8 @@ def set_workload_status_parser(workload_status_parser: ArgumentParser):
           'Your team name. The set of valid teams is discovered at'
           " runtime from the cluster's team-quota ConfigMap."
       ),
-  ).completer = _cached_field_completer(
-      'teams'
-  )  # type: ignore[attr-defined]
+  )
+  team_arg.completer = _cached_field_completer('teams')  # type: ignore[attr-defined]
   workload_status_parser.add_argument(
       '--workload',
       type=str,

--- a/src/xpk/parser/workload.py
+++ b/src/xpk/parser/workload.py
@@ -472,7 +472,7 @@ def set_workload_delete_parser(workload_delete_parser: ArgumentParser):
       default=None,
       help='The name of the cluster to delete the job on.',
       required=True,
-  ).completer = _cluster_completer
+  ).completer = _cluster_completer  # type: ignore[attr-defined]
   ### "workload delete" Optional arguments
   workload_delete_parser_optional_arguments.add_argument(
       '--workload',
@@ -527,7 +527,7 @@ def set_workload_list_parser(workload_list_parser: ArgumentParser):
       default=None,
       help='The name of the cluster to list jobs on.',
       required=True,
-  ).completer = _cluster_completer
+  ).completer = _cluster_completer  # type: ignore[attr-defined]
 
   workload_list_parser.add_argument(
       '--filter-by-status',
@@ -598,7 +598,7 @@ def set_workload_status_parser(workload_status_parser: ArgumentParser):
       default=None,
       required=True,
       help='The name of the cluster.',
-  ).completer = _cluster_completer
+  ).completer = _cluster_completer  # type: ignore[attr-defined]
   workload_status_parser.add_argument(
       '--team',
       type=str,
@@ -607,7 +607,9 @@ def set_workload_status_parser(workload_status_parser: ArgumentParser):
           'Your team name. The set of valid teams is discovered at'
           " runtime from the cluster's team-quota ConfigMap."
       ),
-  ).completer = _cached_field_completer('teams')
+  ).completer = _cached_field_completer(
+      'teams'
+  )  # type: ignore[attr-defined]
   workload_status_parser.add_argument(
       '--workload',
       type=str,

--- a/src/xpk/parser/workload.py
+++ b/src/xpk/parser/workload.py
@@ -23,15 +23,15 @@ from ..commands.workload import (
     workload_create_pathways,
     workload_delete,
     workload_list,
-    workload_status,
 )
+from ..commands.workload_status import workload_status
 from ..core.docker_image import DEFAULT_DOCKER_IMAGE, DEFAULT_SCRIPT_DIR
 from .common import add_shared_arguments, add_tpu_type_argument, add_tpu_and_device_type_arguments
 from .validators import directory_path_type, name_type
 
 
 def _cached_field_completer(field: str):
-  """Build an argcomplete completer that reads the PoC cache for `field`
+  """Build an argcomplete completer that reads the team-quota cache for `field`
   ('teams' or 'valueClasses'). Prefers the cache entry for the kubectl
   context corresponding to parsed_args.cluster; falls back to the union of
   all cached contexts so completion still helps on an unfamiliar cluster."""
@@ -96,7 +96,7 @@ def set_workload_parsers(workload_parser: ArgumentParser):
   # "workload status" command parser.
   workload_status_parser = workload_subcommands.add_parser(
       'status',
-      help='Show PoC queue status and diagnose stuck or queued workloads.',
+      help='Diagnose a workload routed via --team: queued vs admitted vs stuck.',
   )
   set_workload_status_parser(workload_status_parser)
 
@@ -590,15 +590,15 @@ def set_workload_status_parser(workload_status_parser: ArgumentParser):
       type=name_type,
       default=None,
       required=True,
-      help='The name of the PoC cluster.',
+      help='The name of the cluster.',
   ).completer = _cluster_completer
   workload_status_parser.add_argument(
       '--team',
       type=str,
       required=True,
       help=(
-          'Your PoC team name. The set of valid teams is discovered at'
-          ' runtime from the cluster\'s poc-team-config ConfigMap.'
+          'Your team name. The set of valid teams is discovered at'
+          ' runtime from the cluster\'s team-quota ConfigMap.'
       ),
   ).completer = _cached_field_completer('teams')
   workload_status_parser.add_argument(
@@ -730,16 +730,19 @@ def add_shared_workload_create_optional_arguments(args_parsers):
             ' the workload.'
         ),
     )
-    # PoC quota system flags
+    # Team-based Kueue quota routing flags. When --team is set, the workload
+    # is auto-routed to the team's namespace + LocalQueue + PriorityClass
+    # discovered at runtime from the cluster's team-quota ConfigMap, so a
+    # cluster admin can add/remove/retune teams without an xpk release.
     custom_parser.add_argument(
         '--team',
         type=str,
         default=None,
         help=(
-            'PoC quota system: team name. When set, automatically routes the job'
-            ' to the correct namespace, LocalQueue, and PriorityClass. Overrides'
-            ' --priority. Valid teams are discovered at runtime from the'
-            ' cluster\'s poc-team-config ConfigMap.'
+            'Team name. When set, automatically routes the job to the team\'s'
+            ' namespace, LocalQueue, and PriorityClass. Overrides --priority.'
+            ' Valid teams are discovered at runtime from the cluster\'s'
+            ' team-quota ConfigMap.'
         ),
     ).completer = _cached_field_completer('teams')
     custom_parser.add_argument(
@@ -747,9 +750,8 @@ def add_shared_workload_create_optional_arguments(args_parsers):
         type=str,
         default=None,
         help=(
-            'PoC quota system: job type label for audit and priority ordering.'
-            ' Valid classes are discovered at runtime from the cluster\'s'
-            ' poc-team-config ConfigMap.'
+            'Job type label for audit and priority ordering. Valid classes are'
+            ' discovered at runtime from the cluster\'s team-quota ConfigMap.'
         ),
     ).completer = _cached_field_completer('valueClasses')
     custom_parser.add_argument(
@@ -757,9 +759,20 @@ def add_shared_workload_create_optional_arguments(args_parsers):
         type=int,
         default=None,
         help=(
-            'PoC quota system: honest p90 estimate of job runtime in minutes.'
-            ' Used by the time-limit controller to stop overrunning jobs.'
+            'Honest p90 estimate of job runtime in minutes. Used by the'
+            ' cluster-side time-limit controller to stop overrunning jobs.'
             ' Required when --team is set.'
+        ),
+    )
+    custom_parser.add_argument(
+        '--no-shorten-jobset-name',
+        action='store_true',
+        default=False,
+        help=(
+            'When --team is set, xpk normally shortens the K8s JobSet name to'
+            ' fit the super-slice admission controller\'s sliceName.charLimit.'
+            ' Pass this flag to disable shortening (use args.workload as-is)'
+            ' — only safe when your workload name is short enough already.'
         ),
     )
 

--- a/src/xpk/parser/workload.py
+++ b/src/xpk/parser/workload.py
@@ -35,6 +35,7 @@ def _cached_field_completer(field: str):
   ('teams' or 'valueClasses'). Prefers the cache entry for the kubectl
   context corresponding to parsed_args.cluster; falls back to the union of
   all cached contexts so completion still helps on an unfamiliar cluster."""
+
   def _complete(prefix, parsed_args, **_kwargs):
     cluster = getattr(parsed_args, 'cluster', None)
     candidates = set()
@@ -49,14 +50,18 @@ def _cached_field_completer(field: str):
         payload = local_cache.read(c) or {}
         candidates.update(payload.get(field) or [])
     return sorted(v for v in candidates if v.startswith(prefix or ''))
+
   return _complete
 
 
 def _cluster_completer(prefix, parsed_args, **_kwargs):
   """Tab-complete --cluster from GKE contexts in the user's kubeconfig."""
   del parsed_args
-  return [c for c in local_cache.gke_contexts_from_kubeconfig()
-          if c.startswith(prefix or '')]
+  return [
+      c
+      for c in local_cache.gke_contexts_from_kubeconfig()
+      if c.startswith(prefix or '')
+  ]
 
 
 def set_workload_parsers(workload_parser: ArgumentParser):
@@ -96,7 +101,9 @@ def set_workload_parsers(workload_parser: ArgumentParser):
   # "workload status" command parser.
   workload_status_parser = workload_subcommands.add_parser(
       'status',
-      help='Diagnose a workload routed via --team: queued vs admitted vs stuck.',
+      help=(
+          'Diagnose a workload routed via --team: queued vs admitted vs stuck.'
+      ),
   )
   set_workload_status_parser(workload_status_parser)
 
@@ -598,7 +605,7 @@ def set_workload_status_parser(workload_status_parser: ArgumentParser):
       required=True,
       help=(
           'Your team name. The set of valid teams is discovered at'
-          ' runtime from the cluster\'s team-quota ConfigMap.'
+          " runtime from the cluster's team-quota ConfigMap."
       ),
   ).completer = _cached_field_completer('teams')
   workload_status_parser.add_argument(
@@ -739,9 +746,9 @@ def add_shared_workload_create_optional_arguments(args_parsers):
         type=str,
         default=None,
         help=(
-            'Team name. When set, automatically routes the job to the team\'s'
+            "Team name. When set, automatically routes the job to the team's"
             ' namespace, LocalQueue, and PriorityClass. Overrides --priority.'
-            ' Valid teams are discovered at runtime from the cluster\'s'
+            " Valid teams are discovered at runtime from the cluster's"
             ' team-quota ConfigMap.'
         ),
     ).completer = _cached_field_completer('teams')
@@ -751,7 +758,7 @@ def add_shared_workload_create_optional_arguments(args_parsers):
         default=None,
         help=(
             'Job type label for audit and priority ordering. Valid classes are'
-            ' discovered at runtime from the cluster\'s team-quota ConfigMap.'
+            " discovered at runtime from the cluster's team-quota ConfigMap."
         ),
     ).completer = _cached_field_completer('valueClasses')
     custom_parser.add_argument(
@@ -770,7 +777,7 @@ def add_shared_workload_create_optional_arguments(args_parsers):
         default=False,
         help=(
             'When --team is set, xpk normally shortens the K8s JobSet name to'
-            ' fit the super-slice admission controller\'s sliceName.charLimit.'
+            " fit the super-slice admission controller's sliceName.charLimit."
             ' Pass this flag to disable shortening (use args.workload as-is)'
             ' — only safe when your workload name is short enough already.'
         ),

--- a/src/xpk/parser/workload.py
+++ b/src/xpk/parser/workload.py
@@ -16,6 +16,7 @@ limitations under the License.
 
 import argparse
 from argparse import ArgumentParser
+from typing import Any
 
 from ..core import local_cache
 from ..commands.workload import (
@@ -52,6 +53,17 @@ def _cached_field_completer(field: str):
     return sorted(v for v in candidates if v.startswith(prefix or ''))
 
   return _complete
+
+
+def _set_completer(action: argparse.Action, completer: Any) -> None:
+  """Attach an argcomplete completer to an argparse Action.
+
+  argcomplete monkey-patches argparse.Action with a `completer` attribute
+  at runtime; mypy can't see that attribute through the static stubs, so a
+  plain `action.completer = ...` assignment trips `attr-defined`. setattr
+  keeps the assignment explicit and avoids a per-call-site type-ignore.
+  """
+  setattr(action, 'completer', completer)
 
 
 def _cluster_completer(prefix, parsed_args, **_kwargs):
@@ -466,13 +478,16 @@ def set_workload_delete_parser(workload_delete_parser: ArgumentParser):
   add_shared_arguments(workload_delete_parser_optional_arguments)
 
   ### "workload delete" Required arguments
-  workload_delete_parser_required_arguments.add_argument(
-      '--cluster',
-      type=name_type,
-      default=None,
-      help='The name of the cluster to delete the job on.',
-      required=True,
-  ).completer = _cluster_completer  # type: ignore[attr-defined]
+  _set_completer(
+      workload_delete_parser_required_arguments.add_argument(
+          '--cluster',
+          type=name_type,
+          default=None,
+          help='The name of the cluster to delete the job on.',
+          required=True,
+      ),
+      _cluster_completer,
+  )
   ### "workload delete" Optional arguments
   workload_delete_parser_optional_arguments.add_argument(
       '--workload',
@@ -521,13 +536,16 @@ def set_workload_delete_parser(workload_delete_parser: ArgumentParser):
 
 
 def set_workload_list_parser(workload_list_parser: ArgumentParser):
-  workload_list_parser.add_argument(
-      '--cluster',
-      type=name_type,
-      default=None,
-      help='The name of the cluster to list jobs on.',
-      required=True,
-  ).completer = _cluster_completer  # type: ignore[attr-defined]
+  _set_completer(
+      workload_list_parser.add_argument(
+          '--cluster',
+          type=name_type,
+          default=None,
+          help='The name of the cluster to list jobs on.',
+          required=True,
+      ),
+      _cluster_completer,
+  )
 
   workload_list_parser.add_argument(
       '--filter-by-status',
@@ -592,23 +610,28 @@ def set_workload_list_parser(workload_list_parser: ArgumentParser):
 
 def set_workload_status_parser(workload_status_parser: ArgumentParser):
   """Configure the 'xpk workload status' subcommand."""
-  workload_status_parser.add_argument(
-      '--cluster',
-      type=name_type,
-      default=None,
-      required=True,
-      help='The name of the cluster.',
-  ).completer = _cluster_completer  # type: ignore[attr-defined]
-  team_arg = workload_status_parser.add_argument(
-      '--team',
-      type=str,
-      required=True,
-      help=(
-          'Your team name. The set of valid teams is discovered at'
-          " runtime from the cluster's team-quota ConfigMap."
+  _set_completer(
+      workload_status_parser.add_argument(
+          '--cluster',
+          type=name_type,
+          default=None,
+          required=True,
+          help='The name of the cluster.',
       ),
+      _cluster_completer,
   )
-  team_arg.completer = _cached_field_completer('teams')  # type: ignore[attr-defined]
+  _set_completer(
+      workload_status_parser.add_argument(
+          '--team',
+          type=str,
+          required=True,
+          help=(
+              'Your team name. The set of valid teams is discovered at'
+              " runtime from the cluster's team-quota ConfigMap."
+          ),
+      ),
+      _cached_field_completer('teams'),
+  )
   workload_status_parser.add_argument(
       '--workload',
       type=str,
@@ -636,13 +659,16 @@ def add_shared_workload_create_required_arguments(args_parsers):
         help='The name of the workload to run.',
         required=True,
     )
-    custom_parser.add_argument(
-        '--cluster',
-        type=name_type,
-        default=None,
-        help='The name of the cluster to run the job on.',
-        required=True,
-    ).completer = _cluster_completer
+    _set_completer(
+        custom_parser.add_argument(
+            '--cluster',
+            type=name_type,
+            default=None,
+            help='The name of the cluster to run the job on.',
+            required=True,
+        ),
+        _cluster_completer,
+    )
 
 
 def add_shared_workload_create_optional_arguments(args_parsers):
@@ -742,26 +768,33 @@ def add_shared_workload_create_optional_arguments(args_parsers):
     # is auto-routed to the team's namespace + LocalQueue + PriorityClass
     # discovered at runtime from the cluster's team-quota ConfigMap, so a
     # cluster admin can add/remove/retune teams without an xpk release.
-    custom_parser.add_argument(
-        '--team',
-        type=str,
-        default=None,
-        help=(
-            "Team name. When set, automatically routes the job to the team's"
-            ' namespace, LocalQueue, and PriorityClass. Overrides --priority.'
-            " Valid teams are discovered at runtime from the cluster's"
-            ' team-quota ConfigMap.'
+    _set_completer(
+        custom_parser.add_argument(
+            '--team',
+            type=str,
+            default=None,
+            help=(
+                'Team name. When set, automatically routes the job to the'
+                " team's namespace, LocalQueue, and PriorityClass. Overrides"
+                ' --priority. Valid teams are discovered at runtime from'
+                " the cluster's team-quota ConfigMap."
+            ),
         ),
-    ).completer = _cached_field_completer('teams')
-    custom_parser.add_argument(
-        '--value-class',
-        type=str,
-        default=None,
-        help=(
-            'Job type label for audit and priority ordering. Valid classes are'
-            " discovered at runtime from the cluster's team-quota ConfigMap."
+        _cached_field_completer('teams'),
+    )
+    _set_completer(
+        custom_parser.add_argument(
+            '--value-class',
+            type=str,
+            default=None,
+            help=(
+                'Job type label for audit and priority ordering. Valid'
+                " classes are discovered at runtime from the cluster's"
+                ' team-quota ConfigMap.'
+            ),
         ),
-    ).completer = _cached_field_completer('valueClasses')
+        _cached_field_completer('valueClasses'),
+    )
     custom_parser.add_argument(
         '--declared-duration-minutes',
         type=int,

--- a/src/xpk/parser/workload.py
+++ b/src/xpk/parser/workload.py
@@ -16,6 +16,8 @@ limitations under the License.
 
 import argparse
 from argparse import ArgumentParser
+
+from ..core import local_cache
 from ..commands.workload import (
     workload_create,
     workload_create_pathways,
@@ -26,6 +28,35 @@ from ..commands.workload import (
 from ..core.docker_image import DEFAULT_DOCKER_IMAGE, DEFAULT_SCRIPT_DIR
 from .common import add_shared_arguments, add_tpu_type_argument, add_tpu_and_device_type_arguments
 from .validators import directory_path_type, name_type
+
+
+def _cached_field_completer(field: str):
+  """Build an argcomplete completer that reads the PoC cache for `field`
+  ('teams' or 'valueClasses'). Prefers the cache entry for the kubectl
+  context corresponding to parsed_args.cluster; falls back to the union of
+  all cached contexts so completion still helps on an unfamiliar cluster."""
+  def _complete(prefix, parsed_args, **_kwargs):
+    cluster = getattr(parsed_args, 'cluster', None)
+    candidates = set()
+    if cluster:
+      for c in local_cache.all_contexts():
+        # kubectl contexts for GKE end with the cluster name
+        if c.endswith('_' + cluster) or c == cluster:
+          payload = local_cache.read(c) or {}
+          candidates.update(payload.get(field) or [])
+    if not candidates:
+      for c in local_cache.all_contexts():
+        payload = local_cache.read(c) or {}
+        candidates.update(payload.get(field) or [])
+    return sorted(v for v in candidates if v.startswith(prefix or ''))
+  return _complete
+
+
+def _cluster_completer(prefix, parsed_args, **_kwargs):
+  """Tab-complete --cluster from GKE contexts in the user's kubeconfig."""
+  del parsed_args
+  return [c for c in local_cache.gke_contexts_from_kubeconfig()
+          if c.startswith(prefix or '')]
 
 
 def set_workload_parsers(workload_parser: ArgumentParser):
@@ -434,7 +465,7 @@ def set_workload_delete_parser(workload_delete_parser: ArgumentParser):
       default=None,
       help='The name of the cluster to delete the job on.',
       required=True,
-  )
+  ).completer = _cluster_completer
   ### "workload delete" Optional arguments
   workload_delete_parser_optional_arguments.add_argument(
       '--workload',
@@ -489,7 +520,7 @@ def set_workload_list_parser(workload_list_parser: ArgumentParser):
       default=None,
       help='The name of the cluster to list jobs on.',
       required=True,
-  )
+  ).completer = _cluster_completer
 
   workload_list_parser.add_argument(
       '--filter-by-status',
@@ -560,14 +591,16 @@ def set_workload_status_parser(workload_status_parser: ArgumentParser):
       default=None,
       required=True,
       help='The name of the PoC cluster.',
-  )
+  ).completer = _cluster_completer
   workload_status_parser.add_argument(
       '--team',
       type=str,
       required=True,
-      choices=['ml-perf', 'nightly-regression', 'gsc', 'dev', 'reactant', 'scale-test'],
-      help='Your PoC team name.',
-  )
+      help=(
+          'Your PoC team name. The set of valid teams is discovered at'
+          ' runtime from the cluster\'s poc-team-config ConfigMap.'
+      ),
+  ).completer = _cached_field_completer('teams')
   workload_status_parser.add_argument(
       '--workload',
       type=str,
@@ -601,7 +634,7 @@ def add_shared_workload_create_required_arguments(args_parsers):
         default=None,
         help='The name of the cluster to run the job on.',
         required=True,
-    )
+    ).completer = _cluster_completer
 
 
 def add_shared_workload_create_optional_arguments(args_parsers):
@@ -702,20 +735,23 @@ def add_shared_workload_create_optional_arguments(args_parsers):
         '--team',
         type=str,
         default=None,
-        choices=['ml-perf', 'nightly-regression', 'gsc', 'dev', 'scale-test'],
         help=(
             'PoC quota system: team name. When set, automatically routes the job'
-            ' to the correct namespace (poc-<team>), LocalQueue (lq), and'
-            ' PriorityClass. Overrides --priority.'
+            ' to the correct namespace, LocalQueue, and PriorityClass. Overrides'
+            ' --priority. Valid teams are discovered at runtime from the'
+            ' cluster\'s poc-team-config ConfigMap.'
         ),
-    )
+    ).completer = _cached_field_completer('teams')
     custom_parser.add_argument(
         '--value-class',
         type=str,
         default=None,
-        choices=['regression', 'benchmark', 'scale-test', 'development'],
-        help='PoC quota system: job type label for audit and priority ordering.',
-    )
+        help=(
+            'PoC quota system: job type label for audit and priority ordering.'
+            ' Valid classes are discovered at runtime from the cluster\'s'
+            ' poc-team-config ConfigMap.'
+        ),
+    ).completer = _cached_field_completer('valueClasses')
     custom_parser.add_argument(
         '--declared-duration-minutes',
         type=int,


### PR DESCRIPTION
**Stacked on #1180.** Per @jamOne-'s feedback on #1180 ([thread](https://github.com/AI-Hypercomputer/xpk/pull/1180#discussion_r3167443836)), splitting the focused-workload-diagnosis surface out of the team-routing PR so each can be reviewed in isolation.

## What this adds

A new `xpk workload status` subcommand answering "why is *my* job stuck?" with a 3-line plain-English diagnosis:

```
$ xpk workload status --cluster=foo --team=ml-perf --workload=conv-run-42
Workload : conv-run-42  ->  jobset-conv-run-42-a3f1
Age      : 12m
Status   : QUEUED — waiting for quota
Position : 3rd in line  (2 workload(s) ahead: foo-bench-01, bar-eval-09)
Team quota (poc-ml-perf):
  Quota   : 4096 chips nominal  +0 borrow  = 4096 max
  Running : 4096 chips (2 workload(s) admitted)
  Queued  : 3 workload(s) waiting for quota
Diagnosis: Things look normal — waiting behind other workloads.
```

Differs from \`xpk inspector\`, which is a kitchen-sink debug dump for SREs investigating cluster-wide bugs. \`workload status\` is the focused user-facing answer; \`inspector\` is the everything-and-the-kitchen-sink diagnostic.

States the diagnosis recognises:
- **RUNNING** (admitted)
- **QUEUED** (with queue position + workloads ahead)
- **STUCK** (quota reserved but admission check failed; surfaces the underlying error and a specific fix when the failure is the well-known \"slice name > 49 chars\" one)
- **FINISHED** (success / failure with the controller's reason)

## Implementation notes

Single new file \`src/xpk/commands/workload_status.py\` plus the parser hookup in \`parser/workload.py\`. Reuses the team-routing infrastructure that #1180 introduces:
- \`resolve_team_for_args(args)\` to find namespace + ClusterQueue
- \`kubectl_common.parse_kubernetes_status\` for typed condition handling
- \`run_command_for_value\` for kubectl invocations (consistent with the rest of xpk)
- The \`team-quota-config\` ConfigMap as the source of truth for the team list

All round-2 cleanup feedback that applied to this file is already incorporated (typed helpers, no \`subprocess.run\`, no lazy imports, no pylint disables).

## Reviewing this PR

**Please wait for #1180 to land before reviewing.** This branch is currently based on #1180's tip, so the diff against \`main\` includes #1180's work. Once #1180 merges, I'll rebase onto \`main\` and the diff will shrink to just the \`workload_status\` delta (one new file ~370 lines + the parser hookup ~40 lines + a couple of test additions).

Marking as draft until then.