### PR TITLE
feat(cluster): enable GKE managed ML Diagnostics for GKE version >= 1.35.0-gke.3065000

### DIFF
--- a/src/xpk/commands/cluster.py
+++ b/src/xpk/commands/cluster.py
@@ -17,7 +17,11 @@ limitations under the License.
 from tabulate import tabulate
 
 from ..utils.feature_flags import FeatureFlags
-from ..utils.versions import ReleaseChannel
+from ..utils.versions import (
+    ReleaseChannel,
+    is_gke_version_at_least,
+)
+from .managed_ml_diagnostics import MANAGED_MLDIAGNOSTICS_MIN_GKE_VERSION
 from ..core.pathways import get_pathways_machine_types
 from ..core.cluster import (
     get_all_clusters_programmatic,
@@ -539,7 +543,9 @@ def cluster_create(args) -> None:
       f' https://console.cloud.google.com/kubernetes/clusters/details/{get_cluster_location(args.project, args.cluster, args.zone)}/{args.cluster}/details?project={args.project}'
   )
 
-  if args.managed_mldiagnostics:
+  if args.managed_mldiagnostics and not is_gke_version_at_least(
+      gke_control_plane_version, MANAGED_MLDIAGNOSTICS_MIN_GKE_VERSION
+  ):
     return_code = install_mldiagnostics_prerequisites()
     if return_code != 0:
       xpk_print('Installation of MLDiagnostics failed.')
@@ -1368,6 +1374,11 @@ def run_gke_cluster_create_command(
 
   if args.super_slicing:
     command += ' --enable-slice-controller'
+
+  if args.managed_mldiagnostics and is_gke_version_at_least(
+      gke_control_plane_version, MANAGED_MLDIAGNOSTICS_MIN_GKE_VERSION
+  ):
+    command += ' --enable-managed-mldiagnostics'
 
   if args.custom_cluster_arguments:
     command += f' {args.custom_cluster_arguments}'

--- a/src/xpk/commands/cluster_test.py
+++ b/src/xpk/commands/cluster_test.py
@@ -28,6 +28,9 @@ from xpk.core.system_characteristics import SystemCharacteristics, UserFacingNam
 from xpk.core.testing.commands_tester import CommandsTester
 from xpk.utils.feature_flags import FeatureFlags
 from xpk.utils.versions import ReleaseChannel
+from xpk.commands.managed_ml_diagnostics import (
+    MANAGED_MLDIAGNOSTICS_MIN_GKE_VERSION,
+)
 
 
 @dataclass
@@ -881,3 +884,87 @@ def test_get_coredns_replica_count_upper_limit_is_15():
       default_pool_cpu_num_nodes=20,
   )
   assert _get_coredns_replica_count(args) == 15
+
+
+def test_run_gke_cluster_create_command_with_managed_mldiagnostics_and_newer_gke_enables_flag(
+    mocks: _Mocks,
+):
+  result = run_gke_cluster_create_command(
+      args=construct_args(
+          gke_version=MANAGED_MLDIAGNOSTICS_MIN_GKE_VERSION,
+          managed_mldiagnostics=True,
+      ),
+      gke_control_plane_version=MANAGED_MLDIAGNOSTICS_MIN_GKE_VERSION,
+      system=TPU_TEST_SYSTEM,
+      release_channel=ReleaseChannel.REGULAR,
+  )
+
+  assert result == 0
+  mocks.commands_tester.assert_command_run(
+      'clusters create', '--enable-managed-mldiagnostics'
+  )
+
+
+def test_run_gke_cluster_create_command_with_managed_mldiagnostics_and_older_gke_does_not_enable_flag(
+    mocks: _Mocks,
+):
+  result = run_gke_cluster_create_command(
+      args=construct_args(
+          gke_version='1.34.8-gke.1000', managed_mldiagnostics=True
+      ),
+      gke_control_plane_version='1.34.8-gke.1000',
+      system=TPU_TEST_SYSTEM,
+      release_channel=ReleaseChannel.REGULAR,
+  )
+
+  assert result == 0
+  mocks.commands_tester.assert_command_not_run(
+      'clusters create', '--enable-managed-mldiagnostics'
+  )
+
+
+@patch('xpk.commands.cluster.install_mldiagnostics_prerequisites')
+def test_cluster_create_with_managed_mldiagnostics_and_newer_gke_skips_prerequisites(
+    mock_install_prerequisites: MagicMock,
+    mocks: _Mocks,
+    cluster_create_mocks: _ClusterCreateMocks,
+):
+  cluster_create_mocks.get_gke_control_plane_version.return_value = (
+      0,
+      MANAGED_MLDIAGNOSTICS_MIN_GKE_VERSION,
+  )
+  args = construct_args(
+      managed_mldiagnostics=True,
+      spot=True,
+      host_maintenance_interval='AS_NEEDED',
+      custom_tpu_nodepool_arguments='',
+      custom_nodepool_arguments='',
+      force=False,
+  )
+  cluster_create(args)
+
+  mock_install_prerequisites.assert_not_called()
+
+
+@patch('xpk.commands.cluster.install_mldiagnostics_prerequisites')
+def test_cluster_create_with_managed_mldiagnostics_and_older_gke_runs_prerequisites(
+    mock_install_prerequisites: MagicMock,
+    mocks: _Mocks,
+    cluster_create_mocks: _ClusterCreateMocks,
+):
+  mock_install_prerequisites.return_value = 0
+  cluster_create_mocks.get_gke_control_plane_version.return_value = (
+      0,
+      '1.34.8-gke.1000',
+  )
+  args = construct_args(
+      managed_mldiagnostics=True,
+      spot=True,
+      host_maintenance_interval='AS_NEEDED',
+      custom_tpu_nodepool_arguments='',
+      custom_nodepool_arguments='',
+      force=False,
+  )
+  cluster_create(args)
+
+  mock_install_prerequisites.assert_called_once()

--- a/src/xpk/commands/managed_ml_diagnostics.py
+++ b/src/xpk/commands/managed_ml_diagnostics.py
@@ -31,6 +31,7 @@ _OPERATOR_PACKAGE = 'mldiagnostics-connection-operator'
 _OPERATOR_VERSION = Version('v0.5.0')
 _OPERATOR_FILENAME = f'{_OPERATOR_PACKAGE}-v{_OPERATOR_VERSION}.yaml'
 _CERT_MANAGER_VERSION = Version('v1.13.0')
+MANAGED_MLDIAGNOSTICS_MIN_GKE_VERSION = '1.35.0-gke.3065000'
 
 
 def _install_cert_manager(version: Version = _CERT_MANAGER_VERSION) -> int:

--- a/src/xpk/utils/versions.py
+++ b/src/xpk/utils/versions.py
@@ -15,6 +15,7 @@ limitations under the License.
 """
 
 import enum
+from packaging.version import Version, InvalidVersion
 
 
 class ReleaseChannel(enum.Enum):
@@ -29,3 +30,27 @@ class ReleaseChannel(enum.Enum):
   REGULAR = "REGULAR"
   STABLE = "STABLE"
   EXTENDED = "EXTENDED"
+
+
+def is_gke_version_at_least(
+    gke_version: str,
+    target_version: str,
+) -> bool:
+  """Checks if a GKE version string is at least the target GKE version.
+
+  Normalizes '-' to '+' in GKE version strings (e.g. 1.35.0-gke.3065000 ->
+  1.35.0+gke.3065000) to ensure robust comparison under PEP 440.
+
+  Args:
+    gke_version: The GKE version string to check.
+    target_version: The target GKE version string.
+
+  Returns:
+    True if gke_version >= target_version, False otherwise.
+  """
+  try:
+    normalized_gke = gke_version.replace("-", "+")
+    normalized_target = target_version.replace("-", "+")
+    return Version(normalized_gke) >= Version(normalized_target)
+  except (InvalidVersion, AttributeError):
+    return False

--- a/src/xpk/utils/versions_test.py
+++ b/src/xpk/utils/versions_test.py
@@ -1,0 +1,40 @@
+"""
+Copyright 2024 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import pytest
+from .versions import is_gke_version_at_least
+
+
+@pytest.mark.parametrize(
+    "gke_version,target_version,expected",
+    [
+        (
+            "1.35.0-gke.3065000",
+            "1.35.0-gke.3065000",
+            True,
+        ),
+        ("1.35.0-gke.3066000", "1.35.0-gke.3065000", True),
+        ("1.35.1-gke.0", "1.35.0-gke.3065000", True),
+        ("1.36.0-gke.100", "1.35.0-gke.3065000", True),
+        ("1.35.0-gke.3064000", "1.35.0-gke.3065000", False),
+        ("1.34.8-gke.1000000", "1.35.0-gke.3065000", False),
+        ("invalid", "1.35.0-gke.3065000", False),
+        ("1.36.0-gke.100", "1.36.0-gke.0", True),
+        ("1.35.0-gke.3065000", "1.36.0-gke.0", False),
+    ],
+)
+def test_is_gke_version_at_least(gke_version, target_version, expected):
+  assert is_gke_version_at_least(gke_version, target_version) == expected


### PR DESCRIPTION
# Description

This change introduces automated management and lifecycle optimization for GKE Managed Machine Learning Diagnostics on cluster creation.

Specifically:
1. Standardizes PEP 440 version comparison via `is_gke_version_at_least()` with a central minimum requirement constant (`MANAGED_MLDIAGNOSTICS_MIN_GKE_VERSION = "1.35.0-gke.3065000"`).
2. Refactors `run_gke_cluster_create_command()` to dynamically append `--enable-managed-mldiagnostics` when `--managed-mldiagnostics` is requested and the planned GKE control plane version meets or exceeds the minimum threshold.
3. Bypasses legacy user-space prerequisite installations (`install_mldiagnostics_prerequisites()`) when creating or updating clusters on modern GKE versions.
4. Refines `--dry-run` simulation in `get_gke_server_config()` and `get_gke_node_pool_version()` to correctly evaluate user-supplied GKE versions (`--gke-version=X`) or default smoothly to "0", ensuring accurate simulation without breaking Golden Recipe verification.

# Issue
Correcting the behaviour of: `--managed-mldiagnostics`flag

# Testing

Have you performed any manual testing on your change? Yes

`xpk cluster create with >= 1.35.0-gke.3065000`:
```
(xpk_local_venv) rapatchi@rapatchi2:~/xpk_fork/xpk$ xpk cluster create --cluster=maxtest-cluster --tpu-type=v5litepod-8 --project=rapatchiconsumer --zone=us-central1-a --num-nodes=2 --managed-mldiagnostics --spot
[XPK] Starting xpk v0.1.dev902+g7c8ca0ae1
...
[XPK] Task: `GKE Cluster Create` is implemented by `gcloud beta container clusters create maxtest-cluster --project=rapatchiconsumer --region=us-central1 --node-locations=us-central1-a --cluster-version=1.36.0-gke.2459000 --machine-type=e2-standard-16 --enable-autoscaling --total-min-nodes 1 --total-max-nodes 1000 --num-nodes 6 --autoscaling-profile=optimize-utilization --labels=gke_product_type=xpk --release-channel=rapid --enable-ip-alias --enable-dataplane-v2 --enable-multi-networking --enable-dns-access --location-policy=BALANCED --scopes=storage-full,gke-default --enable-managed-mldiagnostics`, streaming output live.
...
[XPK] Task: `Updating Controller Manager resources` terminated with code `0`
[XPK] GKE commands done! Resources are created.
[XPK] See your GKE Cluster here: https://console.cloud.google.com/kubernetes/clusters/details/us-central1/maxtest-cluster/details?project=rapatchiconsumer
[XPK] Exiting XPK cleanly
```

`xpk cluster create with < 1.35.0-gke.3065000`

```
(xpk_local_venv) rapatchi@rapatchi2:~/xpk_fork/xpk$ xpk cluster create --cluster=maxtest-cluster --tpu-type=v5litepod-8 --project=rapatchiconsumer --zone=us-central1-a --num-nodes=2 --managed-mldiagnostics --spot --gke-version=1.34.8-gke.1000000
[XPK] Starting xpk v0.1.dev902+g7c8ca0ae1
...
[XPK] Task: `GKE Cluster Create` is implemented by the following command not running since it is a dry run.
gcloud beta container clusters create maxtest-cluster --project=rapatchiconsumer --region=us-central1 --node-locations=us-central1-a --cluster-version=1.34.8-gke.1000000 --machine-type=e2-standard-16 --enable-autoscaling --total-min-nodes 1 --total-max-nodes 1000 --num-nodes 6 --autoscaling-profile=optimize-utilization --labels=gke_product_type=xpk --release-channel=regular --enable-ip-alias --enable-dataplane-v2 --enable-multi-networking --no-enable-autoupgrade --enable-dns-access --location-policy=BALANCED --scopes=storage-full,gke-default
...
[XPK] Task: `Applying cert-manager 1.13.0 manifest...` is implemented by `kubectl apply -f [https://github.com/cert-manager/cert-manager/releases/download/v1.13.0/cert-manager.yaml](https://www.google.com/url?sa=D&q=https%3A%2F%2Fgithub.com%2Fcert-manager%2Fcert-manager%2Freleases%2Fdownload%2Fv1.13.0%2Fcert-manager.yaml)`, streaming output live.
[XPK] Task: `Create gke-mldiagnostics namespace...` is implemented by `kubectl create namespace gke-mldiagnostics`
[XPK] Task: `Install /tmp/mldiagnostics-injection-webhook-v0.5.0.yaml...` is implemented by `kubectl apply -f /tmp/mldiagnostics-injection-webhook-v0.5.0.yaml -n gke-mldiagnostics`, streaming output live.
```

Have you verified use cases affected by goldens? Yes
