### PR TITLE
FIx scheduling of nap + pathways workloads

### DIFF
--- a/src/xpk/commands/workload_test.py
+++ b/src/xpk/commands/workload_test.py
@@ -487,8 +487,8 @@ def test_pathways_yaml_excludes_autoprovisioning_args_from_head(mocker):
       jobset_annotations='',
   )
 
-  head_section = yaml_output[:yaml_output.find('name: worker')]
-  worker_section = yaml_output[yaml_output.find('name: worker'):]
+  head_section = yaml_output[: yaml_output.find('name: worker')]
+  worker_section = yaml_output[yaml_output.find('name: worker') :]
 
   assert 'cloud.google.com/reservation-name: test-res' not in head_section
   assert 'cloud.google.com/reservation-name: test-res' in worker_section

--- a/src/xpk/commands/workload_test.py
+++ b/src/xpk/commands/workload_test.py
@@ -25,6 +25,7 @@ from ..core.testing.commands_tester import CommandsTester
 from .workload import workload_create
 from .cluster_test import construct_args
 from ..core.docker_container import get_user_workload_container as real_get_user_workload_container
+from .workload import _generate_pathways_workload_yaml
 
 
 SYSTEM_CHARACTERISTICS = SystemCharacteristics(
@@ -457,6 +458,40 @@ def test_workload_create_pathways_jobset_yaml(mocker):
   assert (
       f'--gcs_scratch_location={args.pathways_gcs_location}' in written_content
   )
+
+
+def test_pathways_yaml_excludes_autoprovisioning_args_from_head(mocker):
+  args = MagicMock()
+  args.workload = 'test-pw-workload'
+  args.headless = True
+  args.elastic_slices = 0
+  args.max_slice_restarts = 1
+  args.termination_grace_period_seconds = 30
+  args.priority = 'medium'
+  args.pathways_gcs_location = 'gs://bucket'
+
+  workload_system = MagicMock()
+  workload_system.accelerator_type = AcceleratorType.TPU
+  workload_system.vms_per_slice = 4
+  workload_system.pathways_tpu_version = 'tpuv4'
+  workload_system.topology = '4x4'
+
+  yaml_output = _generate_pathways_workload_yaml(
+      args=args,
+      workload_system=workload_system,
+      parallel_containers=1,
+      placement_policy_label='',
+      autoprovisioning_args='cloud.google.com/reservation-name: test-res',
+      node_selector_machine_label='',
+      tpu_slice_topology_annotation='',
+      jobset_annotations='',
+  )
+
+  head_section = yaml_output[:yaml_output.find('name: worker')]
+  worker_section = yaml_output[yaml_output.find('name: worker'):]
+
+  assert 'cloud.google.com/reservation-name: test-res' not in head_section
+  assert 'cloud.google.com/reservation-name: test-res' in worker_section
 
 
 def test_workload_create_use_parallel_containers_disabled(

--- a/src/xpk/templates/pathways_workload_create.yaml.j2
+++ b/src/xpk/templates/pathways_workload_create.yaml.j2
@@ -31,9 +31,6 @@ spec:
             dnsPolicy: ClusterFirstWithHostNet
             nodeSelector:
               cloud.google.com/gke-nodepool: cpu-np
-{% if autoprovisioning_args %}
-              {{ autoprovisioning_args }}
-{% endif %}
 {% if args.headless %}
             containers:
 {% else %}


### PR DESCRIPTION
# Description
`autoprovisioning_args` can contain following values depending on selected capacity:
- On-Demand: An empty string, meaning no special node selectors
- Spot: `cloud.google.com/gke-spot: "true"`
- Flex-Start: `cloud.google.com/gke-queued: "true"`
- Reservation: `cloud.google.com/reservation-name: <reservation_name>`

This causes scheduling conflict with already declared `cloud.google.com/gke-nodepool: cpu-np` `nodeSelector` and causes workload to never be scheduled.

# Issue
b/510416959

# Testing
Unit tests.