### PR TITLE
build: pin google-cloud-bigquery>=3.10.0 in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ dependencies = [
   "packaging==24.2",
   "google-cloud-filestore==1.12.0",
   "google-cloud-storage",
+  "google-cloud-bigquery>=3.10.0",
   "Jinja2==3.1.6",
   # Urllib 2.6.0 breaks kubernetes client because kubernetes client uses deprecated in 2.0.0 and
   # removed in 2.6.0 `getheaders()` call (instead of `headers` property).


### PR DESCRIPTION
# Description
Newer versions of pip (>=24.1) strictly validate package metadata against PEP 440. When resolving google-cloud-bigquery, pip backtracks and evaluates legacy releases (such as 1.28.1) which contain malformed version specifiers (<2.0de) in their metadata.

Pinning to google-cloud-bigquery>=3.10.0 prevents dependency resolver backtracking and ensures clean local and CI builds.

# Issue
XPK installation with pip 24.1 is failing while installation `google-cloud-bigquery` package `(xpk → cloud-accelerator-diagnostics → google-cloud-aiplatform[tensorboard] → google-cloud-bigquery (>=1.15.0,<4.0.0))`

```
Please use pip<24.1 if you need to use this version.
  Downloading https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-cloud-bigquery/google_cloud_bigquery-1.28.1-py2.py3-none-any.whl (187 kB)
WARNING: Ignoring version 1.28.1 of google-cloud-bigquery since it has invalid metadata:
Requested google-cloud-bigquery!=3.20.0,<4.0.0,>=1.15.0 from https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/google-cloud-bigquery/google_cloud_bigquery-1.28.1-py2.py3-none-any.whl#sha256=5d79a8f03b882e4449d2746580e66955b07a2c74b4ec32846061d80147990631 (from google-cloud-aiplatform[tensorboard]->cloud-accelerator-diagnostics==0.1.1->xpk) has invalid metadata: Expected matching RIGHT_PARENTHESIS for LEFT_PARENTHESIS, after version specifier
    pyarrow (<2.0de,>=1.0.0) ; (python_version >= "3.5") and extra == 'all'
```

# Testing

```
python3 -m venv --system-site-packages xpk_local_venv
source ./xpk_local_venv/bin/activate
pip install .[dev]

```
