### PR TITLE
Grant required IAM roles to Compute Engine default SA when --managed-mldiagnostics is passed during `xpk cluster create`

### DIFF
--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -25,3 +25,4 @@
 * Storage Admin
 * Vertex AI Administrator
 * Filestore Editor (This role is neccessary if you want to run `storage create` command with `--type=gcpfilestore`)
+* Project IAM Admin or Security Admin (This role is necessary if you create a cluster with `--managed-mldiagnostics` to assign required roles to the default Compute Engine service account)

--- a/docs/usage/clusters.md
+++ b/docs/usage/clusters.md
@@ -262,6 +262,8 @@ Enabling ML Diagnostics is streamlined and simplified through XPK cluster creati
 
 By adding the **--managed-mldiagnostics** flag during the execution of either **xpk cluster create** or **xpk cluster create-pathways**, the ML Diagnostics functionality is enabled. This flag ensures the necessary supporting components (such as the injection-webhook and connection-operator) are automatically configured, allowing the feature to function seamlessly in both Pathways and non-Pathways execution environments.
 
+> **Important Note:** When using `--managed-mldiagnostics`, XPK automatically grants `roles/hypercomputecluster.editor`, `roles/storage.objectUser`, and `roles/logging.logWriter` to the Compute Engine default service account. Ensure your user account has **Project IAM Admin** (`roles/resourcemanager.projectIamAdmin`) or **Security Admin** (`roles/iam.securityAdmin`) permissions.
+
 **Example Usage:**
 
 * Cluster Create for Pathways with flag **--managed-mldiagnostics**:

--- a/src/xpk/commands/cluster.py
+++ b/src/xpk/commands/cluster.py
@@ -98,7 +98,7 @@ from jinja2 import Environment, FileSystemLoader
 from ..utils.templates import get_templates_absolute_path
 import shutil
 import os
-from .managed_ml_diagnostics import install_mldiagnostics_prerequisites
+from .managed_ml_diagnostics import install_mldiagnostics_prerequisites, grant_compute_default_sa_mldiagnostics_permissions
 
 CLUSTER_PREHEAT_JINJA_FILE = 'cluster_preheat.yaml.j2'
 
@@ -543,13 +543,20 @@ def cluster_create(args) -> None:
       f' https://console.cloud.google.com/kubernetes/clusters/details/{get_cluster_location(args.project, args.cluster, args.zone)}/{args.cluster}/details?project={args.project}'
   )
 
-  if args.managed_mldiagnostics and not is_gke_version_at_least(
-      gke_control_plane_version, MANAGED_MLDIAGNOSTICS_MIN_GKE_VERSION
-  ):
-    return_code = install_mldiagnostics_prerequisites()
-    if return_code != 0:
-      xpk_print('Installation of MLDiagnostics failed.')
-      xpk_exit(return_code)
+  if args.managed_mldiagnostics:
+    grant_permissions_code = grant_compute_default_sa_mldiagnostics_permissions(
+        args.project
+    )
+    if grant_permissions_code != 0:
+      xpk_exit(grant_permissions_code)
+
+    if not is_gke_version_at_least(
+        gke_control_plane_version, MANAGED_MLDIAGNOSTICS_MIN_GKE_VERSION
+    ):
+      return_code = install_mldiagnostics_prerequisites()
+      if return_code != 0:
+        xpk_print('Installation of MLDiagnostics failed.')
+        xpk_exit(return_code)
 
   xpk_exit(0)
 

--- a/src/xpk/commands/cluster_test.py
+++ b/src/xpk/commands/cluster_test.py
@@ -55,6 +55,7 @@ class _ClusterCreateMocks:
   get_cluster_location: MagicMock
   xpk_exit: MagicMock
   _log_cluster_create_telemetry: MagicMock
+  grant_compute_default_sa_mldiagnostics_permissions: MagicMock
 
 
 @pytest.fixture
@@ -178,6 +179,10 @@ def cluster_create_mocks(mocker) -> _ClusterCreateMocks:
       xpk_exit=mocker.patch('xpk.commands.cluster.xpk_exit'),
       _log_cluster_create_telemetry=mocker.patch(
           'xpk.commands.cluster._log_cluster_create_telemetry'
+      ),
+      grant_compute_default_sa_mldiagnostics_permissions=mocker.patch(
+          'xpk.commands.cluster.grant_compute_default_sa_mldiagnostics_permissions',
+          return_value=0,
       ),
   )
 

--- a/src/xpk/commands/managed_ml_diagnostics.py
+++ b/src/xpk/commands/managed_ml_diagnostics.py
@@ -250,3 +250,42 @@ def _wait_for_deployment_ready(
     return False
 
   return True
+
+
+def grant_compute_default_sa_mldiagnostics_permissions(project_id: str) -> int:
+  """Grants necessary permissions to the compute default service account."""
+  command = (
+      f'gcloud projects describe {project_id} --format="value(projectNumber)"'
+  )
+  return_code, project_number_str = run_command_for_value(
+      command, 'Get Project Number'
+  )
+  if return_code != 0:
+    xpk_print(f'Get Project Number returned ERROR {return_code}')
+    return return_code
+
+  project_number = project_number_str.strip()
+  if not project_number:
+    xpk_print('Unable to retrieve project number.')
+    return 1
+
+  compute_default_sa = f'{project_number}-compute@developer.gserviceaccount.com'
+  xpk_print(f'Granting necessary roles to {compute_default_sa}')
+
+  roles = [
+      'roles/hypercomputecluster.editor',
+      'roles/storage.objectUser',
+      'roles/logging.logWriter',
+  ]
+  for role in roles:
+    cmd = (
+        f'gcloud projects add-iam-policy-binding {project_id} '
+        f'--member="serviceAccount:{compute_default_sa}" '
+        f'--role="{role}" --condition=None'
+    )
+    code = run_command_with_updates(cmd, f'Grant {role}', verbose=False)
+    if code != 0:
+      xpk_print(f'Grant {role} returned ERROR {code}')
+      return code
+
+  return 0

--- a/src/xpk/commands/managed_ml_diagnostics_test.py
+++ b/src/xpk/commands/managed_ml_diagnostics_test.py
@@ -15,9 +15,9 @@ limitations under the License.
 """
 
 from dataclasses import dataclass
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 import pytest
-from xpk.commands.managed_ml_diagnostics import install_mldiagnostics_prerequisites
+from xpk.commands.managed_ml_diagnostics import grant_compute_default_sa_mldiagnostics_permissions, install_mldiagnostics_prerequisites
 from xpk.core.testing.commands_tester import CommandsTester
 
 
@@ -136,3 +136,31 @@ def test_install_mldiagnostics_prerequisites_commands_executed(
   mocks.commands_tester.assert_command_run(
       'kubectl', 'apply', '-f', '-n', 'gke-mldiagnostics', times=2
   )
+
+
+@patch(
+    'xpk.commands.managed_ml_diagnostics.run_command_with_updates',
+    return_value=0,
+)
+@patch(
+    'xpk.commands.managed_ml_diagnostics.run_command_for_value',
+    return_value=(0, '123456789\n'),
+)
+def test_grant_compute_default_sa_mldiagnostics_permissions_success(
+    mock_run_value, mock_run_updates
+):
+  result = grant_compute_default_sa_mldiagnostics_permissions('test-project')
+  assert result == 0
+  mock_run_value.assert_called_once()
+  assert mock_run_updates.call_count == 3
+
+
+@patch(
+    'xpk.commands.managed_ml_diagnostics.run_command_for_value',
+    return_value=(1, 'error'),
+)
+def test_grant_compute_default_sa_mldiagnostics_permissions_fails_on_project_number(
+    mock_run_value,
+):
+  result = grant_compute_default_sa_mldiagnostics_permissions('test-project')
+  assert result == 1


### PR DESCRIPTION
When provisioning clusters with `--managed-mldiagnostics`, XLA ML diagnostics requires `roles/hypercomputecluster.editor`, `roles/storage.objectUser`, and `roles/logging.logWriter` to be bound to the Compute Engine default service account.

This commit:
1. Automatically resolves projectNumber and grants these 3 required IAM roles via `gcloud projects add-iam-policy-binding` during cluster create when `--managed-mldiagnostics` is enabled.
2. Updates user documentation (permissions.md, clusters.md) and unit test coverage accordingly.

# Issue
If not done permissions need to be given manually for mldiagonstics to work. 

# Testing
Have you performed any manual testing on your change? 

Prior IAM Bindings:
<img width="3212" height="264" alt="image" src="https://github.com/user-attachments/assets/46928e18-a69e-4a71-874b-758037320ffc" />

Cluster Creation Logs:
```
(xpk_local_venv) rapatchi@rapatchi2:~/xpk_fork/xpk_sa$ xpk cluster create --cluster=maxtest-cluster1 --tpu-type=v5litepod-8 --project=rapatchiconsumer --zone=us-central1-b --num-nodes=2 --spot --managed-mldiagnostics
[XPK] Starting xpk v0.1.dev903+g2b0dc6334
...
[XPK] Task: `Get Project Number` is implemented by `gcloud projects describe rapatchiconsumer --format="value(projectNumber)"`
[XPK] Granting necessary roles to 641919595434-compute@developer.gserviceaccount.com
[XPK] Task: `Grant roles/hypercomputecluster.editor` is implemented by `gcloud projects add-iam-policy-binding rapatchiconsumer --member="serviceAccount:641919595434-compute@developer.gserviceaccount.com" --role="roles/hypercomputecluster.editor" --condition=None`
[XPK] Task: `Grant roles/hypercomputecluster.editor` succeeded.
[XPK] Task: `Grant roles/storage.objectUser` is implemented by `gcloud projects add-iam-policy-binding rapatchiconsumer --member="serviceAccount:641919595434-compute@developer.gserviceaccount.com" --role="roles/storage.objectUser" --condition=None`
[XPK] Task: `Grant roles/storage.objectUser` succeeded.
[XPK] Task: `Grant roles/logging.logWriter` is implemented by `gcloud projects add-iam-policy-binding rapatchiconsumer --member="serviceAccount:641919595434-compute@developer.gserviceaccount.com" --role="roles/logging.logWriter" --condition=None`
[XPK] Task: `Grant roles/logging.logWriter` succeeded.
[XPK] Task: `Determine server supported GKE versions for default gke version` is implemented by `gcloud container get-server-config --project=rapatchiconsumer --region=us-central1 --flatten="channels" --filter="channels.channel=RAPID" --format="value(channels.defaultVersion)"`
...
```
Post Creation:

<img width="3100" height="412" alt="image" src="https://github.com/user-attachments/assets/2832b51d-14b7-4805-8e63-8164deb50dd9" />

Have you verified use cases affected by goldens? Yes
